### PR TITLE
PF305 prise en compte de l'adresse à rénover

### DIFF
--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -40,8 +40,8 @@ module ProjetConcern
 
     def show
       gon.push({
-        latitude: @projet_courant.latitude,
-        longitude: @projet_courant.longitude
+        latitude:  @projet_courant.adresse.try(:latitude),
+        longitude: @projet_courant.adresse.try(:longitude)
       })
       @intervenants_disponibles = @projet_courant.intervenants_disponibles(role: :operateur).shuffle
       @commentaire = Commentaire.new(projet: @projet_courant)
@@ -65,11 +65,6 @@ module ProjetConcern
     end
 
     def projet_params
-      adresse = params[:projet][:adresse]
-      if adresse
-        service_adresse = ApiBan.new
-        adresse_complete = service_adresse.precise(adresse)
-      end
       attributs = params.require(:projet)
       .permit(:disponibilite, :description, :email, :tel, :annee_construction, :nb_occupants_a_charge,
               :type_logement, :etage, :nb_pieces, :surface_habitable, :etiquette_avant_travaux,
@@ -89,7 +84,6 @@ module ProjetConcern
           projet_aide[:_destroy] = true if projet_aide[:montant].blank?
         end
       end
-      attributs = attributs.merge(adresse_complete) if adresse_complete
       attributs
     end
 

--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -40,6 +40,9 @@ class DemarrageProjetController < ApplicationController
   def etape3_mise_en_relation
     @demande = projet_demande
     @pris_departement = @projet_courant.intervenants_disponibles(role: :pris).first
+    if @pris_departement.blank?
+      raise "Il n’y a pas de PRIS disponible pour le département #{@projet_courant.departement}"
+    end
     @action_label = if needs_etape3? then action_label_create else action_label_update end
   end
 

--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -119,13 +119,13 @@ private
   end
 
   def etape1_save
-    if params[:projet][:adresse].blank?
+    if params[:projet][:adresse_postale].blank?
       flash[:alert] = t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_vide')
       return false
     end
 
-    if params[:projet][:adresse] != @projet_courant.adresse
-      adresse_found = ProjetInitializer.new.precise_adresse(@projet_courant, params[:projet][:adresse])
+    if params[:projet][:adresse_postale] != @projet_courant.adresse_postale.try(:description)
+      adresse_found = ProjetInitializer.new.precise_adresse_postale(@projet_courant, params[:projet][:adresse_postale])
       if !adresse_found
         flash[:alert] = t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_inconnue')
         return false

--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -119,17 +119,21 @@ private
   end
 
   def etape1_save
-    if params[:projet][:adresse_postale].blank?
-      flash[:alert] = t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_vide')
-      return false
-    end
+    begin
+      @projet_courant.adresse_postale = ProjetInitializer.new.precise_adresse(
+        params[:projet][:adresse_postale],
+        previous_value: @projet_courant.adresse_postale,
+        required: true
+      )
 
-    if params[:projet][:adresse_postale] != @projet_courant.adresse_postale.try(:description)
-      adresse_found = ProjetInitializer.new.precise_adresse_postale(@projet_courant, params[:projet][:adresse_postale])
-      if !adresse_found
-        flash[:alert] = t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_inconnue')
-        return false
-      end
+      @projet_courant.adresse_a_renover = ProjetInitializer.new.precise_adresse(
+        params[:projet][:adresse_a_renover],
+        previous_value: @projet_courant.adresse_a_renover,
+        required: false
+      )
+    rescue => e
+      flash[:alert] = e.message
+      return false
     end
 
     @projet_courant.assign_attributes(projet_contacts_params)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -230,7 +230,9 @@ module ApplicationHelper
   end
 
   def affiche_demande_souhaitee(demande)
-    html = content_tag(:h4, "Difficultés rencontrées dans le logement")
+    html = content_tag(:h4, "Adresse du logement")
+    html << content_tag(:p, demande.projet.adresse.description)
+    html << content_tag(:h4, "Difficultés rencontrées dans le logement")
     besoins = []
     besoins << t("demarrage_projet.etape2_description_projet.changement_chauffage") if demande.changement_chauffage
     besoins << t("demarrage_projet.etape2_description_projet.froid") if demande.froid

--- a/app/models/adresse.rb
+++ b/app/models/adresse.rb
@@ -1,0 +1,3 @@
+class Adresse < ActiveRecord::Base
+  validates :ligne_1, :code_postal, :code_insee, :ville, :departement, presence: true
+end

--- a/app/models/adresse.rb
+++ b/app/models/adresse.rb
@@ -1,3 +1,7 @@
 class Adresse < ActiveRecord::Base
   validates :ligne_1, :code_postal, :code_insee, :ville, :departement, presence: true
+
+  def description
+    "#{ligne_1}, #{code_postal} #{ville}"
+  end
 end

--- a/app/models/intervenant.rb
+++ b/app/models/intervenant.rb
@@ -36,6 +36,7 @@ class Intervenant < ActiveRecord::Base
   }
 
   alias_attribute :name, :raison_sociale
+  alias_attribute :description_adresse, :adresse_postale
 
   def self.instructeur_pour(projet)
     instructeur.pour_departement(projet.departement).limit(1).first

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -15,11 +15,11 @@ class Invitation < ActiveRecord::Base
   validates :projet, :intervenant, presence: true
   validates_uniqueness_of :intervenant, scope: :projet_id
 
-  delegate :demandeur_principal, to: :projet
-  delegate :demandeur_principal_prenom, to: :projet
-  delegate :demandeur_principal_nom, to: :projet
+  delegate :demandeur_principal,          to: :projet
+  delegate :demandeur_principal_prenom,   to: :projet
+  delegate :demandeur_principal_nom,      to: :projet
   delegate :demandeur_principal_civilite, to: :projet
-  delegate :adresse, to: :projet
+  delegate :description_adresse,          to: :projet
 
   def intervenant_email
     intervenant.email

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -7,6 +7,8 @@ class Projet < ActiveRecord::Base
   accepts_nested_attributes_for :personne_de_confiance
 
   has_one :demande, dependent: :destroy
+  belongs_to :adresse_postale, class_name: "Adresse", dependent: :destroy
+
   has_many :intervenants, through: :invitations
   has_many :invitations, dependent: :destroy
   belongs_to :operateur, class_name: 'Intervenant'
@@ -28,7 +30,7 @@ class Projet < ActiveRecord::Base
   has_and_belongs_to_many :suggested_operateurs, class_name: 'Intervenant', join_table: 'suggested_operateurs'
 
   validates :numero_fiscal, :reference_avis, presence: true
-  validates :adresse_ligne1, presence: true, on: :update
+  validates :adresse_postale, presence: true, on: :update
   validates_numericality_of :nb_occupants_a_charge, greater_than_or_equal_to: 0, allow_nil: true
 
   localized_numeric_setter :montant_travaux_ht
@@ -207,9 +209,11 @@ class Projet < ActiveRecord::Base
   end
 
   def adresse
-    if adresse_ligne1.present?
-      "#{adresse_ligne1}, #{code_postal} #{ville}"
-    end
+    adresse_postale
+  end
+
+  def departement
+    adresse.try(:departement)
   end
 
   def nom_occupants

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -7,7 +7,8 @@ class Projet < ActiveRecord::Base
   accepts_nested_attributes_for :personne_de_confiance
 
   has_one :demande, dependent: :destroy
-  belongs_to :adresse_postale, class_name: "Adresse", dependent: :destroy
+  belongs_to :adresse_postale,   class_name: "Adresse", dependent: :destroy
+  belongs_to :adresse_a_renover, class_name: "Adresse", dependent: :destroy
 
   has_many :intervenants, through: :invitations
   has_many :invitations, dependent: :destroy
@@ -209,7 +210,7 @@ class Projet < ActiveRecord::Base
   end
 
   def adresse
