### PR TITLE
Tests de la partie "Administrations"

### DIFF
--- a/app/controllers/admin/intervenants_controller.rb
+++ b/app/controllers/admin/intervenants_controller.rb
@@ -12,7 +12,7 @@ class Admin::IntervenantsController < AdminController
     rescue => e
       return redirect_to admin_intervenants_path, alert: "Erreur lors de l’importation : #{e.message}"
     end
-    redirect_to admin_intervenants_path, notice: "Les intervenants ont été importés."
+    redirect_to admin_intervenants_path, notice: I18n.t('admin.intervenants.import_reussi')
   end
 
   private

--- a/app/views/admin/intervenants/index.html.slim
+++ b/app/views/admin/intervenants/index.html.slim
@@ -4,7 +4,7 @@
     fieldset.visible
       legend Importer un fichier CSV
       = file_field_tag 'csv_file'
-      = submit_tag "Importer le fichier", class: 'btn'
+      = submit_tag t('admin.intervenants.impoter_fichier'), class: 'btn'
   - if @intervenants.blank?
     p Aucun intervenant.
   - else

--- a/app/views/admin/intervenants/index.html.slim
+++ b/app/views/admin/intervenants/index.html.slim
@@ -27,8 +27,8 @@
             td= intervenant.raison_sociale
             td= intervenant.email
             td= intervenant.adresse_postale
-            td= intervenant.departements.join(', ')
+            td= intervenant.departements.try(:join, ', ')
             td= intervenant.themes.try(:join, ', ')
-            td= intervenant.roles.join(', ')
+            td= intervenant.roles.try(:join, ', ')
             td= intervenant.informations
             td= intervenant.clavis_service_id

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -336,3 +336,8 @@ fr:
     nouveau:
       explication_html: "<b>Choisir un intervenant vous engage</b><p>L’opérateur est chargé de vous conseiller tout au long de la démarche. Il vous accompagne danss l’élaboration de votre projet de travaux et la constitution de votre dossier de demande de subvention.</p><p>Lorsqu’une subvention vous est accordée, l’opérateur vous accompagne jusqu’au paiement de la subvention.</p><p>Cette prestation payante peut être totalement ou opartiellement couverte par le complément de subvention qui complète la subvention pour travaux"
       action: "Je choisis cet opérateur"
+
+  admin:
+    intervenants:
+      importer_fichier: "Importer le fichier"
+      import_reussi: "Les intervenants ont été importés."

--- a/spec/controllers/admin/intervenants_controller_spec.rb
+++ b/spec/controllers/admin/intervenants_controller_spec.rb
@@ -1,23 +1,131 @@
 require 'rails_helper'
-require 'support/api_particulier_helper'
+require 'support/mpal_helper'
 
 describe Admin::IntervenantsController do
-  describe "#index" do
-    it "affiche la liste des intervenants", pending: true do
-      # TODO
-      skip
+
+  # Génère un fichier CSV à partir d'un tableau de hashes
+  def uploaded_csv(records, separator=',')
+    tmp_file = Tempfile.new('import-test.csv')
+    CSV.open(tmp_file, "wb", { col_sep: separator }) do |csv|
+      csv << records.first.keys # header row
+      records.each do |hash|
+        csv << hash.values
+      end
+    end
+    Rack::Test::UploadedFile.new(tmp_file, 'text/csv')
+  end
+
+  before(:each) do
+    authenticate_as_admin
+  end
+
+  describe "GET index" do
+    it "affiche la liste des intervenants" do
+      get :index
+      expect(response).to render_template("index")
     end
   end
 
-  describe "#import" do
-    it "importe les opérateurs contenus dans un fichier CSV", pending: true do
-      # TODO (voir spec/fixtures/Import intervenants.csv)
-      skip
+  describe "POST import" do
+    let(:data) do
+      [
+        {
+          raison_sociale: 'Opérateur1',
+          email:          'contact@operateur1.fr'
+        },
+        {
+          raison_sociale: 'Instructeur1',
+          email:          'contact@instructeur1.fr'
+        }
+      ]
+    end
+    let(:operateur1)   { Intervenant.find_by_raison_sociale('Opérateur1') }
+    let(:instructeur1) { Intervenant.find_by_raison_sociale('Instructeur1') }
+
+    it "importe un fichier CSV séparé par des virgules" do
+      post :import, { csv_file: uploaded_csv(data, ',') }
+      expect(operateur1).not_to be_nil
+      expect(operateur1.email).to eq 'contact@operateur1.fr'
     end
 
