### PR TITLE
PF-276 Affiche les identifiants de démo sur la page d’accueil

### DIFF
--- a/app/views/sessions/_demo.html.slim
+++ b/app/views/sessions/_demo.html.slim
@@ -8,17 +8,50 @@ section.demo
     p Ré-initialise tous les projets sur l’environnement de démo.
     p= btn name: t('accueil.reinitialiser'), href: reset_path, class: 'btn-test', icon: 'remove'
   div.demo-right
-    h3 Identifiants de démo pour les demandeurs
+    h3 Identifiants de démo
+
+    p Doubs
     ul
-      li
-        | un demandeur habitant dans les Vosges :
-        strong  88 / 1588
-      li
-        | un demandeur habitant dans le Val d’Oise :
-        strong  95 / 1595
-      li
-        | un autre demandeur habitant dans le Val d’Oise :
-        strong  952 / 15952
-      li
-        | un demandeur habitant dans le Doubs :
-        strong  25 / 1525
+      li Demandeur 1 : <strong>25 / 1525</strong>
+      li Opérateur 1 : <strong>operateur25-1@anah.gouv.fr / service-25</strong>
+      li Opérateur 2 : <strong>operateur25-2@anah.gouv.fr / service-25</strong>
+      li Instructeur 1 : <strong>delegation25-1@anah.gouv.fr / service-25</strong>
+      li Instructeur 2 : <strong>delegation25-2@anah.gouv.fr / service-25</strong>
+      li PRIS : <strong>pris25@anah.gouv.fr / service-25</strong>
+
+    p Vosges
+    ul
+      li Demandeur 1 : <strong>88 / 1588</strong>
+      li Opérateur 1 : <strong>operateur88-1@anah.gouv.fr / service-88</strong>
+      li Opérateur 2 : <strong>operateur88-2@anah.gouv.fr / service-88</strong>
+      li Instructeur 1 : <strong>delegation88-1@anah.gouv.fr / service-88</strong>
+      li Instructeur 2 : <strong>delegation88-2@anah.gouv.fr / service-88</strong>
+      li PRIS : <strong>pris88@anah.gouv.fr / service-88</strong>
+
+    p Val d’Oise
+    ul
+      li Demandeur 1 : <strong>95 / 1595</strong>
+      li Demandeur 2 : <strong>952 / 15952</strong>
+      li Opérateur 1 : <strong>operateur95-1@anah.gouv.fr / service-95</strong>
+      li Opérateur 2 : <strong>operateur95-2@anah.gouv.fr / service-95</strong>
+      li Instructeur 1 : <strong>delegation95-1@anah.gouv.fr / service-95</strong>
+      li Instructeur 2 : <strong>delegation95-2@anah.gouv.fr / service-95</strong>
+      li PRIS : <strong>pris95@anah.gouv.fr / service-95</strong>
+
+    p Haute-Garonne
+    ul
+      li Demandeur 1 : <em>à créer</em>
+      li Opérateur 1 : <strong>operateur31-1@anah.gouv.fr / service-31</strong>
+      li Opérateur 2 : <strong>operateur31-2@anah.gouv.fr / service-31</strong>
+      li Instructeur 1 : <strong>delegation31-1@anah.gouv.fr / service-31</strong>
+      li Instructeur 2 : <strong>delegation31-2@anah.gouv.fr / service-31</strong>
+      li PRIS : <strong>pris31@anah.gouv.fr / service-31</strong>
+
+    p Pas-de-Calais
+    ul
+      li Demandeur 1 : <em>à créer</em>
+      li Opérateur 1 : <strong>operateur62-1@anah.gouv.fr / service-62</strong>
+      li Opérateur 2 : <strong>operateur62-2@anah.gouv.fr / service-62</strong>
+      li Instructeur 1 : <strong>delegation62-1@anah.gouv.fr / service-62</strong>
+      li Instructeur 2 : <strong>delegation62-2@anah.gouv.fr / service-62</strong>
+      li PRIS : <strong>pris62@anah.gouv.fr / service-62</strong>