-    adresse_postale
+    adresse_a_renover || adresse_postale
   end
 
   def description_adresse

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -212,6 +212,10 @@ class Projet < ActiveRecord::Base
     adresse_postale
   end
 
+  def description_adresse
+    adresse.try(:description)
+  end
+
   def departement
     adresse.try(:departement)
   end

--- a/app/serializers/projet_serializer.rb
+++ b/app/serializers/projet_serializer.rb
@@ -4,7 +4,7 @@ class ProjetSerializer < ActiveModel::Serializer
   has_many :evenements
 
   def adresse
-    object.adresse.try(:description)
+    object.description_adresse
   end
 
   class OccupantSerializer < ActiveModel::Serializer

--- a/app/serializers/projet_serializer.rb
+++ b/app/serializers/projet_serializer.rb
@@ -3,6 +3,10 @@ class ProjetSerializer < ActiveModel::Serializer
   has_many :occupants
   has_many :evenements
 
+  def adresse
+    object.adresse.try(:description)
+  end
+
   class OccupantSerializer < ActiveModel::Serializer
     attributes :prenom, :nom, :demandeur
   end

--- a/app/services/api_ban.rb
+++ b/app/services/api_ban.rb
@@ -11,21 +11,21 @@ class ApiBan
     coords = json_adresse['features'][0]['geometry']['coordinates']
     longitude = coords[0]
     latitude = coords[1]
-    adresse_ligne1 = json_adresse['features'][0]['properties']['name']
-    code_insee = json_adresse['features'][0]['properties']['citycode']
+    ligne_1 = json_adresse['features'][0]['properties']['name']
     code_postal = json_adresse['features'][0]['properties']['postcode']
+    code_insee = json_adresse['features'][0]['properties']['citycode']
     ville = json_adresse['features'][0]['properties']['city']
     departement = code_postal[0,2]
 
-    {
-      latitude: latitude,
-      longitude: longitude,
-      departement: departement,
-      adresse_ligne1: adresse_ligne1,
-      code_insee: code_insee,
+    Adresse.new({
+      latitude:    latitude,
+      longitude:   longitude,
+      ligne_1:     ligne_1,
       code_postal: code_postal,
-      ville: ville
-    }
+      code_insee:  code_insee,
+      ville:       ville,
+      departement: departement
+    })
   end
 
   def self.uri(adresse)

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -42,9 +42,9 @@ class Opal
           "pphPrenom": projet.prenom_occupants,
           "adressePostale": {
             "payId": 1,
-            "adpLigne1": projet.adresse_ligne1,
-            "adpLocalite": projet.ville,
-            "adpCodePostal": projet.code_postal
+            "adpLigne1": projet.adresse.ligne_1,
+            "adpLocalite": projet.adresse.ville,
+            "adpCodePostal": projet.adresse.code_postal
           }
         }
       },
@@ -57,16 +57,16 @@ class Opal
         "immSiDejaSubventionne": false,
         "immSiProcedureInsalubrite": false,
         "adresseGeographique": {
-          "adgLigne1": projet.adresse_ligne1,
-          "cdpCodePostal": projet.code_postal,
-          "comCodeInsee": recupere_com_code_insee(projet),
-          "dptNumero": projet.departement
+          "adgLigne1": projet.adresse.ligne_1,
+          "cdpCodePostal": projet.adresse.code_postal,
+          "comCodeInsee": code_insee_suffix(projet.adresse.code_insee),
+          "dptNumero": projet.adresse.departement
         }
       }
     }
   end
 
-  def recupere_com_code_insee(projet)
-    projet.code_insee[2, projet.code_insee.length]
+  def code_insee_suffix(code_insee)
+    code_insee[2, code_insee.length]
   end
 end

--- a/app/services/projet_initializer.rb
+++ b/app/services/projet_initializer.rb
@@ -14,7 +14,7 @@ class ProjetInitializer
 
     projet.nb_occupants_a_charge = contribuable.nombre_personnes_charge
 
