### PR TITLE
Permet d’entrer des nombres à virgule dans une proposition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'fakeweb'
   gem 'simplecov', :require => false
+  gem 'temping'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temping (3.8.0)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     temple (0.7.7)
     terminal-notifier-guard (1.7.0)
     thor (0.19.1)
@@ -398,6 +401,7 @@ DEPENDENCIES
   slim
   spring
   spring-commands-rspec
+  temping
   terminal-notifier-guard
   turbolinks
   uglifier (>= 1.3.0)
@@ -407,4 +411,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.7
+   1.14.3

--- a/app/controllers/concerns/localized_model_concern.rb
+++ b/app/controllers/concerns/localized_model_concern.rb
@@ -3,11 +3,16 @@ module LocalizedModelConcern
 
   module ClassMethods
     # Définit un setter qui convertit des nombres localisés en nombres US (parsables par Ruby).
-    # Exemple : "100,25" -> "100.25"
+    # Exemple : "1 200,25" -> "1200.25"
     def localized_numeric_setter(attribute)
       raise "Attribute '#{attribute}' is not among the attributes of the model" unless attribute_names.include?(attribute.to_s)
       define_method :"#{attribute}=" do |value|
-        write_attribute(attribute, value.gsub(I18n.t('number.format.separator'), '.'))
+        if value.kind_of? String
+          value = value
+            .gsub(I18n.t('number.format.delimiter'), '')
+            .gsub(I18n.t('number.format.separator'), '.')
+        end
+        write_attribute(attribute, value)
       end
     end
   end

--- a/app/controllers/concerns/localized_model_concern.rb
+++ b/app/controllers/concerns/localized_model_concern.rb
@@ -1,0 +1,14 @@
+module LocalizedModelConcern
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Définit un setter qui convertit des nombres localisés en nombres US (parsables par Ruby).
+    # Exemple : "100,25" -> "100.25"
+    def localized_numeric_setter(attribute)
+      raise "Attribute '#{attribute}' is not among the attributes of the model" unless attribute_names.include?(attribute.to_s)
+      define_method :"#{attribute}=" do |value|
+        write_attribute(attribute, value.gsub(I18n.t('number.format.separator'), '.'))
+      end
+    end
+  end
+end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -1,8 +1,11 @@
 class Projet < ActiveRecord::Base
+  include LocalizedModelConcern
 
   enum statut: [ :prospect, :en_cours, :proposition_enregistree, :proposition_proposee, :proposition_acceptee, :transmis_pour_instruction, :en_cours_d_instruction ]
+
   has_one :personne_de_confiance, class_name: "Personne"
   accepts_nested_attributes_for :personne_de_confiance
+
   has_one :demande, dependent: :destroy
   has_many :intervenants, through: :invitations
   has_many :invitations, dependent: :destroy
@@ -12,6 +15,7 @@ class Projet < ActiveRecord::Base
   has_many :occupants, -> { order "id" }, dependent: :destroy
   has_many :commentaires, -> { order('created_at DESC') }, dependent: :destroy
   has_many :avis_impositions, dependent: :destroy
+
   has_many :documents, dependent: :destroy
   accepts_nested_attributes_for :documents
 
@@ -23,6 +27,10 @@ class Projet < ActiveRecord::Base
 
   validates :numero_fiscal, :reference_avis, :adresse_ligne1, presence: true
   validates_numericality_of :nb_occupants_a_charge, greater_than_or_equal_to: 0, allow_nil: true
+
+  localized_numeric_setter :montant_travaux_ht
+  localized_numeric_setter :montant_travaux_ttc
+  localized_numeric_setter :reste_a_charge
 
   before_create do
     self.plateforme_id = Time.now.to_i

--- a/app/models/projet_aide.rb
+++ b/app/models/projet_aide.rb
@@ -1,4 +1,8 @@
 class ProjetAide < ActiveRecord::Base
+  include LocalizedModelConcern
+
   belongs_to :projet
   belongs_to :aide
+
+  localized_numeric_setter :montant
 end

--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -73,19 +73,19 @@ table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
     - if @projet_courant.montant_travaux_ht.present?
       tr
         th scope="row"= t('helpers.label.proposition.montant_travaux_ht')
