### PR TITLE
Seeds: met à jour les données sans tronquer la table

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,13 +13,6 @@ private
     end
   end
 
-  def clear_table(*table_names)
-    table_names.flatten.reject(&:blank?).each do |table_name|
-      cnx.execute "TRUNCATE #{cnx.quote_table_name table_name} RESTART IDENTITY CASCADE"
-    end
-  end
-  alias_method :clear_tables, :clear_table
-
   def cnx
     ActiveRecord::Base.connection
   end

--- a/db/seeds/001_intervenants.rb
+++ b/db/seeds/001_intervenants.rb
@@ -184,10 +184,11 @@ class Seeder
   def seed_intervenants
     table_name = 'intervenants'
     seeding table_name
-    clear_table table_name
     progress do
       INTERVENANTS.each do |attributes|
-        Intervenant.create!(attributes)
+        Intervenant
+          .find_or_initialize_by(raison_sociale: attributes[:raison_sociale])
+          .update_attributes!(attributes)
         ahead!
       end
     end

--- a/db/seeds/002_themes.rb
+++ b/db/seeds/002_themes.rb
@@ -71,13 +71,12 @@ class Seeder
   def seed_themes
     table_name = 'themes'
     seeding table_name
-    clear_table 'prestations', table_name
     progress do
       THEMES.each do |libelle_theme, prestations|
-        theme = Theme.create!(libelle: libelle_theme)
+        theme = Theme.find_or_create_by!(libelle: libelle_theme)
         ahead!
         prestations.each do |libelle_prestation|
-          Prestation.create!(theme: theme, libelle: libelle_prestation)
+          Prestation.find_or_create_by!(theme: theme, libelle: libelle_prestation)
           ahead!('+')
         end
       end

--- a/db/seeds/003_type_aides.rb
+++ b/db/seeds/003_type_aides.rb
@@ -26,13 +26,12 @@ class Seeder
   def seed_type_aides
     table_name = 'type_aides'
     seeding table_name
-    clear_table 'aides', table_name
     progress do
       TYPE_AIDES.each do |libelle_type_aide, aides|
-        type_aide = TypeAide.create!(libelle: libelle_type_aide)
+        type_aide = TypeAide.find_or_create_by!(libelle: libelle_type_aide)
         ahead!
         aides.each do |libelle_aide|
-          Aide.create!(type_aide: type_aide, libelle: libelle_aide)
+          Aide.find_or_create_by!(type_aide: type_aide, libelle: libelle_aide)
           ahead!('+')
         end
       end


### PR DESCRIPTION
Pour moi il n’est pas intuitif que `rake db:seed` va tronquer des tables. J’imagine une situation où on voudrait rajouter les intervenants des seeds à un environnement. On lance la commande – et paf, au lieu de rajouter les données, ça a tronqué la table.

À la place les données sont créées si elles n’existent pas, et mises à jour sinon.

@jvignolles je pense que c'est une meilleure approche, mais ça se discute ; on peut en parler si tu veux :)