### PR TITLE
PF348 conserve le PRIS lors de l’invitation d’un opérateur

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -183,13 +183,13 @@ class Projet < ActiveRecord::Base
     ProjetMailer.notification_invitation_intervenant(invitation).deliver_later!
     EvenementEnregistreurJob.perform_later(label: 'invitation_intervenant', projet: self, producteur: invitation)
 
-    if previous_operateur
+    if intervenant.operateur? && previous_operateur
       previous_invitation = invitations.where(intervenant: previous_operateur).first
       ProjetMailer.resiliation_operateur(previous_invitation).deliver_later!
       previous_invitation.destroy!
     end
 
-    if previous_pris
+    if intervenant.pris? && previous_pris
       previous_invitation = invitations.where(intervenant: previous_pris).first
       previous_invitation.destroy!
     end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -235,13 +235,26 @@ describe Projet do
 
       it "sélectionne le nouvel intervenant" do
         projet.invite_intervenant!(new_operateur)
-        expect(projet.invitations.count).to eq(1)
+        expect(projet.invitations.count).to eq(2)
+        expect(projet.invited_pris).not_to be_nil
         expect(projet.invited_operateur).to eq(new_operateur)
-        expect(projet.invited_pris).to be_nil
       end
     end
 
     context "avec un opérateur invité auparavant" do
+      context "et un nouveau PRIS" do
+        let(:projet)    { create :projet, :prospect, :with_invited_operateur }
+        let(:operateur) { projet.invited_operateur }
+        let(:pris)      { create :pris }
+
+        it "rajoute l’opérateur et conserve la relation avec le PRIS" do
+          projet.invite_intervenant!(pris)
+          expect(projet.invitations.count).to eq(2)
+          expect(projet.invited_operateur).to eq(operateur)
+          expect(projet.invited_pris).to eq(pris)
+        end
+      end
+
       context "et un nouvel opérateur différent du précédent" do
         let(:projet)             { create :projet, :prospect, :with_invited_operateur }
         let(:previous_operateur) { projet.invited_operateur }


### PR DESCRIPTION
La relation entre dossier et PRIS (invitation) était supprimée lors de l’invitation d’un opérateur.

Nous la conservons maintenant. À venir : nous filtrerons les dossiers accessibles par un PRIS sur leur état d’avancement.