### PR TITLE
Détecter automatiquement le format des fichiers CSV

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,6 @@ gem 'fog-openstack'
 gem 'devise'
 gem 'devise_cas_authenticatable'
 gem 'newrelic_rpm'
+
+gem 'charlock_holmes'
+gem 'acsv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    acsv (0.0.1)
     actionmailer (4.2.6)
       actionpack (= 4.2.6)
       actionview (= 4.2.6)
@@ -64,6 +65,7 @@ GEM
       json (>= 1.7)
       mime-types (>= 1.16)
       mimemagic (>= 0.3.0)
+    charlock_holmes (0.7.3)
     choice (0.2.0)
     coderay (1.1.1)
     coffee-rails (4.1.1)
@@ -360,11 +362,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acsv
   active_model_serializers
   byebug
   capybara
   capybara-screenshot
   carrierwave
+  charlock_holmes
   coffee-rails (~> 4.1.0)
   csv2json
   database_cleaner

--- a/app/controllers/admin/intervenants_controller.rb
+++ b/app/controllers/admin/intervenants_controller.rb
@@ -1,4 +1,5 @@
-require 'csv'
+require 'charlock_holmes'
+require 'acsv'
 
 class Admin::IntervenantsController < Admin::BaseController
 
@@ -23,7 +24,8 @@ private
     end
 
     begin
-      @csv = _parse_csv(file)
+      # Use ACSV to auto-detect the file encoding and column separator
+      @csv = ACSV::CSV.read(file.tempfile.path, headers: true)
     rescue => e
       raise "Le fichier CSV ne peut être lu (#{e.message})."
     end
@@ -35,17 +37,6 @@ private
         raise "La mise à jour de l’intervenant '#{row['raison_sociale']}' a échoué (#{e.message})."
       end
     end
-  end
-
-  def _parse_csv(file)
-    csv_content = file.read
-    col_separators = [',', ';', '\t']
-    best_separator = col_separators
-      .max_by { |separator|
-        csv = CSV.parse(csv_content, headers: true, col_sep: separator)
-        csv.headers.count
-      }
-    CSV.parse(csv_content, headers: true, col_sep: best_separator)
   end
 
   def _create_or_update_intervenant!(row)

--- a/public/exemples/Exemple import intervenants.csv
+++ b/public/exemples/Exemple import intervenants.csv
@@ -1,5 +1,5 @@
 clavis_service_id;raison_sociale;email;departements;roles;adresse_postale;informations
-9111;Direction DÃ©partementale des Territoires des Vosges;ddt@vosges.anah.exemple.com;88;instructeur;;ExpÃ©rimentation prÃ©vue le 2
-2871;PRIS DDT 88;admin@anah.beta.gouv.fr;88;operateur,pris;9 avenue Jean-JaurÃ¨s, 88 000 Ã‰pinal;
-2376;CommunautÃ© de Communes de Brest;cc@finistere.anah.exemple.com;29,22;operateur;;
+9111;Direction Départementale des Territoires des Vosges;ddt@vosges.anah.exemple.com;88;instructeur;;Expérimentation prévue le 2
+2871;PRIS DDT 88;admin@anah.beta.gouv.fr;88;operateur,pris;9 avenue Jean-Jaurès, 88 000 Épinal;
+2376;Communauté de Communes de Brest;cc@finistere.anah.exemple.com;29,22;operateur;;
 8633;Association IPAHD;contact@ipahd.exemple.org;13;operateur;;

--- a/spec/controllers/admin/intervenants_controller_spec.rb
+++ b/spec/controllers/admin/intervenants_controller_spec.rb
@@ -4,9 +4,9 @@ require 'support/mpal_helper'
 describe Admin::IntervenantsController do
 
   # Génère un fichier CSV à partir d'un tableau de hashes
-  def uploaded_csv(records, separator=',')
-    tmp_file = Tempfile.new('import-test.csv')
-    CSV.open(tmp_file, "wb", { col_sep: separator }) do |csv|
+  def uploaded_csv(records, separator=',', encoding='utf-8')
+    tmp_file = Tempfile.new('import-test.csv', encoding: encoding)
+    CSV.open(tmp_file, "w:#{encoding}", { col_sep: separator }) do |csv|
       csv << records.first.keys # header row
       records.each do |hash|
         csv << hash.values
@@ -52,6 +52,16 @@ describe Admin::IntervenantsController do
       post :import, { csv_file: uploaded_csv(data, ';') }
       expect(operateur1).not_to be_nil
       expect(operateur1.email).to eq 'contact@operateur1.fr'
+    end
+
+    it "import un fichier CSV encodé en UTF-8" do
+      post :import, { csv_file: uploaded_csv(data, ',', 'utf-8') }
+      expect(operateur1.raison_sociale).to eq 'Opérateur1'
+    end
+
+    it "importe un fichier CSV encodé en ISO-8859-1" do
+      post :import, { csv_file: uploaded_csv(data, ',', 'iso-8859-1') }
+      expect(operateur1.raison_sociale).to eq 'Opérateur1'
     end
 
     it "redirige vers la liste des intervenants en cas de succès" do

--- a/spec/fixtures/Import intervenants.csv
+++ b/spec/fixtures/Import intervenants.csv
@@ -1,8 +1,8 @@
 clavis_service_id,raison_sociale,email,departements,roles
-4110,Direction DÃ©partementale des Territoires des Vosges,admin@anah.beta.gouv.fr,88,instructeur
+4110,Direction Départementale des Territoires des Vosges,admin@anah.beta.gouv.fr,88,instructeur
 4111,PRIS DDT 88,admin@anah.beta.gouv.fr,88,operateur
-4112,CommunautÃ© de Communes de la RÃ©gion de Rambervillers,admin@anah.beta.gouv.fr,88,operateur
-4113,Maison de L'Emploi de la DÃ©odatie,admin@anah.beta.gouv.fr,88,operateur
+4112,Communauté de Communes de la Région de Rambervillers,admin@anah.beta.gouv.fr,88,operateur
+4113,Maison de L'Emploi de la Déodatie,admin@anah.beta.gouv.fr,88,operateur
 4114,Association CAMEL Vosges ,admin@anah.beta.gouv.fr,88,operateur
 4115,BET EXERGIE,admin@anah.beta.gouv.fr,88,operateur
 4116,URBAM CONSEIL,admin@anah.beta.gouv.fr,88,operateur


### PR DESCRIPTION
Avant on avait du code custom pour détecter automatiquement le séparateur de colonnes des fichiers CSV d'import.

J'ai remplacé ça par la petite gem [ACSV](https://github.com/wvengen/ruby-acsv), qui détecte automatiquement les séparateurs, et surtout en bonus l'encodage du fichier.

Comme Excel n'aime pas les fichiers en UTF-8, ça permet au code d'import de lire toute sortes de format, et que ça Juste Marche™.