### PR TITLE
Masquer le bouton « Changer d’opérateur » pour les intervenants

### DIFF
--- a/app/views/dossiers/_projet_envisage.html.slim
+++ b/app/views/dossiers/_projet_envisage.html.slim
@@ -1,0 +1,25 @@
+article.block.projet
+  h3 Projet envisagé
+  = link_to t('projets.visualisation.lien_edition'), etape2_description_projet_path(@projet_courant), class: 'edit'
+  .content-block
+    - if @projet_courant.demande.blank?
+      p Le demandeur n'a pas encore rempli le projet.
+    - else
+      = affiche_demande_souhaitee(@projet_courant.demande)
+      hr/
+      h4 Organisme choisi pour accompagner le projet :
+      - operateur = @projet_courant.intervenants.pour_role(:operateur).first
+      - if operateur.present?
+        p
+          strong= operateur
+        - unless current_agent
+          br
+          br
+          | Vous pouvez à présent dialoguer avec le demandeur par la messagerie. Vous serez informé par email pour chaque réponse de sa part.
+      - else
+        p
+          strong Aucun
+        - unless current_agent
+          br
+          br
+        = link_to "Choisir un opérateur", etape3_choix_intervenant_path(@projet_courant), class: 'btn'

--- a/app/views/projets/show.html.slim
+++ b/app/views/projets/show.html.slim
@@ -32,6 +32,6 @@ section.content-projet
             tr
               td= occupant
               td= occupant.date_de_naissance.year
-  = render "projets/projet_envisage"
+  = render "projet_envisage"
   - if @projet_courant.statut != "prospect"
     = render "projet_#{@projet_courant.statut}"

--- a/spec/features/dossier_spec.rb
+++ b/spec/features/dossier_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+require 'support/mpal_helper'
+require 'support/api_particulier_helper'
+require 'support/api_ban_helper'
+
+feature "J'ai accès aux données concernant mes dossiers" do
+  let(:projet)      { create(:projet, :with_intervenants, :with_invited_operateur) }
+  let(:operateur)   { create :intervenant, :operateur,   departements: [projet.departement] }
+  let(:instructeur) { create :intervenant, :instructeur, departements: [projet.departement] }
+  let(:pris)        { create :intervenant, :pris,        departements: [projet.departement] }
+
+  before { login_as agent, scope: :agent }
+
+  context "en tant qu'opérateur" do
+    let(:agent) { create :agent, intervenant: operateur }
+
+    scenario "je peux consulter un dossier" do
+      visit dossier_path(projet)
+      expect(page).to have_content("Jean Martin")
+    end
+
+    scenario "je ne peux pas changer de moi-même l'opérateur du dossier" do
+      visit dossier_path(projet)
+      expect(page).not_to have_content(I18n.t('projets.visualisation.changer_intervenant'))
+    end
+  end
+
+  context "en tant qu'instructeur" do
+    let(:agent) { create :agent, intervenant: instructeur }
+
+    scenario "je peux consulter un dossier" do
+      # TODO
+    end
+  end
+
+  context "en tant que PRIS" do
+    let(:agent) { create :agent, intervenant: pris }
+
+    scenario "je peux consulter un dossier" do
+      # TODO
+    end
+
+    scenario "si je suis saisi par le demandeur, je peux affecter un opérateur au dossier" do
+      # TODO
+    end
+  end
+end


### PR DESCRIPTION
Implémenté en séparant la vue « projet_envisage » des projets (demandeur) de celle des dossiers (intervenant).

@jvignolles je veux bien ton avis sur la séparation des vues.

<img width="910" alt="capture d ecran 2017-01-31 a 17 16 58" src="https://cloud.githubusercontent.com/assets/179923/22473411/1fb348a4-e7d9-11e6-90ee-57c805f5b4a2.png">
