### PR TITLE
Valide l'email et le téléphone

### DIFF
--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -57,10 +57,6 @@ module ProjetConcern
 
 private
 
-    def email_valide?(email)
-      email.match(/\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z/i) || email.empty?
-    end
-
     def projet_params
       attributs = params.require(:projet)
       .permit(:disponibilite, :description, :email, :tel, :annee_construction, :nb_occupants_a_charge,

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -33,6 +33,7 @@ class Projet < ActiveRecord::Base
 
   validates :numero_fiscal, :reference_avis, presence: true
   validates :email, email: true, allow_blank: true, on: :update
+  validates :tel, phone: { :minimum => 10, :maximum => 12 }, allow_blank: true
   validates :adresse_postale, presence: true, on: :update
   validates_numericality_of :nb_occupants_a_charge, greater_than_or_equal_to: 0, allow_nil: true
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -32,7 +32,7 @@ class Projet < ActiveRecord::Base
   has_and_belongs_to_many :suggested_operateurs, class_name: 'Intervenant', join_table: 'suggested_operateurs'
 
   validates :numero_fiscal, :reference_avis, presence: true
-  validates :email, email: true, allow_blank: true, on: :update
+  validates :email, email: true, allow_blank: true
   validates :tel, phone: { :minimum => 10, :maximum => 12 }, allow_blank: true
   validates :adresse_postale, presence: true, on: :update
   validates_numericality_of :nb_occupants_a_charge, greater_than_or_equal_to: 0, allow_nil: true

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -32,6 +32,7 @@ class Projet < ActiveRecord::Base
   has_and_belongs_to_many :suggested_operateurs, class_name: 'Intervenant', join_table: 'suggested_operateurs'
 
   validates :numero_fiscal, :reference_avis, presence: true
+  validates :email, email: true, allow_blank: true, on: :update
   validates :adresse_postale, presence: true, on: :update
   validates_numericality_of :nb_occupants_a_charge, greater_than_or_equal_to: 0, allow_nil: true
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true

--- a/config/initializers/validators.rb
+++ b/config/initializers/validators.rb
@@ -5,7 +5,7 @@ class EmailValidator < ActiveModel::EachValidator
       '@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$', 'i')
 
   def validate_each(record, attribute, value)
-    unless value =~ REG_EMAIL
+    unless value.blank? || value =~ REG_EMAIL
       record.errors.add(attribute, options[:message] || :invalid)
     end
   end

--- a/config/initializers/validators.rb
+++ b/config/initializers/validators.rb
@@ -6,7 +6,7 @@ class EmailValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     unless value =~ REG_EMAIL
-      record.errors[attribute] << (options[:message] || I18n.t('errors.messages.invalid'))
+      record.errors.add(attribute, options[:message] || :invalid)
     end
   end
 end

--- a/config/initializers/validators.rb
+++ b/config/initializers/validators.rb
@@ -10,3 +10,21 @@ class EmailValidator < ActiveModel::EachValidator
     end
   end
 end
+
+class PhoneValidator < ActiveModel::EachValidator
+  # This validator loosely checks if the phone number contains the required number of digits.
+  # It doesn't attempt to normalize or format the phone number.
+  def validate_each(record, attribute, value)
+    numbers = value.gsub(/[^0-9]/, '')
+    minimum_numbers = options[:minimum] || 10
+    maximum_numbers = options[:maximum] || 12
+
+    if value.present?
+      if numbers.length < minimum_numbers
+        record.errors.add(attribute, options[:message] || :too_short, { count: minimum_numbers })
+      elsif numbers.length > maximum_numbers
+        record.errors.add(attribute, options[:message] || :too_long, { count: maximum_numbers })
+      end
+    end
+  end
+end

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -91,7 +91,6 @@ fr:
       erreurs:
         adresse_vide: "Votre adresse doit être renseignée"
         adresse_inconnue: "Nous n’avons pas réussi à localiser votre adresse. Veuillez renseigner une adresse plus précise – ou ré-essayez dans quelques minutes."
-      erreur_email_invalide: "Veuillez entrer une adresse e-mail valide svp"
       section_demandeur: "Demandeur"
       section_occupants: "Occupants"
       recapitulatif_informations: "Veuillez vérifier les champs ci-dessous et les compléter."
@@ -373,6 +372,7 @@ fr:
   activerecord:
     attributes:
       projet:
