### PR TITLE
Ajouts de tests pour vérifier l'auteur des commentaires envoyés

### DIFF
--- a/spec/features/service_messagerie_spec.rb
+++ b/spec/features/service_messagerie_spec.rb
@@ -4,17 +4,29 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature 'messagerie' do
-  let(:message) { "Vous ne m'avez toujours pas répondu." }
-  let(:projet) {          create :projet }
-  let(:operateur) {       create :intervenant, :operateur, departements: [projet.departement] }
-  let(:agent_operateur) { create :agent, intervenant: operateur }
+  let(:message_demandeur) { "Bonjour ! J'ai une question sur mon projet." }
+  let(:message_operateur) { "J'attend votre question." }
+  let(:projet)            { create :projet }
+  let(:operateur)         { create :intervenant, :operateur, departements: [projet.departement] }
+  let(:agent_operateur)   { create :agent, intervenant: operateur }
+
+  context "en tant que demandeur" do
+    before { signin(projet.numero_fiscal, projet.reference_avis) }
+
+    scenario "je veux ajouter un commentaire" do
+      visit projet_path(projet)
+      fill_in :commentaire_corps_message, with: message_demandeur
+      click_button I18n.t('projets.visualisation.lien_ajout_commentaire')
+      expect(page).to have_content(message_demandeur)
+    end
+  end
 
   context "en tant qu'intervenant" do
     before { login_as agent_operateur, scope: :agent }
 
-    scenario "je veux ajouter un commentaire" do
+    scenario "je veux répondre à un commentaire" do
       visit dossier_path(projet)
-      fill_in :commentaire_corps_message, with: message
+      fill_in :commentaire_corps_message, with: message_operateur
       click_button I18n.t('projets.visualisation.lien_ajout_commentaire')
       within ".chat-intervenant" do
         expect(page).to have_content(operateur.raison_sociale)

--- a/spec/features/service_messagerie_spec.rb
+++ b/spec/features/service_messagerie_spec.rb
@@ -16,7 +16,10 @@ feature 'messagerie' do
       visit dossier_path(projet)
       fill_in :commentaire_corps_message, with: message
       click_button I18n.t('projets.visualisation.lien_ajout_commentaire')
-      expect(page).to have_content(message)
+      within ".chat-intervenant" do
+        expect(page).to have_content(operateur.raison_sociale)
+        expect(page).to have_content(message_operateur)
+      end
     end
   end
 end


### PR DESCRIPTION
Ferme https://anah-produits.atlassian.net/browse/PF-215 _("En tant qu'agent opérateur, je peux répondre aux questions du demandeur")_. La fonctionnalité était déjà là, j'ai juste écrit les tests correspondants.