### PR TITLE
Dossier: un PRIS peut recommander des opérateurs

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1152,6 +1152,31 @@ fieldset {
   }
 }
 
+/** RECOMMANDER OPERATEUR */
+.recommander_operateurs {
+  p:not(:last-child) {
+    margin: 10px 0;
+  }
+
+  ul {
+    margin: 20px;
+  }
+
+  input[type=submit] {
+    margin-top: 10px;
+  }
+}
+
+.checkboxes-list {
+  input[type=checkbox] {
+    margin-right: 5px;
+  }
+  label {
+    display: inline-block;
+    padding: 5px 0;
+  }
+}
+
 /** FOOTER **/
 .main-footer {
   text-align: center;

--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -81,10 +81,13 @@ module ProjetConcern
               :montant_travaux_ht, :montant_travaux_ttc, :pret_bancaire, :reste_a_charge,
               :documents_attributes,
               :prestation_ids => [],
+              :suggested_operateur_ids => [],
               :projet_aides_attributes => [:id, :aide_id, :montant])
       attributs[:prestation_ids] = [] if attributs[:prestation_ids].blank?
-      attributs[:projet_aides_attributes].values.each do |projet_aide|
-        projet_aide[:_destroy] = true if projet_aide[:montant].blank?
+      if attributs[:projet_aides_attributes].present?
+        attributs[:projet_aides_attributes].values.each do |projet_aide|
+          projet_aide[:_destroy] = true if projet_aide[:montant].blank?
+        end
       end
       attributs = attributs.merge(adresse_complete) if adresse_complete
       attributs

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -5,6 +5,11 @@ class DossiersController < ApplicationController
   before_action :dossier_ou_projet
   before_action :assert_projet_courant, except: [:index]
 
+  def index
+    @dossiers = Projet.for_agent(current_agent)
+    @page_heading = "Dossiers"
+  end
+
   def affecter_agent
     if @projet_courant.update_attribute(:agent, current_agent)
       flash[:notice] = t('projets.visualisation.projet_affecte')
@@ -14,8 +19,29 @@ class DossiersController < ApplicationController
     redirect_to dossier_path(@projet_courant)
   end
 
-  def index
-    @dossiers = Projet.for_agent(current_agent)
-    @page_heading = "Dossiers"
+  def recommander_operateurs
+    if request.post?
+      if @projet_courant.suggest_operateurs!(suggested_operateurs_params[:suggested_operateur_ids])
+        redirect_to(dossier_path(@projet_courant),
+                    notice: I18n.t('recommander_operateurs.succes',
+                                   count:     @projet_courant.suggested_operateurs.count,
+                                   demandeur: @projet_courant.demandeur_principal.fullname))
+      end
+    end
+
+    @available_operateurs = @projet_courant.intervenants_disponibles(role: :operateur)
+    if @projet_courant.suggested_operateurs.blank? && !request.post?
+      @available_operateurs.shuffle!
+    end
+  end
+
+private
+
+  def suggested_operateurs_params
+    attributes = params
+      .fetch(:projet, {})
+      .permit(:suggested_operateur_ids => [])
+    attributes[:suggested_operateur_ids] ||= []
+    attributes
   end
 end

--- a/app/mailers/projet_mailer.rb
+++ b/app/mailers/projet_mailer.rb
@@ -3,6 +3,15 @@ class ProjetMailer < ActionMailer::Base
   default delivery_method: Proc.new { Rails.env.production? && !Tools.demo? ? :smtp : :letter_opener_web }
   default from: ENV["NO_REPLY_FROM"]
 
