### PR TITLE
ProjetPrestations: suppression de l’état dans la table de jointure

### DIFF
--- a/db/migrate/20170213173118_remove_state_from_projet_prestations.rb
+++ b/db/migrate/20170213173118_remove_state_from_projet_prestations.rb
@@ -1,0 +1,13 @@
+class RemoveStateFromProjetPrestations < ActiveRecord::Migration
+  def up
+    remove_column :projet_prestations, :souhaite,  :boolean
+    remove_column :projet_prestations, :preconise, :boolean
+    remove_column :projet_prestations, :retenu,    :boolean
+  end
+
+  def down
+    add_column :projet_prestations, :souhaite,  :boolean, null: false, default: false
+    add_column :projet_prestations, :preconise, :boolean, null: false, default: false
+    add_column :projet_prestations, :retenu,    :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170209122206) do
+ActiveRecord::Schema.define(version: 20170213173118) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -225,9 +225,6 @@ ActiveRecord::Schema.define(version: 20170209122206) do
   create_table "projet_prestations", force: :cascade do |t|
     t.integer "projet_id"
     t.integer "prestation_id"
-    t.boolean "souhaite",      default: false, null: false
-    t.boolean "preconise",     default: false, null: false
-    t.boolean "retenu",        default: false, null: false
   end
 
   add_index "projet_prestations", ["prestation_id"], name: "index_projet_prestations_on_prestation_id", using: :btree


### PR DESCRIPTION
C’est un ancien artefact du temps où la jointure était gérée
manuellement.

Maintenant qu’on utilise un `has_and_belongs_to_many`, l’état n’est plus
utilisé. Dans le futur on pourra faire porter cet état par un autre modèle (par exemple sur un modèle
Scenario).

Maintenant que #224 a été déployé en production, on peut faire passer la migration.