### PR TITLE
Restructure la page du projet :

### DIFF
--- a/app/controllers/projets_controller.rb
+++ b/app/controllers/projets_controller.rb
@@ -18,18 +18,8 @@ class ProjetsController < ApplicationController
       longitude: @projet_courant.longitude
     })
     @intervenants_disponibles = @projet_courant.intervenants_disponibles(role: :operateur).shuffle
-
     @commentaire = Commentaire.new(projet: @projet_courant)
-  end
-
-  def calcul_revenu_fiscal_reference
-    @calcul = @projet_courant.calcul_revenu_fiscal_reference(params[:annee])
-    redirect_to edit_projet_composition_path(@projet_courant, calcul: @calcul)
-  end
-
-  def preeligibilite
-    @preeligibilite = @projet_courant.preeligibilite(params[:annee])
-    redirect_to edit_projet_composition_path(@projet_courant, preeligibilite: @preeligibilite)
+    @revenu_total_boo = @projet_courant.calcul_revenu_fiscal_reference_total(:annee)
   end
 
   def demande

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,4 +42,12 @@ module ApplicationHelper
     liste_icone = {creation_projet: 'suitcase', invitation_intervenant: 'plug', mise_en_relation_intervenant: 'plug', ajout_avis_imposition: "file text outline" }
     liste_icone[label.to_sym]
   end
+
+  def calcul_revenu_fiscal_reference_total_in_controller(annee)
+    @calcul = @projet_courant.calcul_revenu_fiscal_reference(params[:annee])
+  end
+
+  def calcul_preeligibilite
+    @preeligibilite = @projet_courant.preeligibilite(params[:annee])
+  end
 end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -31,13 +31,13 @@ class Projet < ActiveRecord::Base
     occupant.to_s if occupant
   end
 
-  def calcul_revenu_fiscal_reference(annee)
+  def calcul_revenu_fiscal_reference_total(annee)
     total_revenu_fiscal_reference = 0
     avis_impositions.where(annee: annee).each do |avis_imposition|
       contribuable = ApiParticulier.new.retrouve_contribuable(avis_imposition.numero_fiscal, avis_imposition.reference_avis)
       total_revenu_fiscal_reference += contribuable.revenu_fiscal_reference
     end
-    return total_revenu_fiscal_reference
+    total_revenu_fiscal_reference
   end
 
   def operateur
@@ -45,6 +45,6 @@ class Projet < ActiveRecord::Base
   end
 
   def preeligibilite(annee)
-    Tools.calcule_preeligibilite(calcul_revenu_fiscal_reference(annee), self.departement, self.nb_total_occupants)
+    Tools.calcule_preeligibilite(calcul_revenu_fiscal_reference_total(annee), self.departement, self.nb_total_occupants)
   end
 end

--- a/app/views/compositions/edit.html.slim
+++ b/app/views/compositions/edit.html.slim
@@ -22,28 +22,3 @@ div class="ui grid"
         = f.submit t('projets.composition_logement.edition.action', projet: @projet_courant.to_s), class: 'ui primary button'
     h3
     = "Nombre de personnes composant le ménage : #{@nb_total_occupants}"
-
-    h2 class="ui horizontal divider header"
-      i class="tag icon"
-      = "Avis d'imposition"
-    h2 class="ui horizontal divider header"
-    = link_to t('projets.composition_logement.avis_imposition.nouveau.action'), new_projet_avis_imposition_path(@projet_courant), class: 'ui primary button'
-
-    - @projet_courant.avis_impositions.map(&:annee).uniq.each do |annee|
-      h3 class="ui horizontal divider header"
-        = annee
-      - @projet_courant.avis_impositions.where(annee: annee).each do |avis_imposition|
-        li = link_to avis_imposition.label, projet_avis_imposition_path(@projet_courant, id: avis_imposition.id)
-
-      h2 class="ui horizontal divider header"
-      div
-        = "Revenu total: #{@calcul} euros" if @calcul
-      = link_to t('projets.composition_logement.calcul_revenu_fiscal_reference_total.action', annee: annee.to_s), projet_calcul_revenu_fiscal_reference_path(@projet_courant, annee: annee), class: 'ui primary button'
-      div
-
-      h2 class="ui horizontal divider header"
-        i class="tag icon"
-        = "Calcul de prééligibilité"
-      h3
-        = "Plafond de ressources applicable du foyer: #{@preeligibilite}" if @preeligibilite
-      = link_to t('projets.composition_logement.calcul_preeligibilite.calcul.action', annee: annee.to_s), projet_preeligibilite_path(@projet_courant, annee: annee), class: 'ui primary button'

--- a/app/views/projets/_calculerevenus.html.slim
+++ b/app/views/projets/_calculerevenus.html.slim
@@ -1,0 +1,25 @@
+h2 class="ui horizontal divider header"
+  i class="tag icon"
+  = "Les revenus"
+
+- @projet_courant.avis_impositions.map(&:annee).uniq.each do |annee|
+  h3 class="ui horizontal divider header"
+    = "Avis d'imposition pour l'année : #{annee}"
+  - @projet_courant.avis_impositions.where(annee: annee).each do |avis_imposition|
+    li = link_to avis_imposition.label, projet_avis_imposition_path(@projet_courant, id: avis_imposition.id)
+
+  h2 class="ui horizontal divider header"
+  = link_to t('projets.composition_logement.avis_imposition.nouveau.action'), new_projet_avis_imposition_path(@projet_courant), class: 'ui primary button'
+
+
+  h2 class="ui horizontal divider header"
+    i class="tag icon"
+    = "Calcul de prééligibilité"
+  p L'éligibilité de votre foyer est calculée à partir du revenu total, du nombre d'occupants et de votre département
+
+  h3
+    - revenu_total = @projet_courant.calcul_revenu_fiscal_reference_total(annee)
+    = "Revenus total du ménage : #{revenu_total} euros" if revenu_total
+    br
+    - eligibilite_menage = @projet_courant.preeligibilite(annee)
+    = "Plafond de ressources applicable du foyer: #{eligibilite_menage}" if eligibilite_menage

--- a/app/views/projets/show.html.slim
+++ b/app/views/projets/show.html.slim
@@ -42,6 +42,8 @@ div.class.ui.grid
     = link_to t('projets.visualisation.lien_ajout_occupant'), new_projet_occupant_path(@projet_courant), class: "ui primary button" if @role_utilisateur == :demandeur
     = link_to t('projets.visualisation.modifier_list_occupant'), edit_projet_composition_path(@projet_courant), class: "ui primary button" if @role_utilisateur == :demandeur
 
+    = render partial: 'calculerevenus'
+
     - if @projet_courant.intervenants.present?
       h2.ui.horizontal.divider.header Intervenants invités
       div.ui.cards.invites


### PR DESCRIPTION
- Création d'une vue partielle pour afficher le total des revenus et donc l'éligibilité qui était dans la vue composition auparavant
- Méthodes déplacées dans un helper en attendant l'apel au model projet pour faire le calcul de prééligibilité et des revenus total se fait dans le vue
- Méthode renommée dans le model pour que ce soit plus parlant