### PR TITLE
Améliorations de l'édition d'un projet

### DIFF
--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -65,9 +65,19 @@ class DemarrageProjetController < ApplicationController
   def projet_contacts_params
     # civilite n'est pas pris en compte
     params.require(:projet).permit(
-    :tel,
-    :email,
-    personne_de_confiance_attributes: [:id, :prenom, :nom, :tel, :email, :lien_avec_demandeur, :civilite, :disponibilite])
+      :tel,
+      :email,
+      personne_de_confiance_attributes: [
+        :id,
+        :prenom,
+        :nom,
+        :tel,
+        :email,
+        :lien_avec_demandeur,
+        :civilite,
+        :disponibilite
+      ]
+    )
   end
 
   def demandeur_principal_civilite_params

--- a/app/models/demande.rb
+++ b/app/models/demande.rb
@@ -1,4 +1,25 @@
 class Demande < ActiveRecord::Base
   belongs_to :projet
 
+  REQUIRED_ATTRIBUTES = [
+    :changement_chauffage,
+    :froid,
+    :probleme_deplacement,
+    :accessibilite,
+    :hospitalisation,
+    :adaptation_salle_de_bain,
+    :autre,
+    :travaux_fenetres,
+    :travaux_isolation,
+    :travaux_chauffage,
+    :travaux_adaptation_sdb,
+    :travaux_monte_escalier,
+    :travaux_amenagement_ext,
+    :travaux_autres
+  ]
+
+  def complete?
+    required_attributes_as_string = REQUIRED_ATTRIBUTES.map(&:to_s)
+    attributes.slice(*required_attributes_as_string).values.any? { |v| v == true }
+  end
 end

--- a/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
+++ b/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
@@ -102,4 +102,4 @@
       input#dif1 type="checkbox" class="engagement"
       label for="dif1" = t('agrements.attestation_communiquer_infos_occupants')
 
-  = submit_tag t('demarrage_projet.action'), class: 'validate btn'
+  = submit_tag @action_label, class: 'validate btn'

--- a/app/views/demarrage_projet/etape2_description_projet.html.slim
+++ b/app/views/demarrage_projet/etape2_description_projet.html.slim
@@ -72,4 +72,4 @@
         = f.radio_button :ptz, false
         = f.label :ptz, "Non", value: "false"
 
-  = submit_tag t('demarrage_projet.action'), class: 'validate btn'
+  = submit_tag @action_label, class: 'validate btn'

--- a/app/views/projets/_projet_envisage.html.slim
+++ b/app/views/projets/_projet_envisage.html.slim
@@ -1,6 +1,6 @@
 article.block.projet
   h3 Projet envisagé
-  a.edit href="#"  Modifier
+  = link_to t('projets.visualisation.lien_edition'), etape2_description_projet_path(@projet_courant), class: 'edit'
   .content-block
     = affiche_demande_souhaitee(@projet_courant.demande)
     hr/

--- a/app/views/projets/_projet_proposition.html.slim
+++ b/app/views/projets/_projet_proposition.html.slim
@@ -1,7 +1,7 @@
 /! PROJET PROPOSE - vue operateur 2em etape
 article.block.projet-ope
   h3.is-open Projet proposé
-  = link_to "Modifier", projet_demande_path(@projet_courant), class: "edit"
+  = link_to t('projets.visualisation.lien_edition'), projet_demande_path(@projet_courant), class: "edit"
   .content-block
     h4 Logement du demandeur
     ul.ctr-ope
@@ -39,7 +39,7 @@ article.block.projet-ope
         span= @projet_courant.remarques_diagnostic
 
     h4 Travaux
-    table.recap-ope-table border="0" cellpadding="0" cellspacing="0" width="100%" 
+    table.recap-ope-table border="0" cellpadding="0" cellspacing="0" width="100%"
       tbody
         tr
           th.empty scope="row"  &nbsp;
@@ -55,7 +55,7 @@ article.block.projet-ope
             td= @projet_courant.gain_energetique
         - @projet_courant.projet_aides.each do |projet_aide|
           tr
-            th scope="row" #{projet_aide.aide.libelle} 
+            th scope="row" #{projet_aide.aide.libelle}
             td= "#{projet_aide.montant} €"
         tr
           th scope="row" Reste à charge