-    precise_adresse(projet, contribuable.adresse)
+    precise_adresse_postale(projet, contribuable.adresse)
 
     contribuable.declarants.each do |declarant|
       projet.occupants.build(
@@ -34,17 +34,11 @@ class ProjetInitializer
     projet
   end
 
-  def precise_adresse(projet, adresse)
-    adresse = @service_adresse.precise(adresse)
-    if adresse.present?
-      projet.longitude = adresse[:longitude]
-      projet.latitude = adresse[:latitude]
-      projet.departement = adresse[:departement]
-      projet.adresse_ligne1 = adresse[:adresse_ligne1]
-      projet.code_insee = adresse[:code_insee]
-      projet.code_postal = adresse[:code_postal]
-      projet.ville = adresse[:ville]
+  def precise_adresse_postale(projet, adresse)
+    adresse_localisee = @service_adresse.precise(adresse)
+    if adresse_localisee.present?
+      projet.adresse_postale = adresse_localisee
     end
-    adresse
+    adresse_localisee
   end
 end

--- a/app/views/choix_operateur/new.html.slim
+++ b/app/views/choix_operateur/new.html.slim
@@ -24,7 +24,7 @@
               = radio_button_tag :operateur_id, operateur.id, operateur.id == @operateur.try(:id)
               label for="operateur_id_#{operateur.id}"
                 h3= operateur.raison_sociale
-                p= operateur.adresse_postale
+                p= operateur.description_adresse
                 = btn tag: :div, name: t('projets.visualisation.invitation_intervenant')
         - else
           p.chapo
@@ -38,7 +38,7 @@
                 = radio_button_tag :operateur_id, operateur.id, operateur.id == @operateur.try(:id)
                 label for="operateur_id_#{operateur.id}"
                   h3= operateur.raison_sociale
-                  p= operateur.adresse_postale
+                  p= operateur.description_adresse
                   = btn tag: :a, name: t('projets.visualisation.invitation_intervenant')
           hr/
         = render 'demarrage_projet/etape3_disponibilite_form'

--- a/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
+++ b/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
@@ -19,8 +19,8 @@
         = f.label :demandeur_principal_nom
         = f.text_field :demandeur_principal_nom, disabled: true, class: 'disabled'
       li.full
-        = f.label :adresse
-        = f.text_field :adresse
+        = f.label :adresse_postale
+        = text_field_tag "projet[adresse_postale]", @projet_courant.adresse_postale.try(:description)
       li.full
         label for="dem-address-diff"  Adresse du logement à rénover si différente :
         input#dem-address-diff type="text" /

--- a/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
+++ b/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
@@ -22,8 +22,8 @@
         = f.label :adresse_postale
         = text_field_tag "projet[adresse_postale]", @projet_courant.adresse_postale.try(:description)
       li.full
-        label for="dem-address-diff"  Adresse du logement à rénover si différente :
-        input#dem-address-diff type="text" /
+        = f.label :adresse_a_renover, "Adresse du logement à rénover si différente"
+        = text_field_tag "projet[adresse_a_renover]", @projet_courant.adresse_a_renover.try(:description)
       li
         = f.label :tel
         = f.telephone_field :tel

--- a/app/views/dossiers/_projet_envisage.html.slim
+++ b/app/views/dossiers/_projet_envisage.html.slim
@@ -13,7 +13,7 @@ article.block.projet
       - if operateur.present?
         .description-operateur
           strong= operateur.raison_sociale
-          p= operateur.adresse_postale
+          p= operateur.description_adresse
         - unless current_agent
           br
           br

--- a/app/views/dossiers/index.html.slim
+++ b/app/views/dossiers/index.html.slim
@@ -30,7 +30,7 @@
                 span.lastname<= projet.demandeur_principal.nom
             td
             td= projet.departement
-            td= projet.ville
+            td= projet.adresse.try(:ville)
             td
               = projet.invited_instructeur.raison_sociale rescue ''
               - if projet.agent_instructeur

--- a/app/views/layouts/logged_in.html.slim
+++ b/app/views/layouts/logged_in.html.slim
@@ -16,8 +16,8 @@
               li= @projet_courant.tel
             - if @projet_courant.email.present?
               li= @projet_courant.email
-            - if @projet_courant.ville.present?
-              li= @projet_courant.ville
+            - if @projet_courant.adresse.present?
+              li= @projet_courant.adresse.ville
             li= t('projets.visualisation.occupants', count: @projet_courant.nb_total_occupants)
             - if current_agent
               li= "Revenus dits #{calcul_preeligibilite(annee_fiscale_reference).pluralize}"

--- a/app/views/projet_mailer/invitation_intervenant.html.slim
+++ b/app/views/projet_mailer/invitation_intervenant.html.slim
@@ -1,5 +1,5 @@
 p Bonjour,
-p= "#{@invitation.demandeur_principal.fullname} souhaite effectuer des travaux dans son logement (#{@invitation.adresse.description})"
+p= "#{@invitation.demandeur_principal.fullname} souhaite effectuer des travaux dans son logement (#{@invitation.description_adresse})"
 p Voici une description des travaux qu’il souhaite effectuer :
 br
 p= affiche_demande_souhaitee(@invitation.projet.demande)

--- a/app/views/projet_mailer/invitation_intervenant.html.slim
+++ b/app/views/projet_mailer/invitation_intervenant.html.slim
@@ -1,5 +1,5 @@
 p Bonjour,
-p= "#{@invitation.demandeur_principal.fullname} souhaite effectuer des travaux dans son logement (#{@invitation.adresse})"
+p= "#{@invitation.demandeur_principal.fullname} souhaite effectuer des travaux dans son logement (#{@invitation.adresse.description})"
 p Voici une description des travaux qu’il souhaite effectuer :
 br
 p= affiche_demande_souhaitee(@invitation.projet.demande)

--- a/app/views/projet_mailer/mise_en_relation_intervenant.html.slim
+++ b/app/views/projet_mailer/mise_en_relation_intervenant.html.slim
@@ -1,6 +1,6 @@
 p Bonjour,
 p= "#{@invitation.intermediaire.raison_sociale} vient de vous mettre en relation avec le projet suivant :"
-p= "#{@invitation.demandeur_principal.fullname} souhaite rénover son habitat #{@invitation.adresse.description}"
+p= "#{@invitation.demandeur_principal.fullname} souhaite rénover son habitat #{@invitation.description_adresse}"
 p Voici une description des travaux qu’il souhaite effectuer :
 p= affiche_demande_souhaitee(@invitation.projet.demande)
 p= link_to "Pour visualiser le projet, cliquer sur ce lien", dossier_url(@invitation.projet)

--- a/app/views/projet_mailer/mise_en_relation_intervenant.html.slim
+++ b/app/views/projet_mailer/mise_en_relation_intervenant.html.slim
@@ -1,6 +1,6 @@
 p Bonjour,
 p= "#{@invitation.intermediaire.raison_sociale} vient de vous mettre en relation avec le projet suivant :"
-p= "#{@invitation.demandeur_principal.fullname} souhaite rénover son habitat #{@invitation.adresse}"
+p= "#{@invitation.demandeur_principal.fullname} souhaite rénover son habitat #{@invitation.adresse.description}"
 p Voici une description des travaux qu’il souhaite effectuer :
 p= affiche_demande_souhaitee(@invitation.projet.demande)
 p= link_to "Pour visualiser le projet, cliquer sur ce lien", dossier_url(@invitation.projet)

--- a/app/views/projets/_occupants.html.slim
+++ b/app/views/projets/_occupants.html.slim
@@ -16,9 +16,9 @@ article.block.occupants
       strong
         span.firstname= @projet_courant.demandeur_principal.prenom
         span.lastname<= @projet_courant.demandeur_principal.nom
-      - if @projet_courant.adresse.present?
+      - if @projet_courant.description_adresse.present?
         br/
-        = @projet_courant.adresse.description
+        = @projet_courant.description_adresse
       - if @projet_courant.tel.present?
         br/
         = @projet_courant.tel

--- a/app/views/projets/_occupants.html.slim
+++ b/app/views/projets/_occupants.html.slim
@@ -18,7 +18,7 @@ article.block.occupants
         span.lastname<= @projet_courant.demandeur_principal.nom
       - if @projet_courant.adresse.present?
         br/
-        = @projet_courant.adresse
+        = @projet_courant.adresse.description
       - if @projet_courant.tel.present?
         br/
         = @projet_courant.tel

--- a/app/views/projets/_occupants.html.slim
+++ b/app/views/projets/_occupants.html.slim
@@ -16,9 +16,9 @@ article.block.occupants
       strong
         span.firstname= @projet_courant.demandeur_principal.prenom
         span.lastname<= @projet_courant.demandeur_principal.nom
-      - if @projet_courant.description_adresse.present?
+      - if @projet_courant.adresse_postale.present?
         br/
-        = @projet_courant.description_adresse
+        = @projet_courant.adresse_postale.description
       - if @projet_courant.tel.present?
         br/
         = @projet_courant.tel

--- a/app/views/projets/_projet_envisage.html.slim
+++ b/app/views/projets/_projet_envisage.html.slim
@@ -16,7 +16,7 @@ article.block.projet
       - if operateur.present?
         .description-operateur
           strong= operateur.raison_sociale
-          p= operateur.adresse_postale
+          p= operateur.description_adresse
         - unless current_agent
           br
           br

--- a/app/views/projets/_projet_invoice.html.slim
+++ b/app/views/projets/_projet_invoice.html.slim
@@ -6,7 +6,7 @@ ul.demandeur-info
   - if @projet_courant.tel.present?
     li= @projet_courant.tel
   - if @projet_courant.adresse.present?
-    li= @projet_courant.adresse
+    li= @projet_courant.adresse.description
 - if @projet_courant.operateur
   ul.operateur-info
     li

--- a/app/views/projets/_projet_invoice.html.slim
+++ b/app/views/projets/_projet_invoice.html.slim
@@ -5,12 +5,12 @@ ul.demandeur-info
       span.lastname<= @projet_courant.demandeur_principal.nom
   - if @projet_courant.tel.present?
     li= @projet_courant.tel
-  - if @projet_courant.adresse.present?
-    li= @projet_courant.adresse.description
+  - if @projet_courant.description_adresse.present?
+    li= @projet_courant.description_adresse
 - if @projet_courant.operateur
   ul.operateur-info
     li
       strong= @projet_courant.operateur.raison_sociale
-    li= @projet_courant.operateur.adresse_postale
+    li= @projet_courant.operateur.description_adresse
 /TODO p.delegataire Délégataire : ?
 = render 'projets/projet_details'

--- a/db/migrate/20170308155426_create_adresses.rb
+++ b/db/migrate/20170308155426_create_adresses.rb
@@ -1,0 +1,14 @@
+class CreateAdresses < ActiveRecord::Migration
+  def change
+    create_table :adresses do |t|
+      t.decimal :latitude,    null: true, precision: 10, scale: 6
+      t.decimal :longitude,   null: true, precision: 10, scale: 6
+      t.string  :ligne_1,     null: false
+      t.string  :code_insee,  null: false
+      t.string  :code_postal, null: false
+      t.string  :ville,       null: false
+      t.string  :departement, null: false, limit: 10
+      t.timestamps            null: false
+    end
+  end
+end

--- a/db/migrate/20170309093829_add_adresse_postale_to_projet.rb
+++ b/db/migrate/20170309093829_add_adresse_postale_to_projet.rb
@@ -1,0 +1,6 @@
+class AddAdressePostaleToProjet < ActiveRecord::Migration
+  def change
+    add_belongs_to :projets, :adresse_postale, index: true
+    add_foreign_key :projets, :adresses, column: :adresse_postale_id, dependent: :nullify
+  end
+end

--- a/db/migrate/20170309093830_copy_adresses_to_model.rb
+++ b/db/migrate/20170309093830_copy_adresses_to_model.rb
@@ -1,0 +1,29 @@
+class CopyAdressesToModel < ActiveRecord::Migration
+  def up
+    projets = Projet.where('adresse_ligne1 IS NOT NULL')
+    puts "Migrating addresses of #{projets.count} projects"
+
+    ActiveRecord::Base.transaction do
+      projets.find_each do |projet|
+        begin
+          projet.create_adresse_postale!({
+            latitude:    projet.latitude,
+            longitude:   projet.longitude,
+            ligne_1:     projet.adresse_ligne1,
+            code_postal: projet.code_postal,
+            code_insee:  projet.code_insee,
+            ville:       projet.ville,
+            departement: projet.departement
+          })
+          projet.save!
+          print "."
+        rescue => e
+          puts "Error while migrating projet #{projet.id}: #{e}"
+        end
+      end
+    end
+
+    puts ""
+    puts "All done"
+  end
+end

--- a/db/migrate/20170309134222_add_adresse_a_renover_to_projet.rb
+++ b/db/migrate/20170309134222_add_adresse_a_renover_to_projet.rb
@@ -1,0 +1,6 @@
+class AddAdresseARenoverToProjet < ActiveRecord::Migration
+  def change
+    add_belongs_to :projets, :adresse_a_renover, index: true
+    add_foreign_key :projets, :adresses, column: :adresse_a_renover_id, dependent: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170303151930) do
+ActiveRecord::Schema.define(version: 20170308155426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "adresses", force: :cascade do |t|
+    t.decimal  "latitude",               precision: 10, scale: 6
+    t.decimal  "longitude",              precision: 10, scale: 6
+    t.string   "ligne_1",                                         null: false
+    t.string   "code_insee",                                      null: false
+    t.string   "code_postal",                                     null: false
+    t.string   "ville",                                           null: false
+    t.string   "departement", limit: 10,                          null: false
+    t.datetime "created_at",                                      null: false
+    t.datetime "updated_at",                                      null: false
+  end
 
   create_table "agents", force: :cascade do |t|
     t.string   "username",                           null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170309093830) do
