### PR TITLE
PF305 corrige la migration des adresses 🚑

### DIFF
--- a/db/migrate/20170309093830_copy_adresses_to_model.rb
+++ b/db/migrate/20170309093830_copy_adresses_to_model.rb
@@ -13,7 +13,7 @@ class CopyAdressesToModel < ActiveRecord::Migration
             code_postal: projet.code_postal,
             code_insee:  projet.code_insee,
             ville:       projet.ville,
-            departement: projet.departement
+            departement: projet.read_attribute(:departement)
           })
           projet.save!
           print "."


### PR DESCRIPTION
`Projet#departement` est une méthode overridée, qui va renvoyer nil
tant que les modèles `Adresse` ne sont pas créées.

On ne peut donc pas s’en servir dans la migration…

Cette PR corrige la migration pour lorsqu'elle tournera en prod (mais il faudra que je déboise manuellement `demo`).