--- a/db/seed_intervenants.json
+++ b/db/seed_intervenants.json
@@ -1,206 +1,181 @@
 [
   {
-    "raison_sociale": "Citemetrie 75",
-    "roles": ["operateur"],
-    "departements" : ["75"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "email": "citemetrie75@mailinator.com"
+    "departements": ["25"],
+    "raison_sociale": "ADIL 25",
+    "clavis_service_id": "5264",
+    "adresse_postale": "1 Rue de Ronde du Fort Griffon, 25000 Besançon",
+    "email": "pris25@anah.gouv.fr",
+    "roles": ["pris"]
   },
   {
-    "raison_sociale": "Centre Information Habitat Adil 75",
-    "roles": ["pris"],
+    "departements": ["25"],
+    "raison_sociale": "DDT 25",
+    "clavis_service_id": "5054",
+    "email": "delegation25-1@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
+    "departements": ["25"],
+    "raison_sociale": "AJJ",
+    "clavis_service_id": "5267",
+    "email": "operateur25-1@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["25", "90"],
+    "raison_sociale": "SOLIHA 25-90",
+    "clavis_service_id": "5262",
+    "adresse_postale": "30 rue Caporal Peugeot, 25000 Besançon",
+    "email": "operateur25-2@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["88"],
+    "raison_sociale": "PRIS-DDT-88",
+    "clavis_service_id": "5269",
+    "adresse_postale": "22-26 Avenue Dutac, 88000 Épinal",
+    "email": "pris88@anah.gouv.fr",
+    "roles": ["pris"]
+  },
+  {
+    "departements": ["88"],
+    "raison_sociale": "DDT des VOSGES",
+    "clavis_service_id": "5519",
+    "adresse_postale": "22-26 Avenue Dutac, 88000 Épinal",
+    "email": "delegation88-1@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
+    "departements": ["88"],
+    "raison_sociale": "URBAM CONSEIL SAS",
+    "clavis_service_id": "5265",
+    "adresse_postale": "5 Rue Thiers, 88000 Épinal",
+    "email": "operateur88-1@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["88"],
+    "raison_sociale": "BET Exergie",
+    "clavis_service_id": "5270",
+    "adresse_postale": "2 Route d'Aydoilles, 88600 Fontenay",
+    "email": "operateur88-2@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["95"],
+    "raison_sociale": "ADIL 95",
+    "clavis_service_id": "5272",
+    "adresse_postale": "La Croix Saint-Sylvère, 95000 Cergy",
+    "email": "pris95@anah.gouv.fr",
+    "roles": ["pris"]
+  },
+  {
+    "departements": ["95"],
+    "raison_sociale": "DDT du Val d'Oise",
+    "clavis_service_id": "5123",
+    "email": "delegation95-1@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
+    "departements": ["95"],
+    "raison_sociale": "SOLIHA Paris.Hauts de Seine.Val d'Oise",
+    "clavis_service_id": "5271",
+    "adresse_postale": "Les Châteaux Saint-Sylvère, 95000 Cergy",
+    "email": "operateur95-1@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["31"],
+    "raison_sociale": "PRIS DDT 31",
+    "clavis_service_id": "5277",
+    "email": "pris31@anah.gouv.fr",
+    "roles": ["pris"]
+  },
+  {
+    "departements": ["31"],
+    "raison_sociale": "DDT de Haute-Garonne",
+    "clavis_service_id": "5062",
+    "adresse_postale": "2 Boulevard Armand Duportal, 31000 Toulouse",
+    "email": "delegation31@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
+    "departements": ["31"],
+    "raison_sociale": "SOLIHA Haute Garonne",
+    "clavis_service_id": "5276",
+    "adresse_postale": "2 Boulevard Armand Duportal, 31000 Toulouse",
+    "email": "operateur31-1@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["31"],
+    "raison_sociale": "URBANIS Toulouse",
+    "clavis_service_id": "5274",
+    "adresse_postale": "60 Boulevard Déodat de Sévérac, 31300 Toulouse",
+    "email": "operateur31-2@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["31"],
+    "raison_sociale": "Conseil Départemental de la Haute-Garonne",
+    "clavis_service_id": "5182",
+    "email": "delegataire-cd31-1@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
+    "departements": ["62"],
+    "raison_sociale": "PRIS DDT 62",
+    "clavis_service_id": "5280",
+    "adresse_postale": "1 Boulevard de la Marquette, 31090 Toulouse",
+    "email": "pris62@anah.gouv.fr",
+    "roles": ["pris"]
+  },
+  {
+    "departements": ["62"],
+    "raison_sociale": "Direction Départementale des Territoires et de la Mer du Pas-de-Calais",
+    "clavis_service_id": "5093",
+    "adresse_postale": "8 Rue du Puits d'Amour, 62200 Boulogne-sur-Mer",
+    "email": "delegation62-1@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
+    "departements": ["62"],
+    "raison_sociale": "SOLIHA du Pas de Calais",
+    "clavis_service_id": "5275",
+    "adresse_postale": "6 Rue Jean Bodel, 62000 Arras",
+    "email": "operateur62-1@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["62"],
+    "raison_sociale": "INHARI",
+    "clavis_service_id": "5278",
+    "adresse_postale": "44 Rue du Champ des Oiseaux, 76000 Rouen",
+    "email": "operateur62-2@anah.gouv.fr",
+    "roles": ["operateur"]
+  },
+  {
+    "departements": ["62"],
+    "raison_sociale": "Communauté Urbaine d'Arras",
+    "clavis_service_id": "5226",
+    "adresse_postale": "Boulevard du Général de Gaulle, 62000 Arras",
+    "email": "delegataire-Arras62-1@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
+    "departements": ["62"],
+    "raison_sociale": "Communauté d'Agglomération de Béthune-Bruay",
+    "clavis_service_id": "5228",
+    "adresse_postale": "100 Avenue de Londres, 62400 Béthune",
+    "email": "delegataire-Bethune62-1@anah.gouv.fr",
+    "roles": ["instructeur"]
+  },
+  {
     "departements": ["75"],
+    "raison_sociale": "Centre Information Habitat Adil 75",
     "themes": ["autonomie", "insalubrité", "énergie"],
     "adresse_postale": "13 rue Crespin du Gast, 75011 Paris",
-    "email": "adil_75@mailinator.com"
-  },
-  {
-    "raison_sociale": "Centre Information Habitat Adil 75001",
-    "roles": ["pris"],
-    "departements": ["75"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "adresse_postale": "4 place du Louvre, 75001 Paris",
-    "email": "adil_75@mailinator.com"
-  },
-  {
-    "raison_sociale": "Citemetrie",
-    "roles": ["operateur"],
-    "departements" : ["95"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "email": "citemetrie95@mailinator.com"
-  },
-  {
-    "raison_sociale": "Centre Information Habitat Adil 95 Eaubonne",
-    "roles": ["pris"],
-    "departements": ["95"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "adresse_postale": "7 Rue Cristino Garcia, 95600 Eaubonne",
-    "email": "adil_eaubonne_95@mailinator.com"
-  },
-  {
-    "raison_sociale": "Centre Information Habitat Adil 95 Sarcelles",
-    "roles": ["pris"],
-    "departements": ["95"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "adresse_postale": "6 Allée Fragonard, 95200 Sarcelles",
-    "email": "adil_sarcelles_95@mailinator.com"
-  },
-  {
-    "raison_sociale": "Soliha 95",
-    "roles": ["operateur"],
-    "departements": ["95"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "email": "soliha95@mailinator.com"
-  },
-  {
-    "raison_sociale": "CoProDiag",
-    "roles": ["operateur"],
-    "departements": ["95"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "email": "coprodiag95@mailinator.com"
-  },
-  {
-    "raison_sociale": "DDT 95",
-    "adresse_postale": "22-26 avenue Dutac, 88000 Epinal",
-    "roles": ["instructeur"],
-    "departements": ["95"],
-    "email": "ddt95@mailinator.com"
-  },
-  {
-    "raison_sociale": "CAL-Soliha Vosges",
-    "roles": ["operateur"],
-    "departements": ["88"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "adresse_postale": "1 bis rue du souvenir, BP 93, 88194 Golbey Cedex",
-    "informations": "PIG ComCom du Bassin de NEUFCHATEAU\nPIG ComCom du Pays de Mirecourt",
-    "email": "soliha88@mailinator.com"
-  },
-  {
-    "raison_sociale": "Urbam Conseil",
-    "roles": ["operateur"],
-    "departements": ["88", "25"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "adresse_postale": "5 rue Thiers, BP 450, 88011 Epinal Cedex",
-    "informations": "PIG ComCom de la Moyenne Moselle\nPIG de la Communauté d'agglomération d'Epinal",
-    "email": "urbam88@mailinator.com"
-  },
-  {
-    "raison_sociale": "Association CAMEL",
-    "roles": ["operateur"],
-    "departements": ["88"],
-    "themes": ["autonomie"],
-    "email": "camel88@mailinator.com"
-  },
-  {
-    "raison_sociale": "BET EXERGIE",
-    "roles": ["operateur"],
-    "departements": ["88"],
-    "themes": ["énergie"],
-    "email": "betexergie@mailinator.com"
-  },
-  {
-    "raison_sociale": "Direction Départementale des Territoires des Vosges",
-    "adresse_postale": "22-26 avenue Dutac, 88000 Epinal",
-    "roles": ["pris", "instructeur"],
-    "departements": ["88"],
-    "email": "ddt88@mailinator.com",
-    "clavis_service_id": "5264"
-  },
-  {
-    "raison_sociale": "Soliha 25-90",
-    "adresse_postale": "30 rue Caporal Peugeot, 25000 Besançon",
-    "roles": ["operateur"],
-    "departements": ["25", "90"],
-    "themes": ["énergie"],
-    "clavis_service_id": "5262",
-    "email": "soliha25-90@mailinator.com"
-  },
-  {
-    "raison_sociale": "Association Julienne Javel",
-    "adresse_postale": "2 Grande Rue, 25220 Chalezeule",
-    "roles": ["operateur"],
-    "departements": ["25"],
-    "themes": ["énergie"],
-    "email": "asso-julienne-javel@mailinator.com"
-  },
-  {
-    "raison_sociale": "Adil 25",
-    "adresse_postale": "1 Rue de Ronde du Fort Griffon, 25000 Besançon",
-    "roles": ["pris"],
-    "departements": ["25"],
-    "themes": ["énergie"],
-    "email": "adil25@mailinator.com"
-  },
-  {
-    "raison_sociale": "Direction Départementale des Territoires du Doubs",
-    "adresse_postale": "6 Rue Roussillon, 25000 Besançon",
-    "roles": ["instructeur"],
-    "departements": ["25"],
-    "clavis_service_id": "5054",
-    "email": "ddt25@mailinator.com"
-  },
-  {
-    "raison_sociale": "URBANIS-31",
-    "departements": ["31"],
-    "roles": ["operateur"],
-    "email": "urbanis31@mailinator.com"
-  },
-  {
-    "raison_sociale": "Expertise & Patrimoine",
-    "departements": ["31"],
-    "roles": ["operateur"],
-    "email": "expertise-patrimoine@mailinator.com"
-  },
-  {
-    "raison_sociale": "SOLIHA-31",
-    "departements": ["31"],
-    "roles": ["operateur"],
-    "email": "soliha31@mailinator.com"
-  },
-  {
-    "raison_sociale": "Renoval",
-    "departements": ["31"],
-    "roles": ["pris"],
-    "email": "renoval@mailinator.com"
-  },
-  {
-    "raison_sociale": "Direction Départementale des territoires de Haute-Garonne",
-    "adresse_postale": " 2 Boulevard Armand Duportal, 31000 Toulouse",
-    "roles": ["pris", "instructeur"],
-    "departements": ["31"],
-    "email": "ddt31@mailinator.com"
-  },
-  {
-    "raison_sociale": "CDHAT",
-    "departements": ["14"],
-    "roles": ["operateur"],
-    "email": "cdhat@mailinator.com"
-  },
-  {
-    "raison_sociale": "SOLIHA-14",
-    "departements": ["14"],
-    "roles": ["operateur"],
-    "email": "soliha14@mailinator.com"
-  },
-  {
-    "raison_sociale": "Direction Départementale des territoires et de la Mer du Calvados",
-    "roles": ["pris", "instructeur"],
-    "departements": ["14"],
-    "email": "ddt14@mailinator.com"
-  },
-  {
-    "raison_sociale": "Direction Départementale des Territoires des Yvelines",
-    "roles": ["pris", "instructeur"],
-    "departements": ["78"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "adresse_postale": "35 rue Noailles, 78000 Versailles",
-    "email": "adil_sarcelles_95@mailinator.com"
-  },
-  {
-    "raison_sociale": "Soliha 78",
-    "roles": ["operateur"],
-    "departements": ["78"],
-    "themes": ["autonomie", "insalubrité", "énergie"],
-    "email": "soliha78@mailinator.com"
+    "email": "adil_75@mailinator.com",
+    "roles": ["pris"]
   }
 ]

--- a/spec/features/1_demarrage/etape2_preciser_le_projet_spec.rb
+++ b/spec/features/1_demarrage/etape2_preciser_le_projet_spec.rb
@@ -3,63 +3,65 @@ require 'support/mpal_features_helper'
 require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
-feature "En tant que demandeur, je peux préciser mes besoins pour ma demande de travaux" do
+feature "Préciser le projet :" do
   let(:projet) { Projet.last }
 
-  scenario "je décris précisément mes besoins" do
-    signin_for_new_projet
-    visit etape2_description_projet_path(projet)
-    expect(page).to have_content(I18n.t('demarrage_projet.etape2_description_projet.section_projet_envisage'))
-    # Liste des besoins
-    check('demande_froid')
-    check('demande_changement_chauffage')
-    uncheck('demande_probleme_deplacement')
-    check('demande_accessibilite')
-    check('demande_hospitalisation')
-    check('demande_adaptation_salle_de_bain')
-    choose('demande_ptz_true')
-    choose('demande_date_achevement_15_ans_true')
-    fill_in :demande_complement, with: "J'ai besoin d'un jacuzzi"
-    fill_in :demande_autre, with: "Mes fenêtres ferment mal"
-    fill_in :demande_annee_construction, with: "1930"
-    # Liste des travaux
-    uncheck('demande_travaux_isolation')
-    check('demande_travaux_fenetres')
-    check('demande_travaux_chauffage')
-    uncheck('demande_travaux_adaptation_sdb')
-    check('demande_travaux_monte_escalier')
-    check('demande_travaux_amenagement_ext')
-    fill_in :demande_travaux_autres, with: "Aménager une chambre au RDC"
+  context "en tant que demandeur" do
+    scenario "je peux décrire mes besoins pour ma demande de travaux" do
+      signin_for_new_projet
+      visit etape2_description_projet_path(projet)
+      expect(page).to have_content(I18n.t('demarrage_projet.etape2_description_projet.section_projet_envisage'))
+      # Liste des besoins
+      check('demande_froid')
+      check('demande_changement_chauffage')
+      uncheck('demande_probleme_deplacement')
+      check('demande_accessibilite')
+      check('demande_hospitalisation')
+      check('demande_adaptation_salle_de_bain')
+      choose('demande_ptz_true')
+      choose('demande_date_achevement_15_ans_true')
+      fill_in :demande_complement, with: "J'ai besoin d'un jacuzzi"
+      fill_in :demande_autre, with: "Mes fenêtres ferment mal"
+      fill_in :demande_annee_construction, with: "1930"
+      # Liste des travaux
+      uncheck('demande_travaux_isolation')
+      check('demande_travaux_fenetres')
+      check('demande_travaux_chauffage')
+      uncheck('demande_travaux_adaptation_sdb')
+      check('demande_travaux_monte_escalier')
+      check('demande_travaux_amenagement_ext')
+      fill_in :demande_travaux_autres, with: "Aménager une chambre au RDC"
 
-    click_button I18n.t('demarrage_projet.action')
-    expect(page.current_path).to eq(etape3_mise_en_relation_path(projet))
+      click_button I18n.t('demarrage_projet.action')
+      expect(page.current_path).to eq(etape3_mise_en_relation_path(projet))
 
-    projet.reload
-    expect(projet.demande.froid).to be_truthy
-    expect(projet.demande.changement_chauffage).to be_truthy
-    expect(projet.demande.date_achevement_15_ans).to be_truthy
-    expect(projet.demande.probleme_deplacement).not_to be_truthy
-    expect(projet.demande.complement).to eq("J'ai besoin d'un jacuzzi")
-    expect(projet.demande.autre).to eq("Mes fenêtres ferment mal")
-    expect(projet.demande.changement_chauffage).to be_truthy
-    expect(projet.demande.adaptation_salle_de_bain).to be_truthy
-    expect(projet.demande.accessibilite).to be_truthy
-    expect(projet.demande.ptz).to be_truthy
-    expect(projet.demande.annee_construction).to eq("1930")
-    expect(projet.demande.travaux_isolation).not_to be_truthy
-    expect(projet.demande.travaux_adaptation_sdb).not_to be_truthy
-    expect(projet.demande.travaux_amenagement_ext).to be_truthy
-    expect(projet.demande.travaux_monte_escalier).to be_truthy
-    expect(projet.demande.travaux_chauffage).to be_truthy
-    expect(projet.demande.travaux_fenetres).to be_truthy
-    expect(projet.demande.travaux_autres).to eq("Aménager une chambre au RDC")
-  end
+      projet.reload
+      expect(projet.demande.froid).to be_truthy
+      expect(projet.demande.changement_chauffage).to be_truthy
+      expect(projet.demande.date_achevement_15_ans).to be_truthy
+      expect(projet.demande.probleme_deplacement).not_to be_truthy
+      expect(projet.demande.complement).to eq("J'ai besoin d'un jacuzzi")
+      expect(projet.demande.autre).to eq("Mes fenêtres ferment mal")
+      expect(projet.demande.changement_chauffage).to be_truthy
+      expect(projet.demande.adaptation_salle_de_bain).to be_truthy
+      expect(projet.demande.accessibilite).to be_truthy
+      expect(projet.demande.ptz).to be_truthy
+      expect(projet.demande.annee_construction).to eq("1930")
+      expect(projet.demande.travaux_isolation).not_to be_truthy
+      expect(projet.demande.travaux_adaptation_sdb).not_to be_truthy
+      expect(projet.demande.travaux_amenagement_ext).to be_truthy
+      expect(projet.demande.travaux_monte_escalier).to be_truthy
+      expect(projet.demande.travaux_chauffage).to be_truthy
+      expect(projet.demande.travaux_fenetres).to be_truthy
+      expect(projet.demande.travaux_autres).to eq("Aménager une chambre au RDC")
+    end
 
-  scenario "je ne décris aucun besoin à l'étape 2 et je ne peux pas passer à l'étape suivante" do
-    signin_for_new_projet
-    visit etape2_description_projet_path(projet)
-    click_button I18n.t('demarrage_projet.action')
-    expect(page.current_path).to eq(etape2_description_projet_path(projet))
-    expect(page).to have_content(I18n.t("demarrage_projet.etape2_description_projet.erreurs.besoin_obligatoire"))
+    scenario "je ne peux pas passer à l'étape suivante tant que je n'ai pas rempli au moins un besoin" do
+      signin_for_new_projet
+      visit etape2_description_projet_path(projet)
+      click_button I18n.t('demarrage_projet.action')
+      expect(page.current_path).to eq(etape2_description_projet_path(projet))
+      expect(page).to have_content(I18n.t("demarrage_projet.etape2_description_projet.erreurs.besoin_obligatoire"))
+    end
   end
 end


### PR DESCRIPTION
Les identifiants de démo correspondent aux comptes sur l'Opal d'intégration. Les intervenants correspondants ont été importé sur les environnements de `staging` et `demo`.

<img width="967" alt="capture d ecran 2017-03-08 a 11 16 50" src="https://cloud.githubusercontent.com/assets/179923/23701099/8d691724-03f5-11e7-96f7-0ea840e223c4.png">

TODO :

- [x] Rajouter ces intervenants aux seeds, pour y avoir accès en local