+        email: "L’adresse email"
         note_degradation: "La note de dégradation"
         note_insalubrite: "La note d’insalubrité"
     errors:

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -373,6 +373,7 @@ fr:
     attributes:
       projet:
         email: "L’adresse email"
+        tel: "Le numéro de téléphone"
         note_degradation: "La note de dégradation"
         note_insalubrite: "La note d’insalubrité"
     errors:

--- a/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
+++ b/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
@@ -25,19 +25,22 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     within '.civilite' do
       choose('Monsieur')
     end
+    fill_in :projet_email, with: "demandeur@exemple.fr"
     click_button I18n.t('demarrage_projet.action')
     expect(projet.demandeur_principal.civilite).to eq("mr")
   end
 
-  scenario "mon e-mail doit être valide et obligatoire" do
-    skip
-    signin_for_new_projet
-    fill_in :projet_email, with: "invalid-email"
-    fill_in 'projet_tel', with: "06 06 06 06 06"
-    click_button I18n.t('demarrage_projet.action')
-    expect(page).to have_current_path etape1_recuperation_infos_path(projet)
-    expect(projet.tel).to eq("06 06 06 06 06")
-    expect(page).to have_content(I18n.t('projets.edition_projet.messages.erreur_email_invalide'))
+  context "quand je rentre des données invalides" do
+    scenario "je vois un message d'erreur" do
+      signin_for_new_projet
+      fill_in :projet_email, with: "invalid-email@lol"
+      fill_in 'projet_tel', with: "06 06 06 06 06"
+      click_button I18n.t('demarrage_projet.action')
+      expect(page).to have_current_path etape1_recuperation_infos_path(projet)
+      expect(page).to have_content("L’adresse email n’est pas valide")
+      expect(page).to have_field('Email', with: 'invalid-email@lol')
+      expect(page).to have_field('Téléphone', with: '06 06 06 06 06')
+    end
   end
 
   scenario "je dois rentrer une adresse" do
@@ -50,6 +53,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "je peux ajouter l'adresse du logement à rénover" do
     signin_for_new_projet
+    fill_in :projet_email, with: "demandeur@exemple.fr"
     fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_PORT
     click_button I18n.t('demarrage_projet.action')
 
@@ -62,6 +66,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "j'ajoute une personne de confiance" do
     signin_for_new_projet
+    fill_in :projet_email, with: "demandeur@exemple.fr"
     page.choose I18n.t('demarrage_projet.etape1_demarrage_projet.personne_confiance_choix2')
     within '.dem-diff.ins-form' do
       page.choose('Monsieur')

--- a/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
+++ b/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
@@ -20,26 +20,31 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     expect(page).to have_content(I18n.t('projets.messages.creation.titre', demandeur_principal: projet.demandeur_principal.fullname))
   end
 
-  scenario "je complète la civilité du demandeur principal" do
+  scenario "je remplis mes informations personnelles" do
     signin_for_new_projet
     within '.civilite' do
       choose('Monsieur')
     end
     fill_in :projet_email, with: "demandeur@exemple.fr"
+    fill_in :projet_tel,   with: "01 02 03 04 05"
     click_button I18n.t('demarrage_projet.action')
     expect(projet.demandeur_principal.civilite).to eq("mr")
+    expect(projet.email).to eq("demandeur@exemple.fr")
+    expect(projet.tel).to eq("01 02 03 04 05")
   end
 
   context "quand je rentre des données invalides" do
     scenario "je vois un message d'erreur" do
       signin_for_new_projet
       fill_in :projet_email, with: "invalid-email@lol"
-      fill_in 'projet_tel', with: "06 06 06 06 06"
+      fill_in 'projet_tel', with: "999"
       click_button I18n.t('demarrage_projet.action')
+
       expect(page).to have_current_path etape1_recuperation_infos_path(projet)
       expect(page).to have_content("L’adresse email n’est pas valide")
-      expect(page).to have_field('Email', with: 'invalid-email@lol')
-      expect(page).to have_field('Téléphone', with: '06 06 06 06 06')
+      expect(page).to have_field("Email", with: "invalid-email@lol")
+      expect(page).to have_content("Le numéro de téléphone est trop court")
+      expect(page).to have_field("Téléphone", with: "999")
     end
   end
 

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -26,13 +26,13 @@ describe Projet do
 
     it "accepte les emails valides" do
       projet.email = "email@exemple.fr"
