### PR TITLE
Enregistre une capture HTML des tests d’acceptance en échec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ end
 group :test do
   gem 'rspec-rails'
   gem 'capybara'
+  gem 'capybara-screenshot'
   gem 'launchy'
   gem 'database_cleaner'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-screenshot (1.0.14)
+      capybara (>= 1.0, < 3)
+      launchy
     carrierwave (0.11.2)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -355,6 +358,7 @@ DEPENDENCIES
   active_model_serializers
   byebug
   capybara
+  capybara-screenshot
   carrierwave
   coffee-rails (~> 4.1.0)
   csv2json

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,7 +40,10 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   #
-  config.log_level = :warn 
+  config.log_level = :warn
+
+  # Allow Capybara snapshots to reference non-fingerprinted assets.
+  config.assets.digest = false
 
   config.active_job.queue_adapter = :test
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'simplecov'
 SimpleCov.start 'rails'
 
 require 'capybara/rspec'
+require 'capybara-screenshot/rspec'
 require 'rspec/active_job'
 require 'support/factory_girl'
 
@@ -103,6 +104,10 @@ RSpec.configure do |config|
 
 # Capybara.default_max_wait_time = 600
 
+Capybara::Screenshot.prune_strategy = :keep_last_run
+# Make Capybara HTML snapshots of failed tests look better in a browser.
+# (cf. https://github.com/mattheworiordan/capybara-screenshot#better-looking-html-screenshots)
+Capybara.asset_host = 'http://localhost:3000'
 
 # config DatabaseCleaner v1
   config.include(RSpec::ActiveJob)


### PR DESCRIPTION
Ça permet de voir facilement ce qui se passe dans un test d'acceptance qui échoue.

Les fichiers HTML sont enregistrés dans `tmp/capybara`.