### PR TITLE
Procfile: lance les migrations automatiquement sur Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 web: bundle exec rails server -p $PORT -b 0.0.0.0
 worker: bundle exec sidekiq -q default -q mailers
+release:    bin/rake db:migrate
 postdeploy: bin/rake db:migrate


### PR DESCRIPTION
Heroku recommande d’utiliser la phase `release` pour lancer les migrations automatiquement (https://devcenter.heroku.com/articles/release-phase)

Scalingo recommande quand à eux d’utiliser la phase `postdeploy` (cf. http://doc.scalingo.com/app/postdeploy-hook.html)

Aujourd'hui on ne renseigne que la phase `postdeploy`. Les migrations ne sont lancées automatiquement que sur Scalingo – mais sur Heroku il faut le faire manuellement. Cela conduit à des erreurs comme celle mentionnée dans  https://github.com/sgmap/mpal/pull/242#issuecomment-286037550

Cette PR rajoute donc les deux, pour lancer les migrations automatiquement à la fois sur Heroku (staging) et sur Scalingo (demo, production).