### PR TITLE
PF353 sauvegarde la personne de confiance

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -1,9 +1,11 @@
 $(document).ready(function() {
 
-    // show/hide different demandeur
-    $(".dem-diff").hide();
-    $(".dem-contact input:radio").change(function(){
-        if ($("#contact-diff").is(':checked')){
+    // show/hide personne de confiance
+    if (!$("#contact-diff").is(':checked')) {
+      $(".dem-diff").hide();
+    }
+    $(".dem-contact input:radio").change(function() {
+        if ($("#contact-diff").is(':checked')) {
             $(".dem-diff").slideDown("fast");
         } else {
             $(".dem-diff").slideUp("fast");

--- a/app/models/personne.rb
+++ b/app/models/personne.rb
@@ -1,3 +1,5 @@
 class Personne < ActiveRecord::Base
-  belongs_to :projet
+  has_one :projet
+
+  validates :civilite, :prenom, :nom, :lien_avec_demandeur, presence: true
 end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -3,8 +3,9 @@ class Projet < ActiveRecord::Base
 
   enum statut: [ :prospect, :en_cours, :proposition_enregistree, :proposition_proposee, :proposition_acceptee, :transmis_pour_instruction, :en_cours_d_instruction ]
 
-  has_one :personne_de_confiance, class_name: "Personne"
-  accepts_nested_attributes_for :personne_de_confiance
+  # Personne de confiance
+  belongs_to :personne, dependent: :destroy
+  accepts_nested_attributes_for :personne
 
   has_one :demande, dependent: :destroy
   belongs_to :adresse_postale,   class_name: "Adresse", dependent: :destroy

--- a/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
+++ b/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
@@ -35,7 +35,7 @@
       - has_personne = params[:contact].present? ? "1" == params[:contact] : @projet_courant.personne_id.present?
       ul.dem-contact.ins-form
         li.radio
-          label for="contact-idem" value="0"
+          label for="contact-idem"
             input#contact-idem name="contact" type="radio" value="0" checked=(has_personne ? false : 'checked') /
             = t('demarrage_projet.etape1_demarrage_projet.personne_confiance_choix1')
         li.radio

--- a/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
+++ b/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
@@ -32,16 +32,17 @@
         = f.text_field :email
     .dem-contact-wrapper
       p.chapo= t('demarrage_projet.etape1_demarrage_projet.personne_confiance')
+      - has_personne = params[:contact].present? ? "1" == params[:contact] : @projet_courant.personne_id.present?
       ul.dem-contact.ins-form
         li.radio
-          label for="contact-idem"
-            input#contact-idem checked="checked" name="contact" type="radio" /
+          label for="contact-idem" value="0"
+            input#contact-idem name="contact" type="radio" value="0" checked=(has_personne ? false : 'checked') /
             = t('demarrage_projet.etape1_demarrage_projet.personne_confiance_choix1')
         li.radio
           label for="contact-diff"
-            input#contact-diff name="contact" type="radio" /
+            input#contact-diff name="contact" type="radio" value="1" checked=(has_personne ? 'checked' : false) /
             = t('demarrage_projet.etape1_demarrage_projet.personne_confiance_choix2')
-      = f.fields_for :personne_de_confiance do |ff|
+      = f.fields_for :personne do |ff|
           ul.dem-diff.ins-form
             li.radio
               = ff.radio_button :civilite, "Mme", :value => "madame"

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -97,7 +97,7 @@ fr:
       recapitulatif_informations: "Veuillez vérifier les champs ci-dessous et les compléter."
       personne_confiance: "Qui contacter pour les démarches à venir ?"
       personne_confiance_choix1: Vous-même
-      personne_confiance_choix2: "Une personne chargée du suivi du dossier(pour vous)"
+      personne_confiance_choix2: "Une personne chargée du suivi du dossier (pour vous)"
       telephone: "Numéro de téléphone"
       email: "Votre adresse e-mail"
       civilite: "Civilite"

--- a/db/migrate/20170312190438_change_relation_between_projet_and_personne.rb
+++ b/db/migrate/20170312190438_change_relation_between_projet_and_personne.rb
@@ -1,5 +1,0 @@
-class RemoveProjetIdFromPersonnes < ActiveRecord::Migration
-  def up
-    remove_column :personnes, :projet_id
-  end
-end

--- a/db/migrate/20170312190438_change_relation_between_projet_and_personne.rb
+++ b/db/migrate/20170312190438_change_relation_between_projet_and_personne.rb
@@ -1,0 +1,5 @@
+class RemoveProjetIdFromPersonnes < ActiveRecord::Migration
+  def up
+    remove_column :personnes, :projet_id
+  end
+end

--- a/db/migrate/20170312190438_remove_projet_id_from_personnes.rb
+++ b/db/migrate/20170312190438_remove_projet_id_from_personnes.rb
@@ -1,0 +1,17 @@
+class RemoveProjetIdFromPersonnes < ActiveRecord::Migration
+  def up
+    Personne.all.each do |personne|
+      if personne.prenom.blank? || personne.projet_id.blank?
+        Projet.where(personne_id: personne.id).each do |projet|
+          projet.update_attribute(:personne_id, nil)
+        end
+        personne.destroy!
+      end
+    end
+    remove_column :personnes, :projet_id
+  end
+
+  def down
+    add_belongs_to :personnes, :projet, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170310104600) do
+ActiveRecord::Schema.define(version: 20170312190438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,16 +198,13 @@ ActiveRecord::Schema.define(version: 20170310104600) do
   add_index "occupants", ["projet_id"], name: "index_occupants_on_projet_id", using: :btree
 
   create_table "personnes", force: :cascade do |t|
-    t.string  "prenom"
-    t.string  "nom"
-    t.string  "tel"
-    t.string  "email"
-    t.string  "lien_avec_demandeur"
-    t.integer "projet_id"
-    t.string  "civilite"
+    t.string "prenom"
+    t.string "nom"
+    t.string "tel"
+    t.string "email"
+    t.string "lien_avec_demandeur"
+    t.string "civilite"
   end
-
-  add_index "personnes", ["projet_id"], name: "index_personnes_on_projet_id", using: :btree
 
   create_table "prestations", force: :cascade do |t|
     t.string   "libelle"
@@ -334,7 +331,6 @@ ActiveRecord::Schema.define(version: 20170310104600) do
   add_foreign_key "invitations", "intervenants"
   add_foreign_key "invitations", "projets"
   add_foreign_key "occupants", "projets"
-  add_foreign_key "personnes", "projets"
   add_foreign_key "prestations", "projets"
   add_foreign_key "prestations", "themes"
   add_foreign_key "projet_aides", "aides"

--- a/spec/controllers/demarrage_projet_controller_spec.rb
+++ b/spec/controllers/demarrage_projet_controller_spec.rb
@@ -14,6 +14,7 @@ describe DemarrageProjetController do
     let(:params) do
       default_params = { adresse_postale: projet.adresse_postale.description }
       {
+        contact: "1",
         projet_id: projet.id,
         projet:    default_params.merge(projet_params)
       }
@@ -25,10 +26,11 @@ describe DemarrageProjetController do
     end
 
     context "lorsque les informations changent" do
-      let(:projet_params) do {
-        tel:   '01 02 03 04 05',
-        email: 'particulier@exemple.fr'
-      }
+      let(:projet_params) do
+        {
+          tel:   '01 02 03 04 05',
+          email: 'particulier@exemple.fr'
+        }
       end
 
       it "enregistre les informations modifiées" do
@@ -38,25 +40,26 @@ describe DemarrageProjetController do
       end
     end
 
-    context "lorsque la personne de confiance change" do
-      let(:projet_params) do {
-        personne_de_confiance_attributes: {
-          civilite:            'mr',
-          prenom:              'Tyrone',
-          nom:                 'Meehan',
-          tel:                 '01 02 03 04 05',
-          lien_avec_demandeur: 'ami'
+    context "lorsque la personne de confiance est renseignée" do
+      let(:projet_params) do
+        {
+          personne_attributes: {
+            civilite:            'mr',
+            prenom:              'Tyrone',
+            nom:                 'Meehan',
+            tel:                 '01 02 03 04 05',
+            lien_avec_demandeur: 'ami'
+          }
         }
-      }
       end
 
       it "enregistre la personne de confiance" do
         expect(response).to redirect_to projet_path(projet)
-        expect(projet.personne_de_confiance.civilite).to            eq 'mr'
-        expect(projet.personne_de_confiance.prenom).to              eq 'Tyrone'
-        expect(projet.personne_de_confiance.nom).to                 eq 'Meehan'
-        expect(projet.personne_de_confiance.tel).to                 eq '01 02 03 04 05'
-        expect(projet.personne_de_confiance.lien_avec_demandeur).to eq 'ami'
+        expect(projet.personne.civilite).to            eq 'mr'
+        expect(projet.personne.prenom).to              eq 'Tyrone'
+        expect(projet.personne.nom).to                 eq 'Meehan'
+        expect(projet.personne.tel).to                 eq '01 02 03 04 05'
+        expect(projet.personne.lien_avec_demandeur).to eq 'ami'
       end
     end
 

--- a/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
+++ b/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
@@ -62,23 +62,24 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "j'ajoute une personne de confiance" do
     signin_for_new_projet
+    page.choose I18n.t('demarrage_projet.etape1_demarrage_projet.personne_confiance_choix2')
     within '.dem-diff.ins-form' do
       page.choose('Monsieur')
-      fill_in 'projet_personne_de_confiance_attributes_prenom', with: "Frank"
-      fill_in 'projet_personne_de_confiance_attributes_nom', with: "Strazzeri"
-      fill_in 'projet_personne_de_confiance_attributes_tel', with: "0130201040"
-      fill_in 'projet_personne_de_confiance_attributes_email', with: "frank@strazzeri.com"
-      fill_in 'projet_personne_de_confiance_attributes_lien_avec_demandeur', with: "Mon jazzman favori et neanmoins concubin"
+      fill_in 'projet_personne_attributes_prenom', with: "Frank"
+      fill_in 'projet_personne_attributes_nom', with: "Strazzeri"
+      fill_in 'projet_personne_attributes_tel', with: "0130201040"
+      fill_in 'projet_personne_attributes_email', with: "frank@strazzeri.com"
+      fill_in 'projet_personne_attributes_lien_avec_demandeur', with: "Mon jazzman favori et neanmoins concubin"
     end
     click_button I18n.t('demarrage_projet.action')
     expect(page.current_path).to eq(etape2_description_projet_path(projet))
     projet.reload
-    expect(projet.personne_de_confiance.civilite).to eq('Mr')
-    expect(projet.personne_de_confiance.prenom).to eq("Frank")
-    expect(projet.personne_de_confiance.nom).to eq("Strazzeri")
-    expect(projet.personne_de_confiance.tel).to eq("0130201040")
-    expect(projet.personne_de_confiance.email).to eq("frank@strazzeri.com")
-    expect(projet.personne_de_confiance.lien_avec_demandeur).to eq("Mon jazzman favori et neanmoins concubin")
+    expect(projet.personne.civilite).to eq('Mr')
+    expect(projet.personne.prenom).to eq("Frank")
+    expect(projet.personne.nom).to eq("Strazzeri")
+    expect(projet.personne.tel).to eq("0130201040")
+    expect(projet.personne.email).to eq("frank@strazzeri.com")
+    expect(projet.personne.lien_avec_demandeur).to eq("Mon jazzman favori et neanmoins concubin")
   end
 
   scenario "je vois la liste des personnes présentes dans l'avis d'imposition sous forme d'occupants" do


### PR DESCRIPTION
Les personnes (personnes de confiance) étaient mal sauvegardées.

La relation 1-1 était gérée en double : clés étrangère sur les deux tables. Cela générait des entrées vides en doublon. J’ai supprimé une des deux clés, celle qui devait pas être utilisé.

La production ne possède aucune personne correctement remplie (vérifié directement en base) ce qui veut dire que personne n’a encore utilisé cette partie.

On ajoute des contraintes de présence sur certains champs et la migration supprime les entrées vides.