### PR TITLE
Amélioration des factories

### DIFF
--- a/spec/factories/intervenants.rb
+++ b/spec/factories/intervenants.rb
@@ -4,15 +4,17 @@ FactoryGirl.define do
     email 'contact@urbanos.com'
     departements ['75']
 
-    trait :operateur do
+    factory :operateur do
       sequence(:raison_sociale) {|n| "Operateur#{n}" }
       roles ['operateur']
     end
-    trait :pris do
+
+    factory :pris do
       sequence(:raison_sociale) {|n| "Pris#{n}" }
       roles ['pris']
     end
-    trait :instructeur do
+
+    factory :instructeur do
       sequence(:raison_sociale) {|n| "Instructeur#{n}" }
       roles ['instructeur']
     end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -17,9 +17,9 @@ FactoryGirl.define do
 
     trait :with_intervenants_disponibles do
       after(:build) do |projet, evaluator|
-        create(:intervenant, :operateur,   departements: [projet.departement])
-        create(:intervenant, :pris,        departements: [projet.departement])
-        create(:intervenant, :instructeur, departements: [projet.departement])
+        create(:operateur,   departements: [projet.departement])
+        create(:pris,        departements: [projet.departement])
+        create(:instructeur, departements: [projet.departement])
       end
     end
 
@@ -32,7 +32,7 @@ FactoryGirl.define do
     trait :with_invited_operateur do
       statut :prospect
       after(:build) do |projet|
-        operateur = create(:intervenant, :operateur, departements: [projet.departement])
+        operateur = create(:operateur, departements: [projet.departement])
         create(:invitation, projet: projet, intervenant: operateur)
       end
     end
@@ -40,7 +40,7 @@ FactoryGirl.define do
     trait :en_cours do
       statut :en_cours
       after(:build) do |projet|
-        projet.operateur = create(:intervenant, :operateur, departements: [projet.departement])
+        projet.operateur = create(:operateur, departements: [projet.departement])
       end
     end
   end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -15,7 +15,7 @@ FactoryGirl.define do
       create(:demande, projet: projet)
     end
 
-    trait :with_intervenants do
+    trait :with_intervenants_disponibles do
       after(:build) do |projet, evaluator|
         create(:intervenant, :operateur,   departements: [projet.departement])
         create(:intervenant, :pris,        departements: [projet.departement])
@@ -23,17 +23,24 @@ FactoryGirl.define do
       end
     end
 
+    # Project states
+
+    trait :prospect do
+      statut :prospect
+    end
+
     trait :with_invited_operateur do
-      after(:build) do |projet, evaluator|
+      statut :prospect
+      after(:build) do |projet|
         operateur = create(:intervenant, :operateur, departements: [projet.departement])
         create(:invitation, projet: projet, intervenant: operateur)
       end
     end
 
-    trait :with_committed_operateur do
-      after(:build) do |projet, evaluator|
+    trait :en_cours do
+      statut :en_cours
+      after(:build) do |projet|
         projet.operateur = create(:intervenant, :operateur, departements: [projet.departement])
-        projet.statut = :en_cours
       end
     end
   end

--- a/spec/features/changer_operateur_spec.rb
+++ b/spec/features/changer_operateur_spec.rb
@@ -4,7 +4,7 @@ require 'support/mpal_helper'
 feature "en tant que demandeur, je peux changer d'opérateur" do
 
   context "avant de m'être engagé avec un opérateur" do
-    let(:projet) { create(:projet, :with_intervenants, :with_invited_operateur) }
+    let(:projet) { create(:projet, :with_intervenants_disponibles, :with_invited_operateur) }
 
     scenario "je peux choisir un autre opérateur" do
       signin(projet.numero_fiscal, projet.reference_avis)
@@ -28,7 +28,7 @@ feature "en tant que demandeur, je peux changer d'opérateur" do
   end
 
   context "après m'être engagé avec un opérateur" do
-    let(:projet) { create(:projet, :with_committed_operateur) }
+    let(:projet) { create(:projet, :en_cours) }
 
     scenario "je ne peux plus changer d'opérateur depuis la page du projet" do
       signin(projet.numero_fiscal, projet.reference_avis)

--- a/spec/features/choisir_un_intervenant_spec.rb
+++ b/spec/features/choisir_un_intervenant_spec.rb
@@ -5,9 +5,9 @@ require 'support/api_ban_helper'
 
 feature "intervenant" do
   let(:projet) {            create :projet, statut: :en_cours }