-      projet.valid?(:update)
+      projet.valid?
       expect(projet.errors[:email]).to be_empty
     end
 
     it "rejete les emails invalides" do
       projet.email = "invalid-email@lol"
-      projet.valid?(:update)
+      projet.valid?
       expect(projet.errors[:email]).to be_present
     end
 

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -21,6 +21,18 @@ describe Projet do
     it { is_expected.to have_and_belong_to_many :prestations }
     it { is_expected.to belong_to :agent_operateur }
     it { is_expected.to belong_to :agent_instructeur }
+
+    it "accepte les emails valides" do
+      projet.email = "email@exemple.fr"
+      projet.valid?(:update)
+      expect(projet.errors[:email]).to be_empty
+    end
+
+    it "rejete les emails invalides" do
+      projet.email = "invalid-email@lol"
+      projet.valid?(:update)
+      expect(projet.errors[:email]).to be_present
+    end
   end
 
   describe '#clean_numero_fiscal' do

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -10,6 +10,8 @@ describe Projet do
     it { is_expected.to validate_presence_of :reference_avis }
     it { is_expected.not_to validate_presence_of(:adresse_postale).on(:create) }
     it { is_expected.to validate_presence_of(:adresse_postale).on(:update) }
+    it { is_expected.not_to validate_presence_of(:email) }
+    it { is_expected.not_to validate_presence_of(:tel) }
     it { is_expected.to validate_numericality_of(:nb_occupants_a_charge).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_inclusion_of(:note_degradation).in_range(0..1) }
     it { is_expected.to validate_inclusion_of(:note_insalubrite).in_range(0..1) }
@@ -32,6 +34,18 @@ describe Projet do
       projet.email = "invalid-email@lol"
       projet.valid?(:update)
       expect(projet.errors[:email]).to be_present
+    end
+
+    it "accepte les numéros de téléphone valides" do
+      projet.tel = "01 02 03 04 05 06"
+      projet.valid?
+      expect(projet.errors[:tel]).to be_empty
+    end
+
+    it "rejete les numéros de téléphone invalides" do
+      projet.tel = "111"
+      projet.valid?
+      expect(projet.errors[:tel]).to be_present
     end
   end
 

--- a/spec/validators/phone_validator_spec.rb
+++ b/spec/validators/phone_validator_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+class PhoneValidatable
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_accessor :tel
+end
+
+class DefaultPhoneValidatable < PhoneValidatable
+  validates :tel, phone: true
+end
+
+class SmallPhoneValidatable < PhoneValidatable
+  validates :tel, phone: { :minimum => 3 }
+end
+
+class LargePhoneValidatable < PhoneValidatable
+  validates :tel, phone: { :maximum => 16 }
+end
+
+describe PhoneValidator do
+  subject { DefaultPhoneValidatable.new(tel: tel) }
+
+  context "le numéro est vide" do
+    let(:tel) { "" }
+    it { is_expected.to be_valid }
+  end
+
+  context "le numéro est trop court" do
+    let(:tel) { "999" }
+    it { is_expected.not_to be_valid }
+  end
+
+  context "le numéro est trop long" do
+    let(:tel) { "01020304050607" }
+    it { is_expected.not_to be_valid }
+  end
+
+  context "le numéro a une longueur correcte" do
+    let(:tel) { "0102030405" }
+    it { is_expected.to be_valid }
+  end
+
+  context "le numéro a des espaces" do
+    let(:tel) { "01 02 03 04 05" }
+    it { is_expected.to be_valid }
+  end
+
+  context "le numéro a des caractères spéciaux" do
+    let(:tel) { "+33 1 02 03 04 05" }
+    it { is_expected.to be_valid }
+  end
+
+  describe "options" do
+    describe "la borne inférieure est respectée" do
+      subject { SmallPhoneValidatable.new(tel: tel) }
+      let(:tel) { "115" }
+      it { is_expected.to be_valid }
+    end
+
+    describe "la borne supérieure est modifiée" do
+      subject { LargePhoneValidatable.new(tel: tel) }
+      let(:tel) { "01020304050607" }
+      it { is_expected.to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
Lors du démarrage d'un projet, valide le format de l'email et du numéro de téléphone.

- L'email ~~doit obligatoirement être renseigné~~ est optionnel,
- Le téléphone est optionnel.

<img width="780" alt="capture d ecran 2017-03-13 a 17 35 13" src="https://cloud.githubusercontent.com/assets/179923/23865170/1230d5b4-0815-11e7-8a44-20b2c7d82faf.png">