-        td= "#{@projet_courant.montant_travaux_ht} €"
+        td= number_to_currency(@projet_courant.montant_travaux_ht)
     - if @projet_courant.montant_travaux_ttc.present?
       tr
         th scope="row"= t('helpers.label.proposition.montant_travaux_ttc')
-        td= "#{@projet_courant.montant_travaux_ttc} €"
+        td= number_to_currency(@projet_courant.montant_travaux_ttc)
     - @projet_courant.projet_aides.each do |projet_aide|
       tr
         th scope="row" #{projet_aide.aide.libelle}
-        td= "#{projet_aide.montant} €"
+        td= number_to_currency(projet_aide.montant)
     - if 0 == @projet_courant.reste_a_charge || @projet_courant.reste_a_charge.present?
       tr
         th scope="row"= t('helpers.label.proposition.reste_a_charge')
-        td= "#{@projet_courant.reste_a_charge} €"
+        td= number_to_currency(@projet_courant.reste_a_charge)
 
 ul.ctr-ope
   - if @projet_courant.precisions_travaux.present?

--- a/app/views/projets/demande.html.slim
+++ b/app/views/projets/demande.html.slim
@@ -111,12 +111,13 @@
                 tr
                   th scope="row"= t('helpers.label.proposition.montant_travaux_ht')
                   td
-                    = f.text_field :montant_travaux_ht
+                    = text_field_tag "projet[montant_travaux_ht]", number_to_currency(@projet_courant.montant_travaux_ht, unit: '')
                     = " €"
+
                 tr
                   th scope="row"= t('helpers.label.proposition.montant_travaux_ttc')
                   td
-                    = f.text_field :montant_travaux_ttc
+                    = text_field_tag "projet[montant_travaux_ttc]", number_to_currency(@projet_courant.montant_travaux_ttc, unit: '')
                     = " €"
                 tr
                   th.tab-title colspan="3" scope="row"  Plan de financement prévisionnel
@@ -131,19 +132,20 @@
                         - aide_courante = @projet_courant.projet_aides.find_by(aide_id: aide.id)
                         = hidden_field_tag "#{field_name}[aide_id]", aide.id
                         = hidden_field_tag "#{field_name}[id]",      aide_courante.try(:id)
-                        = text_field_tag   "#{field_name}[montant]", aide_courante.try(:montant), class: "aide"
+                        = text_field_tag   "#{field_name}[montant]", number_to_currency(aide_courante.try(:montant), unit: ''), class: "aide"
+                        = " €"
 
                 tr
                   th.tab-title colspan="3" scope="row"= t('helpers.label.proposition.financement_personnel')
                 tr
                   th scope="row"= t('helpers.label.proposition.reste_a_charge')
                   td
-                    = f.text_field :reste_a_charge
+                    = text_field_tag "projet[reste_a_charge]", number_to_currency(@projet_courant.reste_a_charge, unit: '')
                     = " €"
                 tr
                   th scope="row"= t('helpers.label.proposition.pret_bancaire')
                   td
-                    = f.text_field :pret_bancaire
+                    = text_field_tag "projet[pret_bancaire]", number_to_currency(@projet_courant.pret_bancaire, unit: '')
                     = " €"
           ul.ins-form
             li

--- a/spec/concerns/localized_model_concern_spec.rb
+++ b/spec/concerns/localized_model_concern_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe LocalizedModelConcern do
+  describe "#localized_numeric_setter" do
+    before(:all) do
+      Temping.create :localizable_model do
+        with_columns do |t|
+          t.float :amount, default: false
+        end
+
+        include LocalizedModelConcern
+
+        localized_numeric_setter :amount
+      end
+    end
+
+    let(:model) { LocalizableModel.new }
+
+    it "convertit un nombre localisé en nombre US" do
+      model.amount = "100,25"
+      expect(model.read_attribute(:amount).to_s).to eq '100.25'
+    end
+
+    it "ne convertit pas un nombre déjà au format US" do
+      model.amount = "100.25"
+      expect(model.read_attribute(:amount).to_s).to eq '100.25'
+    end
+  end
+end

--- a/spec/concerns/localized_model_concern_spec.rb
+++ b/spec/concerns/localized_model_concern_spec.rb
@@ -16,14 +16,24 @@ describe LocalizedModelConcern do
 
     let(:model) { LocalizableModel.new }
 