-  let!(:instructeur) {      create :intervenant, :instructeur, departements: [projet.departement] }
-  let!(:pris) {             create :intervenant, :pris,        departements: [projet.departement] }
-  let!(:operateur) {        create :intervenant, :operateur,   departements: [projet.departement] }
+  let!(:instructeur) {      create :instructeur, departements: [projet.departement] }
+  let!(:pris) {             create :pris,        departements: [projet.departement] }
+  let!(:operateur) {        create :operateur,   departements: [projet.departement] }
   let!(:invitation) {       create :invitation, intervenant: operateur, projet: projet }
   let(:mise_en_relation) {  create :mise_en_relation, projet: projet, intermediaire: invitation.intervenant }
   let!(:chaudiere_s) {      create :prestation, libelle: 'Chaudière',      scenario: :souhaite,  projet: projet }

--- a/spec/features/creer_dossier_opal_spec.rb
+++ b/spec/features/creer_dossier_opal_spec.rb
@@ -4,7 +4,7 @@ require 'support/opal_helper'
 
 feature "creer dossier dans opal" do
   let(:projet) {            create :projet, statut: :transmis_pour_instruction }
-  let(:instructeur) {       create :intervenant, :instructeur }
+  let(:instructeur) {       create :instructeur }
   let(:invitation) {        create :invitation, intervenant: instructeur }
 
   context "en tant qu'agent instructeur" do

--- a/spec/features/dossier_spec.rb
+++ b/spec/features/dossier_spec.rb
@@ -5,9 +5,9 @@ require 'support/api_ban_helper'
 
 feature "J'ai accès aux données concernant mes dossiers" do
   let(:projet)      { create(:projet, :with_intervenants_disponibles, :with_invited_operateur) }
-  let(:operateur)   { create :intervenant, :operateur,   departements: [projet.departement] }
-  let(:instructeur) { create :intervenant, :instructeur, departements: [projet.departement] }
-  let(:pris)        { create :intervenant, :pris,        departements: [projet.departement] }
+  let(:operateur)   { create :operateur,   departements: [projet.departement] }
+  let(:instructeur) { create :instructeur, departements: [projet.departement] }
+  let(:pris)        { create :pris,        departements: [projet.departement] }
 
   before { login_as agent, scope: :agent }
 

--- a/spec/features/dossier_spec.rb
+++ b/spec/features/dossier_spec.rb
@@ -4,7 +4,7 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature "J'ai accès aux données concernant mes dossiers" do
-  let(:projet)      { create(:projet, :with_intervenants, :with_invited_operateur) }
+  let(:projet)      { create(:projet, :with_intervenants_disponibles, :with_invited_operateur) }
   let(:operateur)   { create :intervenant, :operateur,   departements: [projet.departement] }
   let(:instructeur) { create :intervenant, :instructeur, departements: [projet.departement] }
   let(:pris)        { create :intervenant, :pris,        departements: [projet.departement] }

--- a/spec/features/projet_spec.rb
+++ b/spec/features/projet_spec.rb
@@ -59,7 +59,7 @@ feature "En tant que demandeur, j'ai accès aux données concernant mon projet" 
     skip
     # cette spec est plus précise, je suggère de la déplacer dans spec/features/choisir_un_operateur_spec.rb
     # il y a également un spc pour les invitations / même genre de tets spec/features/invitation_spec.rb
-    operateur = FactoryGirl.create(:intervenant, :operateur)
+    operateur = FactoryGirl.create(:operateur)
     invitation = FactoryGirl.create(:invitation, projet: projet, intervenant: operateur)
     signin(projet.numero_fiscal, projet.reference_avis)
     visit projet_path(projet)

--- a/spec/features/service_messagerie_spec.rb
+++ b/spec/features/service_messagerie_spec.rb
@@ -7,7 +7,7 @@ feature 'messagerie' do
   let(:message_demandeur) { "Bonjour ! J'ai une question sur mon projet." }
   let(:message_operateur) { "J'attend votre question." }
   let(:projet)            { create :projet }
-  let(:operateur)         { create :intervenant, :operateur, departements: [projet.departement] }
+  let(:operateur)         { create :operateur, departements: [projet.departement] }
   let(:agent_operateur)   { create :agent, intervenant: operateur }
 
   context "en tant que demandeur" do

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -25,7 +25,7 @@ end
 feature "Réinitialisation de la session" do
   let(:projet) {          create :projet }
   let(:invitation) {      create :invitation }
-  let(:operateur) {       create :intervenant, :operateur, departements: [projet.departement] }
+  let(:operateur) {       create :operateur, departements: [projet.departement] }
   let(:agent_operateur) { create :agent, intervenant: operateur }
 
   context "en tant que demandeur" do