+ActiveRecord::Schema.define(version: 20170309134222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -297,8 +297,10 @@ ActiveRecord::Schema.define(version: 20170309093830) do
     t.integer  "agent_operateur_id"
     t.integer  "agent_instructeur_id"
     t.integer  "adresse_postale_id"
+    t.integer  "adresse_a_renover_id"
   end
 
+  add_index "projets", ["adresse_a_renover_id"], name: "index_projets_on_adresse_a_renover_id", using: :btree
   add_index "projets", ["adresse_postale_id"], name: "index_projets_on_adresse_postale_id", using: :btree
   add_index "projets", ["agent_instructeur_id"], name: "index_projets_on_agent_instructeur_id", using: :btree
   add_index "projets", ["agent_operateur_id"], name: "index_projets_on_agent_operateur_id", using: :btree
@@ -338,6 +340,7 @@ ActiveRecord::Schema.define(version: 20170309093830) do
   add_foreign_key "projet_aides", "projets"
   add_foreign_key "projet_prestations", "prestations"
   add_foreign_key "projet_prestations", "projets"
+  add_foreign_key "projets", "adresses", column: "adresse_a_renover_id"
   add_foreign_key "projets", "adresses", column: "adresse_postale_id"
   add_foreign_key "projets", "agents", column: "agent_instructeur_id"
   add_foreign_key "projets", "agents", column: "agent_operateur_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170308155426) do
+ActiveRecord::Schema.define(version: 20170309093830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -296,8 +296,10 @@ ActiveRecord::Schema.define(version: 20170308155426) do
     t.float    "reste_a_charge"
     t.integer  "agent_operateur_id"
     t.integer  "agent_instructeur_id"
+    t.integer  "adresse_postale_id"
   end
 
+  add_index "projets", ["adresse_postale_id"], name: "index_projets_on_adresse_postale_id", using: :btree
   add_index "projets", ["agent_instructeur_id"], name: "index_projets_on_agent_instructeur_id", using: :btree
   add_index "projets", ["agent_operateur_id"], name: "index_projets_on_agent_operateur_id", using: :btree
   add_index "projets", ["operateur_id"], name: "index_projets_on_operateur_id", using: :btree
@@ -336,6 +338,7 @@ ActiveRecord::Schema.define(version: 20170308155426) do
   add_foreign_key "projet_aides", "projets"
   add_foreign_key "projet_prestations", "prestations"
   add_foreign_key "projet_prestations", "projets"
+  add_foreign_key "projets", "adresses", column: "adresse_postale_id"
   add_foreign_key "projets", "agents", column: "agent_instructeur_id"
   add_foreign_key "projets", "agents", column: "agent_operateur_id"
   add_foreign_key "projets", "intervenants", column: "operateur_id"

--- a/spec/controllers/api/projets_controller_spec.rb
+++ b/spec/controllers/api/projets_controller_spec.rb
@@ -23,7 +23,7 @@ describe API::ProjetsController do
     it { expect(response.content_type).to eq(Mime::JSON) }
     it 'renvoie un json avec la bonne adresse' do
       projet_reponse = json(response.body)
-      expect(projet_reponse[:adresse]).to eq(projet.adresse)
+      expect(projet_reponse[:adresse]).to eq(projet.adresse.description)
     end
   end
 end

--- a/spec/controllers/demarrage_projet_controller_spec.rb
+++ b/spec/controllers/demarrage_projet_controller_spec.rb
@@ -12,7 +12,7 @@ describe DemarrageProjetController do
   describe "#etape1_recuperation_infos" do
     let(:projet_params) do {} end
     let(:params) do
-      default_params = { adresse: projet.adresse }
+      default_params = { adresse_postale: projet.adresse_postale.description }
       {
         projet_id: projet.id,
         projet:    default_params.merge(projet_params)
@@ -61,7 +61,7 @@ describe DemarrageProjetController do
     end
 
     context "lorsque l'adresse est vide" do
-      let(:projet_params) do { adresse: '' } end
+      let(:projet_params) do { adresse_postale: '' } end
 
       it "affiche une erreur" do
         expect(response).to render_template(:etape1_recuperation_infos)
@@ -70,33 +70,34 @@ describe DemarrageProjetController do
     end
 
     context "lorsque l'adresse est identique" do
-      let!(:adresse_initiale) { projet.adresse }
-      let(:projet_params) do { adresse: projet.adresse } end
+      let!(:adresse_initiale) { projet.adresse_postale }
+      let(:projet_params) do { adresse_postale: projet.adresse_postale.description } end
 
       it "conserve l'adresse existante" do
         expect_any_instance_of(ApiBan).not_to receive(:precise)
-        expect(projet.adresse).to eq adresse_initiale
+        expect(projet.adresse_postale).to eq adresse_initiale
       end
     end
 
     context "lorsque l'adresse change" do
       context "et est disponible dans la BAN" do
-        let(:projet_params) do { adresse: Fakeweb::ApiBan::ADDRESS_ROME } end
+        let(:projet_params) do { adresse_postale: Fakeweb::ApiBan::ADDRESS_ROME } end
 
-        it "enregistre l'adresse précisée", focus: true do
-          expect(projet.adresse_ligne1).to eq "65 rue de Rome"
-          expect(projet.code_insee).to     eq "75008"
-          expect(projet.code_postal).to    eq "75008"
-          expect(projet.ville).to          eq "Paris"
-          expect(projet.departement).to    eq "75"
-          expect(projet.latitude).to       be_within(0.1).of 57.9
-          expect(projet.longitude).to      be_within(0.1).of 5.8
-          expect(projet.adresse).to        eq Fakeweb::ApiBan::ADDRESS_ROME
+        it "enregistre l'adresse précisée" do
+          expect(projet.adresse_postale).to be_present
+          expect(projet.adresse_postale.ligne_1).to     eq "65 rue de Rome"
+          expect(projet.adresse_postale.code_insee).to  eq "75008"
+          expect(projet.adresse_postale.code_postal).to eq "75008"
+          expect(projet.adresse_postale.ville).to       eq "Paris"
+          expect(projet.adresse_postale.departement).to eq "75"
+          expect(projet.adresse_postale.latitude).to    be_within(0.1).of 57.9
+          expect(projet.adresse_postale.longitude).to   be_within(0.1).of 5.8
+          expect(projet.adresse_postale.description).to eq Fakeweb::ApiBan::ADDRESS_ROME
         end
       end
 
       context "et n'est pas disponible dans la BAN" do
-        let(:projet_params) do { adresse: Fakeweb::ApiBan::ADDRESS_UNKNOWN } end
+        let(:projet_params) do { adresse_postale: Fakeweb::ApiBan::ADDRESS_UNKNOWN } end
         it "affiche une erreur" do
           expect(response).to render_template(:etape1_recuperation_infos)
           expect(flash[:alert]).to eq I18n.t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_inconnue')

--- a/spec/controllers/demarrage_projet_controller_spec.rb
+++ b/spec/controllers/demarrage_projet_controller_spec.rb
@@ -60,7 +60,7 @@ describe DemarrageProjetController do
       end
     end
 
-    context "lorsque l'adresse est vide" do
+    context "lorsque l'adresse postale est vide" do
       let(:projet_params) do { adresse_postale: '' } end
 
       it "affiche une erreur" do
@@ -69,7 +69,7 @@ describe DemarrageProjetController do
       end
     end
 
-    context "lorsque l'adresse est identique" do
+    context "lorsque l'adresse postale n'a pas changée" do
       let!(:adresse_initiale) { projet.adresse_postale }
       let(:projet_params) do { adresse_postale: projet.adresse_postale.description } end
 
@@ -79,7 +79,7 @@ describe DemarrageProjetController do
       end
     end
 
-    context "lorsque l'adresse change" do
+    context "lorsque l'adresse postale est mise à jour" do
       context "et est disponible dans la BAN" do
         let(:projet_params) do { adresse_postale: Fakeweb::ApiBan::ADDRESS_ROME } end
 
@@ -102,6 +102,39 @@ describe DemarrageProjetController do
           expect(response).to render_template(:etape1_recuperation_infos)
           expect(flash[:alert]).to eq I18n.t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_inconnue')
         end
+      end
+    end
+
+    context "lorsque l'adresse à rénover est renseignée" do
+      let(:projet_params) do
+        {
+          adresse_postale:   Fakeweb::ApiBan::ADDRESS_MARE,
+          adresse_a_renover: Fakeweb::ApiBan::ADDRESS_ROME
+        }
+      end
+      it "enregistre l'adresse à rénover" do
+        expect(projet.adresse_a_renover).to be_present
+        expect(projet.adresse_a_renover.ligne_1).to     eq "65 rue de Rome"
+        expect(projet.adresse_a_renover.code_insee).to  eq "75008"
+        expect(projet.adresse_a_renover.code_postal).to eq "75008"
+        expect(projet.adresse_a_renover.ville).to       eq "Paris"
+        expect(projet.adresse_a_renover.departement).to eq "75"
+        expect(projet.adresse_a_renover.latitude).to    be_within(0.1).of 57.9
+        expect(projet.adresse_a_renover.longitude).to   be_within(0.1).of 5.8
+        expect(projet.adresse_a_renover.description).to eq Fakeweb::ApiBan::ADDRESS_ROME
+      end
+    end
+
+    context "lorsque l'adresse à rénover est supprimée" do
+      let(:projet) { create :projet, :prospect, adresse_a_renover: create(:adresse) }
+      let(:projet_params) do
+        {
+          adresse_postale:   Fakeweb::ApiBan::ADDRESS_MARE,
+          adresse_a_renover: nil
+        }
+      end
+      it "supprime l'adresse à rénover" do
+        expect(projet.adresse_a_renover).to be_nil
       end
     end
   end

--- a/spec/factories/adresses.rb
+++ b/spec/factories/adresses.rb
@@ -5,5 +5,21 @@ FactoryGirl.define do
     code_postal '75010'
     ville       'Paris'
     departement '75'
+
+    trait :rue_de_la_mare do
+      ligne_1     '12 rue de la Mare'
+      code_insee  '75010'
+      code_postal '75010'
+      ville       'Paris'
+      departement '75'
+    end
+
+    trait :rue_de_rome do
+      ligne_1     '65 rue de Rome'
+      code_insee  '75008'
+      code_postal '75008'
+      ville       'Paris'
+      departement '75'
+    end
   end
 end

--- a/spec/factories/adresses.rb
+++ b/spec/factories/adresses.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :adresse do
+    ligne_1     '12 rue de la Mare'
+    code_insee  '75010'
+    code_postal '75010'
+    ville       'Paris'
+    departement '75'
+  end
+end

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :invitation do
-    association :projet, departement: '95'
+    association :projet
     association :intervenant, departements: [ '95' ], roles: [ :operateur ]
   end
   factory :mise_en_relation, parent: :invitation do

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -2,13 +2,10 @@ FactoryGirl.define do
   factory :projet do
     numero_fiscal 12
     reference_avis 15
-    adresse_ligne1 '12 rue de la Mare'
-    departement '75'
-    code_insee '75010'
-    code_postal '75010'
     email 'prenom.nom@site.com'
     nb_occupants_a_charge 0
     plateforme_id 1234
+    association :adresse_postale, factory: :adresse
 
     after(:create) do |projet, evaluator|
       create_list(:demandeur, 1, projet: projet)

--- a/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
+++ b/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
@@ -15,7 +15,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     expect(projet.demandeur_principal_prenom).to eq("Pierre")
     expect(page).to have_content(I18n.t('demarrage_projet.etape1_demarrage_projet.section_demandeur'))
     expect(page).to have_content(I18n.t('demarrage_projet.etape1_demarrage_projet.section_occupants'))
-    expect(find_field('projet_adresse').value).to eq('12 rue de la Mare, 75010 Paris')
+    expect(find_field('projet_adresse_postale').value).to eq('12 rue de la Mare, 75010 Paris')
     expect(page).to have_content(I18n.t('projets.messages.creation.corps'))
     expect(page).to have_content(I18n.t('projets.messages.creation.titre', demandeur_principal: projet.demandeur_principal.fullname))
   end
@@ -42,7 +42,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "je dois rentrer une adresse" do
     signin_for_new_projet
-    fill_in :projet_adresse, with: nil
+    fill_in :projet_adresse_postale, with: nil
     click_button I18n.t('demarrage_projet.action')
     expect(page).to have_current_path(etape1_recuperation_infos_path(projet))
     expect(page).to have_content(I18n.t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_vide'))
@@ -50,14 +50,14 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "je peux modifier mon adresse" do
     signin_for_new_projet
-    fill_in :projet_adresse, with: Fakeweb::ApiBan::ADDRESS_ROME
+    fill_in :projet_adresse_postale, with: Fakeweb::ApiBan::ADDRESS_ROME
     click_button I18n.t('demarrage_projet.action')
 
     projet.reload
     expect(page).to have_current_path etape2_description_projet_path(projet)
-    expect(projet.adresse_ligne1).to eq("65 rue de Rome")
-    expect(projet.code_postal).to eq("75008")
-    expect(projet.ville).to eq("Paris")
+    expect(projet.adresse_postale.ligne_1).to eq("65 rue de Rome")
+    expect(projet.adresse.code_postal).to eq("75008")
+    expect(projet.adresse_postale.ville).to eq("Paris")
   end
 
   scenario "j'ajoute une personne de confiance" do

--- a/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
+++ b/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
@@ -48,16 +48,16 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     expect(page).to have_content(I18n.t('demarrage_projet.etape1_demarrage_projet.erreurs.adresse_vide'))
   end
 
-  scenario "je peux modifier mon adresse" do
+  scenario "je peux ajouter l'adresse du logement à rénover" do
     signin_for_new_projet
-    fill_in :projet_adresse_postale, with: Fakeweb::ApiBan::ADDRESS_ROME
+    fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_ROME
     click_button I18n.t('demarrage_projet.action')
 
     projet.reload
     expect(page).to have_current_path etape2_description_projet_path(projet)
-    expect(projet.adresse_postale.ligne_1).to eq("65 rue de Rome")
-    expect(projet.adresse.code_postal).to eq("75008")
-    expect(projet.adresse_postale.ville).to eq("Paris")
+    expect(projet.adresse_a_renover.ligne_1).to eq("65 rue de Rome")
+    expect(projet.adresse_a_renover.code_postal).to eq("75008")
+    expect(projet.adresse_a_renover.ville).to eq("Paris")
   end
 
   scenario "j'ajoute une personne de confiance" do

--- a/spec/features/2_choix_operateur/changer_projet_spec.rb
+++ b/spec/features/2_choix_operateur/changer_projet_spec.rb
@@ -17,13 +17,20 @@ feature "En tant que demandeur, j'ai accès aux données concernant mon projet" 
     within 'article.occupants' do
       click_link I18n.t('projets.visualisation.lien_edition')
     end
+
     expect(find('#demandeur_principal_civilite_mr')).to be_checked
-    fill_in :projet_adresse_postale, with: Fakeweb::ApiBan::ADDRESS_ROME
+    expect(page).to have_field('Adresse postale', with: '12 rue de la Mare, 75010 Paris')
+
+    fill_in :projet_adresse_postale,   with: Fakeweb::ApiBan::ADDRESS_ROME
+    fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_MARE
     fill_in :projet_tel, with: '01 10 20 30 40'
+
     click_button I18n.t('projets.edition.action')
+
     expect(page).to have_content('01 10 20 30 40')
     expect(page).to have_current_path projet_path(projet)
     expect(page).to have_content Fakeweb::ApiBan::ADDRESS_ROME
+    expect(page).to have_content Fakeweb::ApiBan::ADDRESS_MARE
   end
 
   scenario "je peux modifier les données concernant mon habitation et mon projet" do

--- a/spec/features/2_choix_operateur/changer_projet_spec.rb
+++ b/spec/features/2_choix_operateur/changer_projet_spec.rb
@@ -18,7 +18,7 @@ feature "En tant que demandeur, j'ai accès aux données concernant mon projet" 
       click_link I18n.t('projets.visualisation.lien_edition')
     end
     expect(find('#demandeur_principal_civilite_mr')).to be_checked
-    fill_in :projet_adresse, with: Fakeweb::ApiBan::ADDRESS_ROME
+    fill_in :projet_adresse_postale, with: Fakeweb::ApiBan::ADDRESS_ROME
     fill_in :projet_tel, with: '01 10 20 30 40'
     click_button I18n.t('projets.edition.action')
     expect(page).to have_content('01 10 20 30 40')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -26,7 +26,7 @@ describe ApplicationHelper do
   context "avec une demande existante" do
     let(:demande) { FactoryGirl.build(:demande) }
     it "une demande souhaitée contient un titre" do
-      expect(helper.affiche_demande_souhaitee(demande)).to start_with("<h4>Difficultés rencontrées dans le logement</h4>")
+      expect(helper.affiche_demande_souhaitee(demande)).to include("<h4>Difficultés rencontrées dans le logement</h4>")
     end
 
     it "une demande souhaitée contient les besoins" do

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -18,7 +18,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.to).to eq([invitation.intervenant_email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur_principal: invitation.demandeur_principal.fullname)) }
     it { expect(email.body.encoded).to match(invitation.demandeur_principal.fullname) }
-    it { expect(email.body.encoded).to match(invitation.adresse) }
+    it { expect(email.body.encoded).to match(invitation.adresse.description) }
     it { expect(email.body.encoded).to include("Difficultés rencontrées dans le logement") }
     it { expect(email.body.encoded).to include(dossier_url(invitation.projet)) }
   end
@@ -29,6 +29,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([mise_en_relation.intervenant_email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: mise_en_relation.intermediaire.raison_sociale)) }
+    it { expect(email.body.encoded).to match(mise_en_relation.adresse.description) }
   end
 
   describe "l'opérateur reçoit un email lorsque le demandeur choisit un autre opérateur" do

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -18,7 +18,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.to).to eq([invitation.intervenant_email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur_principal: invitation.demandeur_principal.fullname)) }
     it { expect(email.body.encoded).to match(invitation.demandeur_principal.fullname) }
