### PR TITLE
Met en cache le résultat de l’API particuliers

### DIFF
--- a/spec/services/api_particulier_spec.rb
+++ b/spec/services/api_particulier_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require 'support/api_particulier_helper'
+
+describe ApiParticulier do
+  before do
+    Rails.cache.clear
+  end
+
+  context "on success" do
+    it "renvoie un objet Contribuable" do
+      contribuable = subject.retrouve_contribuable(12, 15)
+
+      expect(contribuable.declarants[0][:prenom]).to eq('Pierre')
+      expect(contribuable.declarants[0][:nom]).to eq('Martin')
+      expect(contribuable.annee_impots).to eq('2015')
+      expect(contribuable.nombre_personnes_charge).to eq(2)
+      expect(contribuable.adresse).to eq('12 rue de la mare, 75010 Paris')
+      expect(contribuable.revenu_fiscal_reference).to eq(29880)
+    end
+
+    it "met en cache le résultat" do
+      expect(subject).to receive(:requete_contribuable).once.and_call_original
+
+      first_response = subject.retrouve_contribuable(12, 15)
+      expect(first_response).not_to be_nil
+
+      second_response = subject.retrouve_contribuable(12, 15)
+      expect(second_response).not_to be_nil
+    end
+  end
+
+  context "on error" do
+    it "renvoie nil en cas d'erreur" do
+      contribuable = subject.retrouve_contribuable('INVALID', 'INVALID')
+      expect(contribuable).to be_nil
+    end
+
+    it "ne met pas en cache le résultat en cas d'erreur" do
+      expect(subject).to receive(:requete_contribuable).twice.and_call_original
+
+      first_response = subject.retrouve_contribuable('INVALID', 'INVALID')
+      expect(first_response).to be_nil
+
+      second_response = subject.retrouve_contribuable('INVALID', 'INVALID')
+      expect(second_response).to be_nil
+    end
+  end
+end

--- a/spec/support/api_particulier_helper.rb
+++ b/spec/support/api_particulier_helper.rb
@@ -18,5 +18,12 @@ RSpec.configure do |config|
         "revenuFiscalReference": 29880
       }),
     )
+
+    FakeWeb.register_uri(
+      :get, "https://#{ENV['API_PARTICULIER_DOMAIN']}/api/impots/svair?numeroFiscal=INVALID&referenceAvis=INVALID",
+      content_type: 'application/json',
+      status: ["404", "Not Found"],
+      body: JSON.generate({ error: 'An error occured.'}),
+    )
   end
 end


### PR DESCRIPTION
Ça améliore les performances des pages qui utilisent fréquemment cette API (notamment project#show, qui prenait plusieurs secondes à s’afficher avant).

Pour éviter de mettre en cache une valeur erronée, les réponses invalide de l’API ne sont pas sauvegardées. Comme ça si l’API est down momentanément on évite de sauvegarder une erreur pour toujours.

Et pour faire ceinture-et-bretelle, les réponses ne sont cachées que pendant 24h : comme ça si _jamais_ on met en cache de la bad data (ce qui ne devrait jamais arriver), l’utilisateur peut malgré tout ré-essayer le lendemain, et ça se sera déboisé tout seul.