--- a/spec/features/transmettre_a_l_instructeur_spec.rb
+++ b/spec/features/transmettre_a_l_instructeur_spec.rb
@@ -14,13 +14,13 @@ feature "transmettre à l'instructeur" do
 
   scenario "en tant que demandeur je transmet une demande aux services instructeurs" do
     projet = FactoryGirl.create(:projet)
-    operateur = FactoryGirl.create(:intervenant, :operateur)
+    operateur = FactoryGirl.create(:operateur)
     invitation = FactoryGirl.create(:invitation, projet: projet, intervenant: operateur)
     projet.statut = :en_cours
     projet.operateur = invitation.intervenant
     projet.save
     # Intervenant.instructeur.pour_departement(projet.departement).destroy_all
-    instructeur = FactoryGirl.create(:intervenant, :instructeur, departements: [ projet.departement ])
+    instructeur = FactoryGirl.create(:instructeur, departements: [ projet.departement ])
     signin(12, 15)
     expect(page.current_path).to eq(projet_path(projet))
 

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -22,7 +22,7 @@ describe ProjetMailer, type: :mailer do
   end
 
   describe "l'intervenant reçoit un e-mail lorsqu'il a été choisi par le demandeur" do
-    let(:operateur) { create :intervenant, :operateur }
+    let(:operateur) { create :operateur }
     let(:projet) { create :projet, operateur: operateur }
     let!(:invitation) { create :invitation, projet: projet, intervenant: operateur }
     let(:email) { ProjetMailer.notification_choix_intervenant(projet) }

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -18,10 +18,10 @@ describe Projet do
 
   describe '#for_agent' do
     context "en tant qu'operateur" do
-      let(:instructeur) {       create :intervenant, :instructeur }
-      let(:operateur1) {        create :intervenant, :operateur }
-      let(:operateur2) {        create :intervenant, :operateur }
-      let(:operateur3) {        create :intervenant, :operateur }
+      let(:instructeur) {       create :instructeur }
+      let(:operateur1) {        create :operateur }
+      let(:operateur2) {        create :operateur }
+      let(:operateur3) {        create :operateur }
       let(:agent_instructeur) { create :agent, intervenant: instructeur }
       let(:agent_operateur1) {  create :agent, intervenant: operateur1 }
       let(:agent_operateur2) {  create :agent, intervenant: operateur2 }
@@ -83,7 +83,7 @@ describe Projet do
   describe "invite_intervenant!" do
     context "sans intervenant invité au préalable" do
       let(:projet)    { create :projet }
-      let(:operateur) { create :intervenant, :operateur }
+      let(:operateur) { create :operateur }
 
       it "sélectionne et notifie l'intervenant" do
         expect(ProjetMailer).to receive(:invitation_intervenant).and_call_original
@@ -96,7 +96,7 @@ describe Projet do
     context "avec un opérateur invité auparavant" do
       let(:projet)             { create :projet, :with_invited_operateur }
       let(:previous_operateur) { projet.invited_operateur }
-      let(:new_operateur)      { create :intervenant, :operateur }
+      let(:new_operateur)      { create :operateur }
 
       it "sélectionne le nouvel opérateur, et notifie l'ancien opérateur" do
         expect(ProjetMailer).to receive(:invitation_intervenant).and_call_original
@@ -118,7 +118,7 @@ describe Projet do
 
   describe "commit_to_operateur!" do
     let(:projet)    { create :projet, statut: :prospect }
-    let(:operateur) { create :intervenant, :operateur }
+    let(:operateur) { create :operateur }
 
     it "s'engage auprès d'un opérateur" do
       expect(projet.commit_with_operateur!(operateur)).to be true
@@ -131,7 +131,7 @@ describe Projet do
   describe "#transmettre!" do
     context "with valid call" do
       let(:projet) { create :projet }
-      let!(:instructeur) { create :intervenant, :instructeur }
+      let!(:instructeur) { create :instructeur }
       it do
         result = projet.transmettre!(instructeur)
         expect(result).to be true


### PR DESCRIPTION
- On peut créer un opérateur avec `create :operateur` (plutôt que `create :intervenant, :operateur`). Idem pour les PRIS et les instructeurs. Ça allège l'utilisation des factories dans les tests.
- Il y a maintenant une factory par état possible d'un `Projet`. En plus d'être plus lisible dans les tests, ça permettra à terme d'avoir une vue rapide des différents états possibles d'un projet.