-    it "convertit un nombre localisé en nombre US" do
+    it "convertit un séparateur de décimales localisé en séparateur de décimales US" do
       model.amount = "100,25"
       expect(model.read_attribute(:amount).to_s).to eq '100.25'
     end
 
-    it "ne convertit pas un nombre déjà au format US" do
-      model.amount = "100.25"
-      expect(model.read_attribute(:amount).to_s).to eq '100.25'
+    it "convertit un séparateur de milliers localisé en séparateur de milliers US" do
+      model.amount = "1 200,25"
+      expect(model.read_attribute(:amount).to_s).to eq '1200.25'
+    end
+
+    it "ne convertit pas une valeur déjà au format US" do
+      model.amount = "1200.25"
+      expect(model.read_attribute(:amount).to_s).to eq '1200.25'
+    end
+
+    it "ne convertit pas une valeur déjà sous forme numérique" do
+      model.amount = 1200.25
+      expect(model.read_attribute(:amount).to_s).to eq '1200.25'
     end
   end
 end

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -50,10 +50,10 @@ feature "Remplir la proposition de travaux" do
       fill_in 'projet_etiquette_apres_travaux', with: 'A'
 
       # Section "Financement"
-      fill_in 'projet_montant_travaux_ht', with: '3333,33'
-      fill_in 'projet_montant_travaux_ttc', with: '4444,44'
-      fill_in 'projet_reste_a_charge', with: '1111,11'
-      fill_in  aide.libelle, with: '5555,55'
+      fill_in 'projet_montant_travaux_ht', with: '3 333,33'
+      fill_in 'projet_montant_travaux_ttc', with: '4 444,44'
+      fill_in 'projet_reste_a_charge', with: '1 111,11'
+      fill_in  aide.libelle, with: '5 555,55'
 
       # Section "Précisions"
       fill_in 'projet_precisions_travaux', with: 'Il faudra casser un mur.'

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -50,10 +50,10 @@ feature "Remplir la proposition de travaux" do
       fill_in 'projet_etiquette_apres_travaux', with: 'A'
 
       # Section "Financement"
-      fill_in 'projet_montant_travaux_ht', with: '3333'
-      fill_in 'projet_montant_travaux_ttc', with: '4444'
-      fill_in 'projet_reste_a_charge', with: '1111'
-      fill_in  aide.libelle, with: '5555'
+      fill_in 'projet_montant_travaux_ht', with: '3333,33'
+      fill_in 'projet_montant_travaux_ttc', with: '4444,44'
+      fill_in 'projet_reste_a_charge', with: '1111,11'
+      fill_in  aide.libelle, with: '5555,55'
 
       # Section "Précisions"
       fill_in 'projet_precisions_travaux', with: 'Il faudra casser un mur.'
@@ -92,13 +92,13 @@ feature "Remplir la proposition de travaux" do
 
       # Section "Financement"
       expect(page).to have_content(I18n.t('helpers.label.proposition.montant_travaux_ht'))
-      expect(page).to have_content('3333')
+      expect(page).to have_content('3 333,33 €')
       expect(page).to have_content(I18n.t('helpers.label.proposition.montant_travaux_ht'))
-      expect(page).to have_content('4444')
+      expect(page).to have_content('4 444,44 €')
       expect(page).to have_content(I18n.t('helpers.label.proposition.reste_a_charge'))
-      expect(page).to have_content('1111')
+      expect(page).to have_content('1 111,11 €')
       expect(page).to have_content(aide.libelle)
-      expect(page).to have_content('5555')
+      expect(page).to have_content('5 555,55 €')
       expect(page).to have_content(I18n.t('helpers.label.proposition.precisions_travaux') + ' : Il faudra casser un mur.')
       expect(page).to have_content(I18n.t('helpers.label.proposition.precisions_financement') + ' : Le prêt sera sans doute accordé.')
     end


### PR DESCRIPTION
Aujourd'hui les différents montants d'une proposition n'acceptent pas les montants décimaux.

Avec cette PR :

- Les champs acceptent des valeurs avec des virgules,
- Les valeurs sont correctement formatées quand on les affiche (`3 100,25` au lieu de `3100.25`).

C'est implémenté à l'aide d'un helper `localized_numeric_setter` sur les modèles, qui convertit un nombre localisé en format US.

TODO :

- S'interroger sur notre usage de champs `float` pour stocker des montants.