-    it "met à jour les opérateurs existants", pending: true do
-      # TODO (voir spec/fixtures/Import intervenants.csv)
-      skip
+    it "importe un fichier CSV séparé par des points-virgules" do
+      post :import, { csv_file: uploaded_csv(data, ';') }
+      expect(operateur1).not_to be_nil
+      expect(operateur1.email).to eq 'contact@operateur1.fr'
+    end
+
+    it "redirige vers la liste des intervenants en cas de succès" do
+      post :import, { csv_file: uploaded_csv(data) }
+      expect(response).to redirect_to(admin_intervenants_path)
+      expect(flash[:notice]).to eq I18n.t('admin.intervenants.import_reussi')
+    end
+
+    it "redirige vers la liste des intervenants en cas d'erreur" do
+      post :import, { csv_file: nil }
+      expect(response).to redirect_to(admin_intervenants_path)
+      expect(flash[:alert]).to include 'Erreur lors de l’importation'
+    end
+
+    context "avec des intervenants qui n'existent pas encore" do
+      it "importe les intervenants dans la base" do
+        post :import, { csv_file: uploaded_csv(data) }
+        expect(operateur1).not_to be_nil
+        expect(operateur1.email).to eq 'contact@operateur1.fr'
+        expect(instructeur1).not_to be_nil
+        expect(instructeur1.email).to eq 'contact@instructeur1.fr'
+      end
+    end
+
+    context "avec des intervenants qui existent déjà" do
+      before do
+        create :operateur, raison_sociale: 'Opérateur1', email: 'previous-email@operateur1.fr'
+      end
+
+      it "met à jour les intervenants existants" do
+        expect(operateur1).not_to be_nil
+        expect(operateur1.email).to eq 'previous-email@operateur1.fr'
+
+        post :import, { csv_file: uploaded_csv(data) }
+        operateur1.reload
+        expect(operateur1).not_to be_nil
+        expect(operateur1.email).to eq 'contact@operateur1.fr'
+      end
+
+      it "crée les intervenants qui n'existent pas" do
+        post :import, { csv_file: uploaded_csv(data) }
+        expect(instructeur1).not_to be_nil
+        expect(instructeur1.email).to eq 'contact@instructeur1.fr'
+      end
+    end
+
+    context "avec plusieurs départements" do
+      let(:data) do [{
+          raison_sociale: 'Opérateur1',
+          email:          'contact@operateur1.fr',
+          departements:   '94, 95'
+        }]
+      end
+
+      it "importe les départements" do
+        post :import, { csv_file: uploaded_csv(data, ';') }
+        expect(operateur1).not_to be_nil
+        expect(operateur1.departements).to eq ['94', '95']
+      end
+    end
+
+    context "avec plusieurs rôles" do
+      let(:data) do [{
+          raison_sociale: 'Instructeur1',
+          email:          'contact@instructeur1.fr',
+          roles:          'instructeur, pris'
+        }]
+      end
+
+      it "importe les rôles" do
+        post :import, { csv_file: uploaded_csv(data, ';') }
+        expect(instructeur1).not_to be_nil
+        expect(instructeur1.roles).to eq ['instructeur', 'pris']
+      end
     end
   end
 end

--- a/spec/features/admin/intervenants_spec.rb
+++ b/spec/features/admin/intervenants_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+require 'support/mpal_helper'
+
+feature "Administration des intervenants" do
+  let!(:intervenant1) { create :operateur }
+  let!(:intervenant2) { create :instructeur }
+  let!(:intervenant3) { create :pris }
+
+  scenario "je peux lister tous les intervenants du site" do
+    authenticate_as_admin
+    visit admin_intervenants_path
+    expect(page.current_path).to eq(admin_intervenants_path)
+    expect(page).to have_content intervenant1.raison_sociale
+    expect(page).to have_content intervenant2.raison_sociale
+    expect(page).to have_content intervenant3.raison_sociale
+  end
+
+  scenario "je peux importer des opérateurs contenus dans un fichier CSV" do
+    authenticate_as_admin
+    visit admin_intervenants_path
+    attach_file :csv_file, Rails.root + "spec/fixtures/Import intervenants.csv"
+    click_button I18n.t('admin.intervenants.impoter_fichier')
+    expect(page.current_path).to eq(admin_intervenants_path)
+    expect(page).to have_content "Les intervenants ont été importés."
+    expect(page).to have_content "Maison de L'Emploi de la Déodatie"
+  end
+end

--- a/spec/support/mpal_helper.rb
+++ b/spec/support/mpal_helper.rb
@@ -5,6 +5,22 @@ def signin(numero_fiscal, reference_avis)
   find('.form-login .btn').click
 end
 
+def authenticate_as_admin
+  # L'environnement est mocké car CircleCI ne permet pas d'exposer des
+  # variables d'environnement lors des builds de Pull requests.
+  allow(ENV).to receive(:[]).and_call_original
+  allow(ENV).to receive(:[]).with('ADMIN_TOKEN').and_return('admin-test-token')
+
+  if defined?(page) # Capybara
+    page.driver.browser.set_cookie("admin_token=#{ENV['ADMIN_TOKEN']}")
+    # Capybara will clear the cookies at the end of the scenario
+  end
+
+  if @request.present? && @request.cookies # Controller specs
+    @request.cookies['admin_token'] = ENV['ADMIN_TOKEN']
+  end
+end
+
 def json(body)
   JSON.parse(body, symbolize_names: true)
 end


### PR DESCRIPTION
Ajout de tests pour la partie "Administration des intervenants" et "Import de fichier CSV".

On avait fait sans test pour pouvoir s'en servir lors des tests utilisateurs – mais apparemment ça a vocation à rester. Donc tests :)