--- a/app/views/projets/show.html.slim
+++ b/app/views/projets/show.html.slim
@@ -2,7 +2,7 @@ section.content-projet
   = render "projets/messagerie"
   article.block.occupants
     h3 Détails des occupants
-    a.edit href="#"  Modifier
+    = link_to t('projets.visualisation.lien_edition'), etape1_recuperation_infos_demarrage_projet_path(@projet_courant), class: 'edit'
     hr/
     .occupants-recap
       ul

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -9,9 +9,16 @@ FactoryGirl.define do
     email 'prenom.nom@site.com'
     nb_occupants_a_charge 0
     plateforme_id 1234
+
     after(:create) do |projet, evaluator|
       create_list(:demandeur, 1, projet: projet)
       create(:demande, projet: projet)
+    end
+
+    trait :with_invitation do
+      after(:create) do |projet, evaluator|
+        create(:invitation, projet: projet, intervenant: create(:intervenant, :operateur))
+      end
     end
   end
 end

--- a/spec/features/projet_spec.rb
+++ b/spec/features/projet_spec.rb
@@ -4,7 +4,7 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature "J'ai accès aux données concernant le demandeur et son logement" do
-  let(:projet) { FactoryGirl.create(:projet) }
+  let(:projet) { create(:projet, :with_invitation) }
 
   scenario "affichage du nom du demandeur principal" do
     signin(projet.numero_fiscal, projet.reference_avis)
@@ -41,10 +41,12 @@ feature "J'ai accès aux données concernant le demandeur et son logement" do
     expect(page).to have_content('12 rue de la Mare, 75010 Paris')
   end
 
-  scenario "correction de l'année de construction de mon logement", pending: true do
+  scenario "je peux modifier l'année de construction de mon logement" do
     signin(projet.numero_fiscal, projet.reference_avis)
-    click_link I18n.t('projets.visualisation.lien_edition_projet')
-    fill_in :projet_annee_construction, with: '1950'
+    within 'article.projet' do
+      click_link I18n.t('projets.visualisation.lien_edition')
+    end
+    fill_in :demande_annee_construction, with: '1950'
     click_button I18n.t('projets.edition.action')
     expect(page).to have_content(1950)
   end

--- a/spec/features/projet_spec.rb
+++ b/spec/features/projet_spec.rb
@@ -20,9 +20,22 @@ feature "J'ai accès aux données concernant le demandeur et son logement" do
     expect(page).to have_content("Total Revenu Fiscal de Référence")
   end
 
-  scenario "correction de mon adresse", pending: true do
+  scenario "je peux modifier mon numéro de téléphone" do
     signin(projet.numero_fiscal, projet.reference_avis)
-    click_link I18n.t('projets.visualisation.lien_edition_projet', match: :first)
+    within 'article.occupants' do
+      click_link I18n.t('projets.visualisation.lien_edition')
+    end
+    fill_in :projet_tel, with: '01 10 20 30 40'
+    click_button I18n.t('projets.edition.action')
+    expect(page).to have_content('01 10 20 30 40')
+  end
+
+  scenario "je peux modifier mon adresse", pending: true do
+    # FIXME: l'adresse doit être décomposée en éléments individuels (rue, code postal, ville, etc.)
+    signin(projet.numero_fiscal, projet.reference_avis)
+    within 'article.occupants' do
+      click_link I18n.t('projets.visualisation.lien_edition')
+    end
     fill_in :projet_adresse, with: '12 rue de la mare, 75010 Paris'
     click_button I18n.t('projets.edition.action')
     expect(page).to have_content('12 rue de la Mare, 75010 Paris')


### PR DESCRIPTION
Travaux préparatoires pour la story "permettre de changer d'opérateur" : permettre d'éditer les informations d'un projet. Ça pose les bases nécessaires, en attendant l'implémentation du changement d'opérateur en tant que tel.

## Modification des informations personnelles du demandeur

![edit-projet](https://cloud.githubusercontent.com/assets/179923/22375064/e34b4a5c-e4a8-11e6-8939-08fb3f8eef49.gif)

## Modification de la demande du projet

![edit-demande](https://cloud.githubusercontent.com/assets/179923/22375072/e85b5b68-e4a8-11e6-8563-5588dabc94fe.gif)
