### PR TITLE
PF356 corrige la synthèse et ses tests

### DIFF
--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -5,31 +5,37 @@ ul.ctr-ope
     span= @projet_courant.type_logement
   li
     = "Étage : "
-    span= @projet_courant.etage
-  li
+    span class='etage'= @projet_courant.etage
+  li class='pieces'
     = "Nombre de pièces : "
     span= @projet_courant.nb_pieces
   - if @projet_courant.annee_construction.present?
     li
       = "Année de construction : "
-      span= @projet_courant.annee_construction
+      span class='construction'= @projet_courant.annee_construction
   - if @projet_courant.surface_habitable.present?
     li
       = "Surface avant travaux : "
       span= "#{@projet_courant.surface_habitable} m2"
+  - if @projet_courant.etiquette_avant_travaux.present?
+    li
+      = with_semicolon(t('helpers.label.proposition.etiquette_avant_travaux'))
+      span class='etiquette_avant' = @projet_courant.etiquette_avant_travaux
 
 h4 Votre évaluation
 ul.ctr-ope
-  li
-    = t('helpers.label.diagnostic.autonomie')
-    span=< readable_bool(@projet_courant.autonomie)
+  - if @projet_courant.autonomie.present?
+    li
+      = t('helpers.label.diagnostic.autonomie')
+      span=< readable_bool(@projet_courant.autonomie)
   - if @projet_courant.niveau_gir.present?
     li
       = with_semicolon(t('helpers.label.diagnostic.niveau_gir'))
       span= @projet_courant.niveau_gir
-  li
-    = with_semicolon(t('helpers.label.diagnostic.handicap'))
-    span= readable_bool(@projet_courant.handicap)
+  - if @projet_courant.autonomie.present?
+    li
+      = with_semicolon(t('helpers.label.diagnostic.handicap'))
+      span= readable_bool(@projet_courant.handicap)
   - if @projet_courant.note_degradation.present?
     li
       = with_semicolon(t('helpers.label.diagnostic.note_degradation'))
@@ -38,15 +44,18 @@ ul.ctr-ope
     li
       = with_semicolon(t('helpers.label.diagnostic.note_insalubrite'))
       span= number_with_delimiter(@projet_courant.note_insalubrite)
-  li
-    = with_semicolon(t('helpers.label.diagnostic.ventilation_adaptee'))
-    span= readable_bool(@projet_courant.ventilation_adaptee)
-  li
-    = with_semicolon(t('helpers.label.diagnostic.presence_humidite'))
-    span= readable_bool(@projet_courant.presence_humidite)
-  li
-    = t('helpers.label.diagnostic.auto_rehabilitation')
-    span=< readable_bool(@projet_courant.auto_rehabilitation)
+  - if @projet_courant.ventilation_adaptee.present?
+    li
+      = with_semicolon(t('helpers.label.diagnostic.ventilation_adaptee'))
+      span= readable_bool(@projet_courant.ventilation_adaptee)
+  - if @projet_courant.presence_humidite.present?
+    li
+      = with_semicolon(t('helpers.label.diagnostic.presence_humidite'))
+      span= readable_bool(@projet_courant.presence_humidite)
+  - if @projet_courant.auto_rehabilitation.present?
+    li
+      = t('helpers.label.diagnostic.auto_rehabilitation')
+      span=< readable_bool(@projet_courant.auto_rehabilitation)
   - if @projet_courant.remarques_diagnostic.present?
     li
       = with_semicolon(t('helpers.label.diagnostic.remarques_diagnostic'))
@@ -65,11 +74,11 @@ table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
     - if @projet_courant.gain_energetique
       tr
         th scope="row"= t('helpers.label.proposition.gain_energetique')
-        td= @projet_courant.gain_energetique
+        td class='gain_energetique' = @projet_courant.gain_energetique
     - if @projet_courant.etiquette_apres_travaux.present?
       tr
         th scope="row"= t('helpers.label.proposition.etiquette_apres_travaux')
-        td= @projet_courant.etiquette_apres_travaux
+        td class='etiquette_apres' = @projet_courant.etiquette_apres_travaux
     - if @projet_courant.montant_travaux_ht.present?
       tr
         th scope="row"= t('helpers.label.proposition.montant_travaux_ht')

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -46,6 +46,7 @@ fr:
         remarques_diagnostic: "Autres remarques"
       proposition:
         gain_energetique: "Gain énergétique"
+        etiquette_avant_travaux: "Étiquette énergétique avant travaux"
         etiquette_apres_travaux: "Étiquette énergétique après travaux"
         montant: "Montant"
         montant_travaux_ht: "Montant total HT"

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -65,11 +65,11 @@ feature "Remplir la proposition de travaux" do
       # Section "Logement"
       expect(page.current_path).to eq(dossier_path(projet))
       expect(page).to have_content('Appartement')
-      expect(page).to have_content('2')
-      expect(page).to have_content('Plus de 5')
+      expect(page).to have_css('.etage', text: 2)
+      expect(page).to have_css('.pieces', text:'Plus de 5')
       expect(page).to have_content('1954')
-      expect(page).to have_content('42')
-      expect(page).to have_content('C')
+      expect(page).to have_content('42 m2')
+      expect(page).to have_css('.etiquette_avant', text: 'C')
 
       # Section "Diagnostic opérateur"
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.autonomie'))
@@ -87,9 +87,9 @@ feature "Remplir la proposition de travaux" do
       expect(page).to have_content('Lavabo adapté')
       expect(page).not_to have_content('Géothermie')
       expect(page).to have_content(I18n.t('helpers.label.proposition.gain_energetique'))
-      expect(page).to have_content('31')
+      expect(page).to have_css('.gain_energetique', text: 31)
       expect(page).to have_content(I18n.t('helpers.label.proposition.etiquette_apres_travaux'))
-      expect(page).to have_content('A')
+      expect(page).to have_css('.etiquette_apres', text: 'A')
 
       # Section "Financement"
       expect(page).to have_content(I18n.t('helpers.label.proposition.montant_travaux_ht'))
@@ -113,6 +113,16 @@ feature "Remplir la proposition de travaux" do
         click_on 'Enregistrer cette proposition'
         expect(page).to have_current_path dossier_proposition_path(projet)
         expect(page).to have_content "La note de dégradation doit être comprise entre zéro et un"
+      end
+    end
+
+    context "quand je ne réponds non/pas aux questions" do
+      scenario "elles n'apparaissent pas dans la synthèse" do
+        visit dossier_proposition_path(projet)
+        choose 'projet_ventilation_adaptee_false'
+        click_on 'Enregistrer cette proposition'
+        expect(page.current_path).to eq(dossier_path(projet))
+        within('.block.projet-ope') { expect(page).not_to have_content 'Non' }
       end
     end
 


### PR DESCRIPTION
Corrige le bug où : 
- l'étiquette énergétique n'était pas présente sur la synthèse du projet proposé
- les questions étaient affichées alors que leur réponse n'était pas renseignée ou à faux

Étoffe les tests de la synthèse 