+  def recommandation_operateurs(projet)
+    @demandeur = projet.demandeur_principal
+    @pris = projet.invited_pris
+    mail(
+      to: projet.email,
+      subject: t('mailers.projet_mailer.recommandation_operateurs.sujet')
+    )
+  end
+
   def invitation_intervenant(invitation)
     @invitation = invitation
     mail(

--- a/app/models/intervenant.rb
+++ b/app/models/intervenant.rb
@@ -4,6 +4,9 @@ class Intervenant < ActiveRecord::Base
   has_many :invitations
   has_many :projets, through: :invitations
   has_many :agents
+
+  has_and_belongs_to_many :suggested_on_projets, class_name: 'Projet', join_table: 'suggested_operateurs'
+
   validates :raison_sociale, presence: true
   validates :email, email: true, allow_blank: true
 

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -24,6 +24,7 @@ class Projet < ActiveRecord::Base
   accepts_nested_attributes_for :projet_aides, reject_if: :all_blank, allow_destroy: true
 
   has_and_belongs_to_many :prestations, join_table: 'projet_prestations'
+  has_and_belongs_to_many :suggested_operateurs, class_name: 'Intervenant', join_table: 'suggested_operateurs'
 
   validates :numero_fiscal, :reference_avis, :adresse_ligne1, presence: true
   validates_numericality_of :nb_occupants_a_charge, greater_than_or_equal_to: 0, allow_nil: true
@@ -139,6 +140,16 @@ class Projet < ActiveRecord::Base
     Tools.calcule_preeligibilite(calcul_revenu_fiscal_reference_total(annee_revenus), self.departement, self.nb_total_occupants)
   end
 
+  def suggest_operateurs!(operateur_ids)
+    self.suggested_operateur_ids = operateur_ids
+    if validate_suggested_operateurs && save
+      ProjetMailer.recommandation_operateurs(self).deliver_later!
+      true
+    else
+      false
+    end
+  end
+
   def invite_intervenant!(intervenant)
     return if intervenants.include? intervenant
 
@@ -199,5 +210,13 @@ class Projet < ActiveRecord::Base
 
   def prenom_occupants
     occupants.map { |occupant| occupant.prenom.capitalize }.join(' et ')
+  end
+
+  def validate_suggested_operateurs
+    if suggested_operateurs.blank?
+      errors[:base] << I18n.t('recommander_operateurs.errors.blank')
+      return false
+    end
+    valid?
   end
 end

--- a/app/views/contacts/new.html.slim
+++ b/app/views/contacts/new.html.slim
@@ -1,5 +1,5 @@
 = simple_form_for @contact, html: { class: "form-horizontal form-regular form-with-alerts form-contact clearfix" }, wrapper: :bootstrap do |f|
-  = render "shared/errors", item: @contact
+  = render "shared/errors", resource: @contact
   = f.input :name, wrapper_html: { class: "size-m" }, required: true
   = f.input :email, wrapper_html: { class: "size-m" }, required: true
   = f.input :phone, wrapper_html: { class: "size-m" }

--- a/app/views/dossiers/_projet_envisage.html.slim
+++ b/app/views/dossiers/_projet_envisage.html.slim
@@ -22,4 +22,12 @@ article.block.projet
           | . Vous serez informé par email pour chaque réponse de sa part.
       - else
         p
-          strong Aucun
+          = t('projets.envisage.operateur.aucun')
+        - if @projet_courant.suggested_operateurs.present?
+          h4 = t('projets.envisage.operateurs_recommandes')
+          ul
+          - @projet_courant.suggested_operateurs.each do |operateur|
+            li = operateur.raison_sociale
+          = link_to t('recommander_operateurs.modifier'), dossier_recommander_operateurs_path(@projet_courant), class: "btn"
+        - else
+          = link_to t('recommander_operateurs.recommander'), dossier_recommander_operateurs_path(@projet_courant), class: "btn"

--- a/app/views/dossiers/recommander_operateurs.html.slim
+++ b/app/views/dossiers/recommander_operateurs.html.slim
@@ -1,0 +1,15 @@
+.main-content-block.recommander_operateurs
+  h2.heading Recommander des opérateurs
+  = form_for @projet_courant, url: {controller: 'dossiers', action: 'recommander_operateurs' }, method: 'post', html: { class: 'form' } do |f|
+    p #{@projet_courant.demandeur_principal.fullname}, le demandeur de ce projet, recevra un email l'invitant à contacter un opérateur parmi ceux recommandés.
+    = render 'shared/errors', resource: @projet_courant
+    ul.checkboxes-list
+      - @available_operateurs.each do |operateur|
+        li
+          label
+            = check_box_tag "projet[suggested_operateur_ids][]",
+                            operateur.id,
+                            @projet_courant.suggested_operateur_ids.include?(operateur.id),
+                            { id: "operateur_#{operateur.id}" }
+            = operateur.raison_sociale
+    = f.submit t('recommander_operateurs.valider'), class: 'btn'

--- a/app/views/projet_mailer/recommandation_operateurs.html.slim
+++ b/app/views/projet_mailer/recommandation_operateurs.html.slim
@@ -1,0 +1,8 @@
+p Bonjour #{@demandeur.fullname},
+p Nous avons sélectionné pour vous des intervenants qui pourraient vous accompagner dans votre projet de rénovation.
+p Ces intervenants pourront discuter avec vous de votre projet, et vous aider à monter un dossier de subventions pour vos travaux.
+p Cliquez ici TODO pour consulter les intervenants qui vous ont été recommandés, et choisir un d’entre eux pour vous accompagner dans votre projet.
+p
+ | Cordialement,<br>
+ | #{@pris.raison_sociale}<br>
+ | Point Rénovation Info-Service

--- a/app/views/shared/_errors.html.slim
+++ b/app/views/shared/_errors.html.slim
@@ -1,15 +1,12 @@
-- unless defined?(resource)
-  - resource = defined?(item) ? item : nil
 - if resource && resource.errors.present?
   - model = resource.class.to_s.underscore
   .row
     .col-xxs-12
       div.form-errors.alert.alert-danger
-        button.close data-dismiss="alert" type="button" &times;
-        strong
-          = %(#{pluralize resource.errors.count, "erreur"} sur :)
+        - if resource.errors.count == 1
+          p = resource.errors.full_messages.first
+        - else
+          = "#{resource.errors.count} erreurs :"
           ul
-            - resource.errors.each do |error|
-              li
-                label for="#{model}_#{error}"
-                  = i18n_simple_form_label(model, error)
+            - resource.errors.full_messages.each do |message|
+              li = message

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -194,6 +194,12 @@ fr:
       messages:
         succes: "La composition du logement a bien été mise à jour."
 
+    envisage:
+      pas_encore_rempli: "Le demandeur n’a pas encore rempli le projet"
+      operateur:
+        aucun: "Aucun pour l’instant"
+      operateurs_recommandes: "Opérateurs recommandés"
+
     proposition:
       plan_financement: "Plan de financement prévisionnel"
       titre_affiche_adresse: "Adresse du logement à renover"
@@ -267,6 +273,17 @@ fr:
   conversation:
     titre_section: "Chat"
 
+  # ----------------------- Recommander des opérateurs -----------------
+  recommander_operateurs:
+    recommander: "Recommander des opérateurs"
+    modifier: "Modifier les opérateurs recommandés"
+    valider: "Recommander ces opérateurs"
+    succes:
+      one: "L’opérateur sélectionné a été recommandé à %{demandeur}."
+      other: "Les opérateurs sélectionnés ont été recommandés à %{demandeur}."
+    errors:
+      blank: "Choisissez au moins un opérateur à recommander."
+
   # ----------------------- Choix d’un intervenant ---------------------
   intervenant_projets:
     visualisation:
@@ -311,6 +328,8 @@ fr:
   # ----------------------- Mailers ---------------------
   mailers:
     projet_mailer:
+      recommandation_operateurs:
+        sujet: "[ANAH] Voici nos recommandations pour votre projet de rénovation"
       invitation_intervenant:
         sujet: "[ANAH] Invitation de %{demandeur_principal} à consulter son projet"
       notification_invitation_intervenant:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
     resources :dossiers, only: [], concerns: :projectable do
       post :dossiers_opal, controller: 'dossiers_opal', action: 'create'
       get  :affecter_agent
+      get  :recommander_operateurs
+      post :recommander_operateurs
       get  :proposer
     end
     resources :dossiers, only: [:show, :edit, :update, :index], param: :dossier_id

--- a/db/migrate/20170220160351_create_suggested_operateurs.rb
+++ b/db/migrate/20170220160351_create_suggested_operateurs.rb
@@ -1,0 +1,11 @@
+class CreateSuggestedOperateurs < ActiveRecord::Migration
+  def change
+    create_table :suggested_operateurs, id: false do |t|
+      t.integer :projet_id
+      t.integer :intervenant_id
+    end
+
+    add_index :suggested_operateurs, :projet_id
+    add_index :suggested_operateurs, :intervenant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170215171607) do
+ActiveRecord::Schema.define(version: 20170220160351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -294,6 +294,14 @@ ActiveRecord::Schema.define(version: 20170215171607) do
     t.string  "code"
     t.text    "libelle"
   end
+
+  create_table "suggested_operateurs", id: false, force: :cascade do |t|
+    t.integer "projet_id"
+    t.integer "intervenant_id"
+  end
+
+  add_index "suggested_operateurs", ["intervenant_id"], name: "index_suggested_operateurs_on_intervenant_id", using: :btree
+  add_index "suggested_operateurs", ["projet_id"], name: "index_suggested_operateurs_on_projet_id", using: :btree
 
   create_table "themes", force: :cascade do |t|
     t.string "libelle"

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -36,6 +36,16 @@ FactoryGirl.define do
       end
     end
 
+    trait :with_suggested_operateurs do
+      after(:build) do |projet|
+        operateurA = create(:operateur, departements: [projet.departement])
+        operateurB = create(:operateur, departements: [projet.departement])
+        operateurC = create(:operateur, departements: [projet.departement])
+        projet.suggested_operateurs = [operateurA, operateurC]
+        # B is available but not suggested
+      end
+    end
+
     trait :with_invited_operateur do
       after(:build) do |projet|
         operateur = create(:operateur, departements: [projet.departement])

--- a/spec/features/2_choix_operateur/choisir_operateur_spec.rb
+++ b/spec/features/2_choix_operateur/choisir_operateur_spec.rb
@@ -4,25 +4,88 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature "Choisir un opérateur:" do
-  context "en tant que demandeur, avant que le PRIS ne me suggère des opérateurs" do
-    let(:projet) { create(:projet, :prospect, :with_intervenants_disponibles, :with_invited_pris) }
+  context "en tant que PRIS" do
+    let(:projet)      { create(:projet, :prospect, :with_intervenants_disponibles, :with_invited_pris) }
+    let(:pris)        { projet.invited_pris }
+    let(:agent_pris)  { create :agent, intervenant: pris }
 
-    scenario "je peux choisir un opérateur moi-même" do
-      signin(projet.numero_fiscal, projet.reference_avis)
-      click_link I18n.t('projets.visualisation.choisir_intervenant')
+    before { login_as agent_pris, scope: :agent }
 
-      expect(page).not_to have_content(I18n.t('demarrage_projet.etape3_choix_intervenant.section_eligibilite'))
-      expect(page).to have_selector('.choose-operator.choose-operator-intervenant')
+    context "pour un projet sans opérateurs recommandés" do
+      let(:projet) { create(:projet, :prospect, :with_intervenants_disponibles, :with_invited_pris) }
+      let!(:operateurA) { create :operateur, departements: [projet.departement] }
+      let!(:operateurB) { create :operateur, departements: [projet.departement] }
 
-      invited_pris = projet.invited_pris
-      new_operateur = projet.intervenants_disponibles(role: :operateur).first
+      scenario "je peux recommander un ou plusieurs opérateurs au demandeur" do
+        visit dossier_path(projet)
+        click_link I18n.t('recommander_operateurs.recommander')
 
-      choose new_operateur.raison_sociale
-      check I18n.t('agrements.autorisation_acces_donnees_intervenants')
-      click_button I18n.t('projets.edition.action')
+        expect(page).to have_current_path dossier_recommander_operateurs_path(projet)
+        check operateurA.raison_sociale
+        check operateurB.raison_sociale
+        click_button I18n.t('recommander_operateurs.valider')
 
-      expect(page).to have_content(new_operateur.raison_sociale)
-      expect(page).not_to have_content(invited_pris)
+        expect(page).to have_current_path dossier_path(projet)
+        expect(page).to have_content "Les opérateurs sélectionnés ont été recommandés"
+        expect(page).to have_content I18n.t('projets.envisage.operateurs_recommandes')
+        expect(page).to have_content operateurA.raison_sociale
+        expect(page).to have_content operateurB.raison_sociale
+      end
+
+      scenario "je reçois une erreur si je ne sélectionne aucun opérateur" do
+        visit dossier_path(projet)
+        click_link I18n.t('recommander_operateurs.recommander')
+        click_button I18n.t('recommander_operateurs.valider')
+        expect(page).to have_current_path dossier_recommander_operateurs_path(projet)
+        expect(page).to have_content I18n.t('recommander_operateurs.errors.blank')
+      end
+    end
+
+    context "après avoir recommandé des opérateurs" do
+      let(:projet) { create(:projet,
+                            :prospect,
+                            :with_intervenants_disponibles,
+                            :with_invited_pris,
+                            :with_suggested_operateurs) }
+      let(:suggested_operateur) { projet.suggested_operateurs.first }
+
+      scenario "je peux modifier les opérateurs recommandés" do
+        visit dossier_path(projet)
+        click_link I18n.t('recommander_operateurs.modifier')
+
+        expect(page).to have_current_path dossier_recommander_operateurs_path(projet)
+        expect(find("#operateur_#{suggested_operateur.id}")).to be_checked
+        uncheck suggested_operateur.raison_sociale
+        click_button I18n.t('recommander_operateurs.valider')
+
+        expect(page).to have_current_path dossier_path(projet)
+        expect(page).to have_content "L’opérateur sélectionné a été recommandé"
+        expect(page).not_to have_content suggested_operateur.raison_sociale
+      end
+    end
+  end
+
+  context "en tant que demandeur" do
+    context "avant que le PRIS ne me suggère des opérateurs" do
+      let(:projet) { create(:projet, :prospect, :with_intervenants_disponibles, :with_invited_pris) }
+
+      scenario "je peux choisir un opérateur moi-même" do
+        signin(projet.numero_fiscal, projet.reference_avis)
+        click_link I18n.t('projets.visualisation.choisir_intervenant')
+
+        expect(page).not_to have_content(I18n.t('demarrage_projet.etape3_choix_intervenant.section_eligibilite'))
+        expect(page).to have_selector('.choose-operator.choose-operator-intervenant')
+
+        invited_pris = projet.invited_pris
+        new_operateur = projet.intervenants_disponibles(role: :operateur).first
+
+        choose new_operateur.raison_sociale
+        check I18n.t('agrements.autorisation_acces_donnees_intervenants')
+        click_button I18n.t('projets.edition.action')
+
+        expect(page).to have_content(new_operateur.raison_sociale)
+        expect(page).not_to have_content(invited_pris)
+      end
     end
   end
 end

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 describe ProjetMailer, type: :mailer do
+  describe "recommandation operateurs" do
+    let(:projet) { create :projet, :with_suggested_operateurs, :with_invited_pris }
+    let(:email) { ProjetMailer.recommandation_operateurs(projet) }
+    it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
+    it { expect(email.to).to eq([projet.email]) }
+    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.recommandation_operateurs.sujet')) }
+    it { expect(email.body.encoded).to match(projet.demandeur_principal.fullname) }
+  end
+
   describe "invitation intervenant" do
     let(:invitation) { create :invitation }
     let(:email) { ProjetMailer.invitation_intervenant(invitation) }

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -121,7 +121,27 @@ describe Projet do
     it { expect(projet.numero_plateforme).to eq("42_1234") }
   end
 
-  describe "invite_intervenant!" do
+  describe "#suggest_operateurs!" do
+    let(:projet)     { create :projet, :with_suggested_operateurs }
+    let(:operateurA) { create :operateur }
+    let(:operateurB) { create :operateur }
+
+    it "ajoute les opérateurs aux opérateurs suggérés" do
+      expect(ProjetMailer).to receive(:recommandation_operateurs).and_call_original
+      result = projet.suggest_operateurs!([operateurA.id, operateurB.id])
+      expect(result).to be true
+      expect(projet.suggested_operateurs.count).to eq 2
+      expect(projet.errors).to be_empty
+    end
+
+    it "signale une erreur si aucun opérateur n'est suggéré" do
+      result = projet.suggest_operateurs!([])
+      expect(result).to be false
+      expect(projet.errors).to be_present
+    end
+  end
+
+  describe "#invite_intervenant!" do
     context "sans intervenant invité au préalable" do
       let(:projet)    { create :projet }
       let(:operateur) { create :operateur }
@@ -198,7 +218,7 @@ describe Projet do
     end
   end
 
-  describe "commit_to_operateur!" do
+  describe "#commit_to_operateur!" do
     let(:projet)    { create :projet, :prospect }
     let(:operateur) { create :operateur }
 


### PR DESCRIPTION
**En tant que PRIS :**

- Je consulte un dossier en attente de recommandation,
- Je clique sur un bouton "Recommander des opérateurs"
- Une page s'affiche, avec une liste d'opérateurs, des checkboxes, et un bouton "Recommander ces opérateurs"
- le bouton "Recommander ces opérateurs" enregistre, envoie un email au demandeur, et retourne à la page d'accueil du dossier.

![recommander-operateurs emails](https://cloud.githubusercontent.com/assets/179923/23172083/ecd00134-f854-11e6-92ee-34e60b6f7dbc.gif)