-    it { expect(email.body.encoded).to match(invitation.adresse.description) }
+    it { expect(email.body.encoded).to match(invitation.description_adresse) }
     it { expect(email.body.encoded).to include("Difficultés rencontrées dans le logement") }
     it { expect(email.body.encoded).to include(dossier_url(invitation.projet)) }
   end
@@ -29,7 +29,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([mise_en_relation.intervenant_email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: mise_en_relation.intermediaire.raison_sociale)) }
-    it { expect(email.body.encoded).to match(mise_en_relation.adresse.description) }
+    it { expect(email.body.encoded).to match(mise_en_relation.description_adresse) }
   end
 
   describe "l'opérateur reçoit un email lorsque le demandeur choisit un autre opérateur" do

--- a/spec/models/adresse_spec.rb
+++ b/spec/models/adresse_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe Adresse do
+  describe 'validations' do
+    let(:adresse) { build :adresse }
+    it { expect(adresse).to be_valid }
+    it { is_expected.to validate_presence_of :ligne_1 }
+    it { is_expected.to validate_presence_of :code_postal }
+    it { is_expected.to validate_presence_of :code_insee }
+    it { is_expected.to validate_presence_of :ville }
+    it { is_expected.to validate_presence_of :departement }
+  end
+end

--- a/spec/models/intervenant_spec.rb
+++ b/spec/models/intervenant_spec.rb
@@ -9,29 +9,51 @@ describe Intervenant do
   let!(:soliho) { FactoryGirl.create(:intervenant, raison_sociale: 'Soliho', departements: ['91', '77'], roles: [:operateur]) }
   let!(:ddt95) { FactoryGirl.create(:intervenant, raison_sociale: 'DDT95', departements: ['95'], roles: [:pris]) }
 
