### PR TITLE
PF354 enregistre les notes de dégradation et d’insalubrité décimales

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -35,6 +35,8 @@ class Projet < ActiveRecord::Base
   validates :adresse_postale, presence: true, on: :update
   validates_numericality_of :nb_occupants_a_charge, greater_than_or_equal_to: 0, allow_nil: true
 
+  localized_numeric_setter :note_degradation
+  localized_numeric_setter :note_insalubrite
   localized_numeric_setter :montant_travaux_ht
   localized_numeric_setter :montant_travaux_ttc
   localized_numeric_setter :reste_a_charge

--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -33,11 +33,11 @@ ul.ctr-ope
   - if @projet_courant.note_degradation.present?
     li
       = with_semicolon(t('helpers.label.diagnostic.note_degradation'))
-      span= @projet_courant.note_degradation
+      span= number_with_delimiter(@projet_courant.note_degradation)
   - if @projet_courant.note_insalubrite.present?
     li
       = with_semicolon(t('helpers.label.diagnostic.note_insalubrite'))
-      span= @projet_courant.note_insalubrite
+      span= number_with_delimiter(@projet_courant.note_insalubrite)
   li
     = with_semicolon(t('helpers.label.diagnostic.ventilation_adaptee'))
     span= readable_bool(@projet_courant.ventilation_adaptee)

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -52,10 +52,10 @@
                 = f.label :handicap, "Non", value: "false"
               li
                 = f.label :note_degradation, t('helpers.label.diagnostic.note_degradation')
-                = f.text_field :note_degradation
+                = text_field_tag "projet[note_degradation]", number_with_delimiter(@projet_courant.note_degradation)
               li
                 = f.label :note_insalubrite, t('helpers.label.diagnostic.note_insalubrite')
-                = f.text_field :note_insalubrite
+                = text_field_tag "projet[note_insalubrite]", number_with_delimiter(@projet_courant.note_insalubrite)
               li.radio
                 p.like-label= t('helpers.label.diagnostic.ventilation_adaptee')
                 = f.radio_button :ventilation_adaptee, true

--- a/db/migrate/20170313093933_change_projet_degradation_insalubrite.rb
+++ b/db/migrate/20170313093933_change_projet_degradation_insalubrite.rb
@@ -1,0 +1,6 @@
+class ChangeProjetDegradationInsalubrite < ActiveRecord::Migration
+  def change
+    change_column :projets, :note_degradation, :decimal, :precision => 10, :scale => 6
+    change_column :projets, :note_insalubrite, :decimal, :precision => 10, :scale => 6
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170312190438) do
+ActiveRecord::Schema.define(version: 20170313093933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -276,8 +276,8 @@ ActiveRecord::Schema.define(version: 20170312190438) do
     t.boolean  "handicap"
     t.boolean  "demandeur_salarie"
     t.boolean  "entreprise_plus_10_personnes"
-    t.integer  "note_degradation"
-    t.integer  "note_insalubrite"
+    t.decimal  "note_degradation",             precision: 10, scale: 6
+    t.decimal  "note_insalubrite",             precision: 10, scale: 6
     t.boolean  "ventilation_adaptee"
     t.boolean  "presence_humidite"
     t.boolean  "auto_rehabilitation"

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -36,8 +36,8 @@ feature "Remplir la proposition de travaux" do
       choose 'projet_autonomie_true'
       fill_in 'projet_niveau_gir', with: '712'
       choose 'projet_handicap_true'
-      fill_in 'projet_note_degradation', with: '345'
-      fill_in 'projet_note_insalubrite', with: '977'
+      fill_in 'projet_note_degradation', with: '0,1'
+      fill_in 'projet_note_insalubrite', with: '0,2'
       choose 'projet_ventilation_adaptee_true'
       choose 'projet_presence_humidite_true'
       choose 'projet_auto_rehabilitation_true'
@@ -75,8 +75,8 @@ feature "Remplir la proposition de travaux" do
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.autonomie'))
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.niveau_gir') + ' : 712')
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.handicap') + ' : Oui')
-      expect(page).to have_content(I18n.t('helpers.label.diagnostic.note_degradation') + ' : 345')
-      expect(page).to have_content(I18n.t('helpers.label.diagnostic.note_insalubrite') + ' : 977')
+      expect(page).to have_content(I18n.t('helpers.label.diagnostic.note_degradation') + ' : 0,1')
+      expect(page).to have_content(I18n.t('helpers.label.diagnostic.note_insalubrite') + ' : 0,2')
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.ventilation_adaptee') + ' : Oui')
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.presence_humidite') + ' : Oui')
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.auto_rehabilitation') + ' Oui')


### PR DESCRIPTION
Permet d'entrer un nombre décimal pour les notes de dégradation et d'insalubrité.

https://anah-produits.atlassian.net/browse/PF-354

<img width="626" alt="capture d ecran 2017-03-13 a 11 03 47" src="https://cloud.githubusercontent.com/assets/179923/23849680/c05fada6-07dc-11e7-890f-437c58e6f185.png">
