### PR TITLE
Ajout de bin/rspec pour lancer rspec via Spring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ end
 group :development do
   gem 'web-console', '~> 2.0'
   gem 'spring'
+  gem 'spring-commands-rspec'
   gem 'foreman'
   gem 'pry'
   gem 'pry-nav'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,6 +319,8 @@ GEM
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     spring (1.7.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -399,6 +401,7 @@ DEPENDENCIES
   sinatra
   slim
   spring
+  spring-commands-rspec
   terminal-notifier-guard
   turbolinks
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ rake db:seed
 foreman start
 ```
 
+## Lancer les tests
+
+```shell
+bin/rspec
+```
+
 # Notes
 
 Kanban Zenhub sur ce projet

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
Ça permet d’être cohérent avec la convention d’utiliser des binstubs comme `bin/rake` ou `bin/rails` (plutôt que `bundle exec rake`).

Ça a également l’air de mieux utiliser Spring : le temps d’initialisation des tests (délai avant le lancement du 1er test) passe de quelques secondes à quasi-instantané 🎉.