-  it "renvoie la liste des opérateurs des départements à partir d'une adresse" do
-    expect(Intervenant.pour_departement(91).pour_role(:operateur)).to contain_exactly(urbanos, soliho)
+  describe "#pour_departement" do
+    it "renvoie la liste des opérateurs des départements à partir d'une adresse" do
+      expect(Intervenant.pour_departement(91).pour_role(:operateur)).to contain_exactly(urbanos, soliho)
+    end
+
+    it "renvoie le PRIS à partir d'une adresse" do
+      expect(Intervenant.pour_departement(95).pour_role(:pris)).to include(ddt95)
+    end
   end
 
-  it "renvoie le PRIS à partir d'une adresse" do
-    expect(Intervenant.pour_departement(95).pour_role(:pris)).to include(ddt95)
+  describe "#operateur?" do
+    it "renvoie true si l'intervenant est un operateur" do
+      intervenant = FactoryGirl.create(:intervenant, roles: [:operateur])
+      expect(intervenant.operateur?).to be_truthy
+    end
+
+    it "renvoie false si l'intervenant n'est pas un operateur" do
+      intervenant = FactoryGirl.create(:intervenant, roles: [:pris])
+      expect(intervenant.operateur?).to be_falsy
+    end
   end
 
-  it "renvoie true si l'intervenant est un operateur" do
-    intervenant = FactoryGirl.create(:intervenant, roles: [:operateur])
-    expect(intervenant.operateur?).to be_truthy
+  describe "#instructeur_pour" do
+    let(:departement) { 23 }
+    let(:adresse) { build :adresse, departement: departement }
+    let(:projet) { create(:projet, adresse_postale: adresse) }
+
+    let!(:operateur23)   { create(:operateur,   departements: [projet.departement]) }
+    let!(:instructeur23) { create(:instructeur, departements: [projet.departement]) }
+    let!(:instructeur75) { create(:instructeur, departements: ["75"]) }
+
+    it "renvoie l'instructeur de ce projet" do
+      expect(Intervenant.instructeur_pour(projet)).to eq(instructeur23)
+    end
   end
 
-  it "renvoie false si l'intervenant n'est pas un operateur" do
-    intervenant = FactoryGirl.create(:intervenant, roles: [:pris])
-    expect(intervenant.operateur?).to be_falsy
-  end
-
-  it "renvoie l'instructeur de ce projet" do
-    projet = FactoryGirl.create(:projet, departement: 23)
-    FactoryGirl.create(:intervenant, roles: [:operateur], departements: [projet.departement])
-    instructeur = FactoryGirl.create(:intervenant, roles: [:instructeur], departements: [projet.departement])
-    FactoryGirl.create(:intervenant, roles: [:instructeur], departements: [75])
-    expect(Intervenant.instructeur_pour(projet)).to eq(instructeur)
+  describe "#description_adresse" do
+    subject { intervenant.description_adresse }
+    context "quand l'adresse est renseignée" do
+      let(:intervenant) { build :intervenant, adresse_postale: "31 avenue Jean Jaurès, 70000 Vesoul" }
+      it { is_expected.to eq "31 avenue Jean Jaurès, 70000 Vesoul" }
+    end
+    context "quand l'adresse est vide" do
+      let(:intervenant) { build :intervenant, adresse_postale: nil }
+      it { is_expected.to eq nil }
+    end
   end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -13,7 +13,7 @@ describe Invitation do
   it { is_expected.to be_valid }
 
   it { is_expected.to delegate_method(:demandeur_principal).to(:projet) }
-  it { is_expected.to delegate_method(:adresse).to(:projet) }
+  it { is_expected.to delegate_method(:description_adresse).to(:projet) }
 
   describe '#projet_email' do
     it "devrait retourner l'email du projet" do

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -138,6 +138,18 @@ describe Projet do
     end
   end
 
+  describe "#description_adresse" do
+    context "quand l'adresse est renseignée" do
+      let(:adresse) { build :adresse }
+      let(:projet)  { build :projet, adresse_postale: adresse }
+      it { expect(projet.description_adresse).to eq adresse.description }
+    end
+    context "quand l'adresse est vide" do
+      let(:projet) { build :projet, adresse_postale: nil }
+      it { expect(projet.description_adresse).to be nil }
+    end
+  end
+
   describe "#suggest_operateurs!" do
     let(:projet)     { create :projet, :with_suggested_operateurs }
     let(:operateurA) { create :operateur }

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -8,12 +8,14 @@ describe Projet do
     it { expect(projet).to be_valid }
     it { is_expected.to validate_presence_of :numero_fiscal }
     it { is_expected.to validate_presence_of :reference_avis }
-    it { is_expected.not_to validate_presence_of(:adresse_ligne1).on(:create) }
-    it { is_expected.to     validate_presence_of(:adresse_ligne1).on(:update) }
+    it { is_expected.not_to validate_presence_of(:adresse_postale).on(:create) }
+    it { is_expected.to validate_presence_of(:adresse_postale).on(:update) }
     it { is_expected.to validate_numericality_of(:nb_occupants_a_charge).is_greater_than_or_equal_to(0) }
+    it { is_expected.to have_one :demande }
     it { is_expected.to have_many :intervenants }
     it { is_expected.to have_many :evenements }
     it { is_expected.to belong_to :operateur }
+    it { is_expected.to belong_to :adresse_postale }
     it { is_expected.to have_and_belong_to_many :prestations }
     it { is_expected.to belong_to :agent_operateur }
     it { is_expected.to belong_to :agent_instructeur }
@@ -125,12 +127,13 @@ describe Projet do
   end
 
   describe "#adresse" do
-    context "avec une adresse" do
-      let(:projet) do build :projet, adresse_ligne1: "12 rue de la Mare", code_postal: "75 010", ville: "Paris" end
-      it { expect(projet.adresse).to eq("12 rue de la Mare, 75 010 Paris") }
+    context "avec une adresse postale" do
+      let(:adresse_postale) { build :adresse }
+      let(:projet) { build :projet, adresse_postale: adresse_postale }
+      it { expect(projet.adresse).to eq adresse_postale }
     end
-    context "sans adresse" do
-      let(:projet) do build :projet, adresse_ligne1: nil, code_postal: nil, ville: nil end
+    context "sans adresse postale" do
+      let(:projet) { build :projet, adresse_postale: nil }
       it { expect(projet.adresse).to be nil }
     end
   end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -127,14 +127,23 @@ describe Projet do
   end
 
   describe "#adresse" do
+    let(:projet) { build :projet, adresse_postale: adresse_postale, adresse_a_renover: adresse_a_renover }
+    context "sans adresse" do
+      let(:adresse_postale)   { nil }
+      let(:adresse_a_renover) { nil }
+      it { expect(projet.adresse).to be nil }
+    end
     context "avec une adresse postale" do
-      let(:adresse_postale) { build :adresse }
-      let(:projet) { build :projet, adresse_postale: adresse_postale }
+      let(:adresse_postale)   { build :adresse }
+      let(:adresse_a_renover) { nil }
       it { expect(projet.adresse).to eq adresse_postale }
     end
-    context "sans adresse postale" do
-      let(:projet) { build :projet, adresse_postale: nil }
-      it { expect(projet.adresse).to be nil }
+    context "avec une adresse postale et une adresse à rénover" do
+      let(:adresse_postale)   { build :adresse, :rue_de_la_mare }
+      let(:adresse_a_renover) { build :adresse, :rue_de_rome }
+      it "l'adresse utilisée est celle du logement à rénover" do
+        expect(projet.adresse).to eq adresse_a_renover
+      end
     end
   end
 
@@ -147,6 +156,15 @@ describe Projet do
     context "quand l'adresse est vide" do
       let(:projet) { build :projet, adresse_postale: nil }
       it { expect(projet.description_adresse).to be nil }
+    end
+  end
+
+  describe "#departement" do
+    let(:adresse_postale)   { build :adresse, :rue_de_la_mare }
+    let(:adresse_a_renover) { build :adresse, :rue_de_rome }
+    let(:projet) { build :projet, adresse_postale: adresse_postale, adresse_a_renover: adresse_a_renover }
+    it "renvoie le département du logement à rénover (ou de l'adresse postale le cas échéant" do
+      expect(projet.departement).to eq adresse_a_renover.departement
     end
   end
 

--- a/spec/services/projet_initializer_spec.rb
+++ b/spec/services/projet_initializer_spec.rb
@@ -29,28 +29,85 @@ class MonServiceAdresse
   end
 end
 
+class FailingServiceAdresse
+  def precise(adresse)
+    nil
+  end
+end
+
 describe ProjetInitializer do
-  it "renvoie un projet qui contient l'adresse" do
-    ligne_1 = "12 rue de la Mare"
-    code_postal = "75010"
-    ville = "Paris"
-    description_adresse = "#{ligne_1}, #{code_postal} #{ville}"
+  let(:service_contribuable) do
+    MonServiceContribuable.new(
+      adresse: "12 rue de la Mare, 75020 Paris",
+      declarants: [ {prenom: 'Jean', nom: 'Martin', date_de_naissance: '19/04/1980'}],
+      annee_impots: "2015",
+      nombre_personnes_charge: 3
+    )
+  end
+  let(:service_adresse) do
+    MonServiceAdresse.new(
+      latitude: "46",
+      longitude: "6",
+      ligne_1: "12 rue de la Mare",
+      code_postal: "75020",
+      code_insee: "75020",
+      ville: "Paris",
+      departement: "75"
+    )
+  end
+  let(:adresse) { "12 rue de la Mare, 75020 Paris" }
+  subject(:projet_initializer) do
+    ProjetInitializer.new(service_contribuable, service_adresse)
+  end
 
-    declarants = [ {prenom: 'Jean', nom: 'Martin', date_de_naissance: '19/04/1980'}]
-    annee_impots = "2015"
-    nombre_personnes_charge = 3
-    mon_service_contribuable = MonServiceContribuable.new(adresse: description_adresse, declarants: declarants, annee_impots: annee_impots, nombre_personnes_charge: nombre_personnes_charge)
-    mon_service_adresse = MonServiceAdresse.new(ligne_1: ligne_1, code_postal: code_postal, ville: ville, latitude: '46', longitude: '6', departement: '92')
-    projet_initializer = ProjetInitializer.new(mon_service_contribuable, mon_service_adresse)
+  describe "#initialize_projet" do
+    it "renvoie un projet avec les informations du contribuable" do
+      projet = projet_initializer.initialize_projet(15, 1515)
+      expect(projet).to be_valid
+      expect(projet.adresse.description).to eq(adresse)
+      expect(projet.numero_fiscal).to eq('15')
+      expect(projet.reference_avis).to eq('1515')
+      expect(projet.occupants.any?).to be_truthy
+      expect(projet.occupants.first).to be_demandeur
+      expect(projet.nb_occupants_a_charge).to eq(3)
+    end
+  end
 
-    projet = projet_initializer.initialize_projet(12, 15)
-    projet.save
+  describe "#precise_adresse" do
+    context "lorsque l'adresse est disponible" do
+      it "renvoie l'adresse localisée" do
+        adresse_localisee = subject.precise_adresse(adresse)
+        expect(adresse_localisee).to be_present
+        expect(adresse_localisee.ville).to eq "Paris"
+      end
+    end
 
-    expect(projet.adresse.description).to eq(description_adresse)
-    expect(projet.numero_fiscal).to eq('12')
-    expect(projet.reference_avis).to eq('15')
-    expect(projet.occupants.any?).to be_truthy
-    expect(projet.occupants.first).to be_demandeur
-    expect(projet.nb_occupants_a_charge).to eq(3)
+    context "lorsque l'adresse est indisponible" do
+      let(:service_adresse) { FailingServiceAdresse.new }
+      it { expect { subject.precise_adresse(adresse) }.to raise_error RuntimeError }
+    end
+
+    describe "previous_value" do
+      context "lorsque l'adresse est identique à la valeur précédente" do
+        let(:previous_value) { service_adresse.precise(adresse) }
+        it { expect(subject.precise_adresse(adresse, previous_value: previous_value)).to equal previous_value }
+      end
+      context "lorsque l'adresse est différente de la valeur précédente" do
+        let(:previous_value) { Adresse.new }
+        it { expect(subject.precise_adresse(adresse, previous_value: previous_value)).not_to equal previous_value }
+      end
+    end
+
+    describe "required" do
+      let(:adresse) { nil }
+      context "lorsque l'adresse est requise" do
+        let(:required) { true }
+        it { expect { subject.precise_adresse(adresse, required: required) }.to raise_error RuntimeError }
+      end
+      context "lorsque l'adresse n'est pas requise" do
+        let(:required) { false }
+        it { expect(subject.precise_adresse(adresse, required: required)).to be nil }
+      end
+    end
   end
 end

--- a/spec/services/projet_initializer_spec.rb
+++ b/spec/services/projet_initializer_spec.rb
@@ -19,34 +19,34 @@ class MonServiceAdresse
     @latitude = params[:latitude]
     @longitude = params[:longitude]
     @departement = params[:departement]
-    @adresse = params[:adresse_ligne1]
+    @ligne_1 = params[:ligne_1]
     @code_postal = params[:code_postal]
     @ville = params[:ville]
   end
 
   def precise(adresse)
-    { latitude: @latitude, longitude: @longitude, departement: @departement, adresse_ligne1: @adresse, code_postal: @code_postal, ville: @ville }
+    Adresse.new({ latitude: @latitude, longitude: @longitude, departement: @departement, ligne_1: @ligne_1, code_postal: @code_postal, ville: @ville })
   end
 end
 
 describe ProjetInitializer do
   it "renvoie un projet qui contient l'adresse" do
-    adresse_ligne1 = "12 rue de la Mare"
+    ligne_1 = "12 rue de la Mare"
     code_postal = "75010"
     ville = "Paris"
-    adresse = "#{adresse_ligne1}, #{code_postal} #{ville}"
+    description_adresse = "#{ligne_1}, #{code_postal} #{ville}"
 
     declarants = [ {prenom: 'Jean', nom: 'Martin', date_de_naissance: '19/04/1980'}]
     annee_impots = "2015"
     nombre_personnes_charge = 3
-    mon_service_contribuable = MonServiceContribuable.new(adresse: adresse, declarants: declarants, annee_impots: annee_impots, nombre_personnes_charge: nombre_personnes_charge)
-    mon_service_adresse = MonServiceAdresse.new(adresse_ligne1: adresse_ligne1, code_postal: code_postal, ville: ville, latitude: '46', longitude: '6', departement: '92')
+    mon_service_contribuable = MonServiceContribuable.new(adresse: description_adresse, declarants: declarants, annee_impots: annee_impots, nombre_personnes_charge: nombre_personnes_charge)
+    mon_service_adresse = MonServiceAdresse.new(ligne_1: ligne_1, code_postal: code_postal, ville: ville, latitude: '46', longitude: '6', departement: '92')
     projet_initializer = ProjetInitializer.new(mon_service_contribuable, mon_service_adresse)
 
     projet = projet_initializer.initialize_projet(12, 15)
     projet.save
 
-    expect(projet.adresse).to eq(adresse)
+    expect(projet.adresse.description).to eq(description_adresse)
     expect(projet.numero_fiscal).to eq('12')
     expect(projet.reference_avis).to eq('15')
     expect(projet.occupants.any?).to be_truthy

--- a/spec/support/mpal_features_helper.rb
+++ b/spec/support/mpal_features_helper.rb
@@ -2,7 +2,7 @@ require 'support/api_particulier_helper'
 
 def signin(numero_fiscal, reference_avis)
   visit new_session_path
-  fill_in :numero_fiscal, with: numero_fiscal
+  fill_in :numero_fiscal,  with: numero_fiscal
   fill_in :reference_avis, with: reference_avis
   find('.form-login .btn').click
 end


### PR DESCRIPTION
Story : https://anah-produits.atlassian.net/browse/PF-305

## État des lieux

En ce moment un projet contient deux adresses, qui sont stockées directement sur le projet.

1. L'**adresse postale du demandeur** :

```
Projet.latitude
Projet.longitude
Projet.adresse_ligne1
Projet.code_postal
Projet.code_insee
Projet.ville
Projet.departement
```

2. L'**adresse du logement à rénover** (pas utilisée pour l'instant) :

```
Projet.adresse_postale_ligne1
Projet.adresse_postale_code_postal
Projet.adresse_postale_ville
```

Comme on le voit, le modèle de données est un peu foireux : les colonnes sont interverties, et toutes les infos nécessaires ne sont pas disponibles.

## Proposition

Cette PR :

- Crée un modèle `Adresse`,
- Crée `Projet.adresse_postale` et `Projet.adresse_a_renover` (qui contiennent une `Adresse`),
- Ajoute une migration pour copier les adresses actuelles vers le nouveau modèle,
- Considère que l'adresse du projet est l'adresse à rénover si elle existe, et l'adresse postale sinon :

    ```ruby
    # projet_model.rb
    def adresse
      adresse_a_renover || adresse_postale
    end
    ```

Cela permet de grouper proprement les propriétés d'une adresse (plutôt que d'avoir un sac d'attributs mélangés avec les autres attributs du projet). Ça simplifie également le code de l'API-BAN, qui peut maintenant renvoyer un modèle `Adresse` (plutôt qu'un hash de propriétés).

## À faire dans une future PR
_(après la mise en production de celle-ci)_

- [ ] Écrire une migration pour supprimer les colonnes inutilisées de la table Projet