### PR TITLE
PF355 transmet la bonne civilité à Opal

### DIFF
--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -13,7 +13,7 @@ class DemarrageProjetController < ApplicationController
     end
 
     @projet_courant.personne ||= Personne.new
-    @demandeur_principal = @projet_courant.occupants.where(demandeur: true).first
+    @demandeur_principal = @projet_courant.demandeur_principal
     @action_label = if needs_etape2? then action_label_create else action_label_update end
   end
 
@@ -153,7 +153,7 @@ private
       return false
     end
 
-    demandeur_principal = @projet_courant.occupants.where(demandeur: true).first
+    demandeur_principal = @projet_courant.demandeur_principal
     demandeur_principal.assign_attributes(demandeur_principal_params)
     if !demandeur_principal.save
       flash[:alert] = t('demarrage_projet.etape1_demarrage_projet.erreurs.enregistrement_demandeur')

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,7 +32,7 @@ class SessionsController < ApplicationController
       flash[:notice_titre] = t('projets.messages.creation.titre', demandeur_principal: projet.demandeur_principal.fullname)
       redirect_to etape1_recuperation_infos_path(projet), notice: notice
     else
-      redirect_to new_session_path, alert: t('sessions.erreurs.creation_projet')
+      redirect_to new_session_path, alert: t('sessions.erreur_creation_projet')
     end
   end
 

--- a/app/models/occupant.rb
+++ b/app/models/occupant.rb
@@ -7,10 +7,15 @@ class Occupant < ActiveRecord::Base
   has_many :avis_impositions
 
   validates :nom, :prenom, :date_de_naissance, presence: true
+  validates :civilite, presence: true, on: :update, if: :require_civilite?
 
   strip_fields :nom, :prenom
 
   scope :sans_revenus, -> { where(revenus: nil) }
+
+  def require_civilite?
+    projet && projet.demandeur_principal == self
+  end
 
   def fullname
     "#{prenom} #{nom}"

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -114,7 +114,7 @@ class Projet < ActiveRecord::Base
   end
 
   def demandeur_principal
-    occupants.where(demandeur: true).first
+    @demandeur_principal ||= occupants.where(demandeur: true).first
   end
 
   def demandeur_principal_nom

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -42,9 +42,9 @@ class Opal
           "pphPrenom": projet.prenom_occupants,
           "adressePostale": {
             "payId": 1,
-            "adpLigne1": projet.adresse.ligne_1,
-            "adpLocalite": projet.adresse.ville,
-            "adpCodePostal": projet.adresse.code_postal
+            "adpLigne1":     projet.adresse_postale.ligne_1,
+            "adpLocalite":   projet.adresse_postale.ville,
+            "adpCodePostal": projet.adresse_postale.code_postal
           }
         }
       },

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -17,6 +17,8 @@ class Opal
   end
 
 private
+  OPAL_CIVILITE_M   = 1
+  OPAL_CIVILITE_MME = 2
 
   def ajoute_id_opal(projet, reponse)
     opal = JSON.parse(reponse)
@@ -26,6 +28,16 @@ private
 
   def met_a_jour_statut(projet)
     projet.statut = :en_cours_d_instruction
+  end
+
+  def serialize_civilite_occupants(occupants)
+    # Seule la civilité du demandeur principal est renseignée
+    civilite = occupants.map(&:civilite).compact.first
+    if civilite == Occupant.civilites.keys[0]
+      OPAL_CIVILITE_M
+    else
+      OPAL_CIVILITE_MME
+    end
   end
 
   def serialize_prenom_occupants(occupants)
@@ -51,7 +63,7 @@ private
         "qdmId": 29,
         "cadId": 2,
         "personnePhysique": {
-          "civId": 4,
+          "civId":     serialize_civilite_occupants(projet.occupants),
           "pphNom":    serialize_noms_occupants(projet.occupants),
           "pphPrenom": serialize_prenom_occupants(projet.occupants),
           "adressePostale": {

--- a/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
+++ b/app/views/demarrage_projet/etape1_recuperation_infos.html.slim
@@ -1,6 +1,7 @@
 /! Demandeur
 = form_for @projet_courant, url: { controller: 'demarrage_projet', action: 'etape1_recuperation_infos' }, method: 'post', html: { class: 'form' }  do |f|
   = render 'shared/errors', resource: @projet_courant
+  = render 'shared/errors', resource: @demandeur_principal
   section.demandeur
     h2.header-blk= t('demarrage_projet.etape1_demarrage_projet.section_demandeur')
     p.chapo= t('demarrage_projet.etape1_demarrage_projet.recapitulatif_informations')

--- a/app/views/shared/_errors.html.slim
+++ b/app/views/shared/_errors.html.slim
@@ -1,5 +1,4 @@
 - if resource && resource.errors.present?
-  - model = resource.class.to_s.underscore
   .row
     .col-xxs-12
       div.form-errors.alert.alert-danger

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -92,6 +92,7 @@ fr:
       erreurs:
         adresse_vide: "Votre adresse doit être renseignée"
         adresse_inconnue: "Nous n’avons pas réussi à localiser votre adresse. Veuillez renseigner une adresse plus précise – ou ré-essayez dans quelques minutes."
+        enregistrement_demandeur: "Une erreur s’est produite lors de l’enregistrement de vos informations personnelles."
       section_demandeur: "Demandeur"
       section_occupants: "Occupants"
       recapitulatif_informations: "Veuillez vérifier les champs ci-dessous et les compléter."
@@ -377,6 +378,8 @@ fr:
         tel: "Le numéro de téléphone"
         note_degradation: "La note de dégradation"
         note_insalubrite: "La note d’insalubrité"
+      occupant:
+        civilite: "La civilité"
     errors:
       models:
         projet:
@@ -385,3 +388,7 @@ fr:
               inclusion: "doit être comprise entre zéro et un."
             note_insalubrite:
               inclusion: "doit être comprise entre zéro et un."
+        occupant:
+          attributes:
+            civilite:
+              blank: "doit être renseignée."

--- a/db/migrate/20170315170006_add_civilite_to_demandeur_principal.rb
+++ b/db/migrate/20170315170006_add_civilite_to_demandeur_principal.rb
@@ -1,0 +1,26 @@
+class AddCiviliteToDemandeurPrincipal < ActiveRecord::Migration
+  def up
+    count = 0
+
+    ActiveRecord::Base.transaction do
+      Projet.find_each do |projet|
+        if projet.demandeur_principal && projet.demandeur_principal.civilite.blank?
+          begin
+            projet.demandeur_principal.civilite = Occupant.civilites.keys[0]
+            projet.demandeur_principal.save!
+            print "."
+            count += 1
+          rescue => e
+            puts "Error while migrating projet #{projet.id}: #{e}"
+          end
+        end
+      end
+    end
+
+    puts
+    puts "Filled civility of #{count} occupants."
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170313093933) do
+ActiveRecord::Schema.define(version: 20170315170006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :invitation do
-    association :projet
+    association :projet, :prospect
     association :intervenant, departements: [ '95' ], roles: [ :operateur ]
   end
   factory :mise_en_relation, parent: :invitation do

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -10,12 +10,11 @@ FactoryGirl.define do
 
     after(:create) do |projet, evaluator|
       create_list(:demandeur, 1, projet: projet)
-      create(:demande, projet: projet)
     end
 
     trait :with_demande do
       after(:build) do |projet|
-        projet.build_demande
+        create(:demande, projet: projet)
       end
     end
 
@@ -86,27 +85,32 @@ FactoryGirl.define do
 
     trait :prospect do
       statut :prospect
+      with_demande
     end
 
     trait :en_cours do
       statut :en_cours
+      with_demande
       with_committed_operateur
     end
 
     trait :proposition_enregistree do
       statut :proposition_enregistree
+      with_demande
       with_committed_operateur
       with_prestations
     end
 
     trait :proposition_acceptee do
       statut :proposition_acceptee
+      with_demande
       with_committed_operateur
       with_prestations
     end
 
     trait :transmis_pour_instruction do
       statut :transmis_pour_instruction
+      with_demande
       with_committed_operateur
       with_prestations
 
@@ -118,6 +122,7 @@ FactoryGirl.define do
     trait :en_cours_d_instruction do
       statut :en_cours_d_instruction
       opal_numero 4567
+      with_demande
       with_committed_operateur
       with_invited_instructeur
       with_invited_pris

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -4,7 +4,9 @@ FactoryGirl.define do
     reference_avis 15
     email 'prenom.nom@site.com'
     nb_occupants_a_charge 0
-    association :adresse_postale, factory: :adresse
+    annee_construction 1975
+    association :adresse_postale,   factory: [ :adresse, :rue_de_rome ]
+    association :adresse_a_renover, factory: [ :adresse, :rue_de_la_mare ]
 
     after(:create) do |projet, evaluator|
       create_list(:demandeur, 1, projet: projet)

--- a/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
+++ b/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
@@ -21,9 +21,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "je remplis mes informations personnelles" do
     signin_for_new_projet
-    within '.civilite' do
-      choose('Monsieur')
-    end
+    within '.civilite' do choose('Monsieur') end
     fill_in :projet_email, with: "demandeur@exemple.fr"
     fill_in :projet_tel,   with: "01 02 03 04 05"
     click_button I18n.t('demarrage_projet.action')
@@ -57,6 +55,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "je peux ajouter l'adresse du logement à rénover" do
     signin_for_new_projet
+    within '.civilite' do choose('Monsieur') end
     fill_in :projet_email, with: "demandeur@exemple.fr"
     fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_PORT
     click_button I18n.t('demarrage_projet.action')
@@ -70,6 +69,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
 
   scenario "j'ajoute une personne de confiance" do
     signin_for_new_projet
+    within '.civilite' do choose('Monsieur') end
     fill_in :projet_email, with: "demandeur@exemple.fr"
     page.choose I18n.t('demarrage_projet.etape1_demarrage_projet.personne_confiance_choix2')
     within '.dem-diff.ins-form' do

--- a/spec/features/2_choix_operateur/changer_projet_spec.rb
+++ b/spec/features/2_choix_operateur/changer_projet_spec.rb
@@ -19,7 +19,7 @@ feature "En tant que demandeur, j'ai accès aux données concernant mon projet" 
     end
 
     expect(find('#demandeur_principal_civilite_mr')).to be_checked
-    expect(page).to have_field('Adresse postale', with: '12 rue de la Mare, 75010 Paris')
+    expect(page).to have_field('Adresse postale', with: '65 rue de Rome, 75008 Paris')
 
     fill_in :projet_adresse_postale,   with: Fakeweb::ApiBan::ADDRESS_PORT
     fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_MARE

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe ApplicationHelper do
+  let(:projet) { FactoryGirl.build(:projet) }
+
   it "renvoie l'icone correspondant au type d'évènement" do
     expect(helper.icone_evenement('creation_projet')).to eq ('suitcase')
   end
@@ -13,14 +15,20 @@ describe ApplicationHelper do
 
   it { expect(helper.affiche_message_eligibilite('plafond_depasse')).to eq ('plafond dépassé')}
 
-  let(:projet) { FactoryGirl.build(:projet) }
+  describe "#icone_presence" do
+    context "quand la donnée existe" do
+      let(:projet) { build(:projet, annee_construction: 1975) }
+      it "renvoie l'icone effectué" do
+        expect(helper.icone_presence(projet, :annee_construction)).to eq ("<i class=\"checkmark box icon\"></i>Année de construction : ")
+      end
+    end
 
-  it "renvoie l'icone effectué si la donnée existe" do
-    expect(helper.icone_presence(projet, :adresse)).to eq ("<i class=\"checkmark box icon\"></i>Adresse : ")
-  end
-
-  it "renvoie l'icone à faire et message si la donnée n'existe pas" do
-    expect(helper.icone_presence(projet, :annee_construction)).to eq ("<i class=\"square outline icon\"></i>Année de construction :  Veuillez renseigner cette donnée")
+    context "quand la donnée n'existe pas" do
+      let(:projet) { build(:projet, annee_construction: nil) }
+      it "renvoie l'icone à faire" do
+        expect(helper.icone_presence(projet, :annee_construction)).to eq ("<i class=\"square outline icon\"></i>Année de construction :  Veuillez renseigner cette donnée")
+      end
+    end
   end
 
   context "avec une demande existante" do

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ProjetMailer, type: :mailer do
   describe "recommandation operateurs" do
-    let(:projet) { create :projet, :with_suggested_operateurs, :with_invited_pris }
+    let(:projet) { create :projet, :prospect, :with_suggested_operateurs, :with_invited_pris }
     let(:email) { ProjetMailer.recommandation_operateurs(projet) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([projet.email]) }
@@ -43,7 +43,7 @@ describe ProjetMailer, type: :mailer do
 
   describe "l'intervenant reçoit un email lorsqu'il a été choisi par le demandeur" do
     let(:operateur) { create :operateur }
-    let(:projet) { create :projet, operateur: operateur }
+    let(:projet) { create :projet, :prospect, operateur: operateur }
     let!(:invitation) { create :invitation, projet: projet, intervenant: operateur }
     let(:email) { ProjetMailer.notification_choix_intervenant(projet) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }

--- a/spec/models/occupant_spec.rb
+++ b/spec/models/occupant_spec.rb
@@ -1,14 +1,34 @@
 require 'rails_helper'
 
 describe Occupant do
-  let(:occupant) { FactoryGirl.build(:occupant) }
-  it { expect(FactoryGirl.build(:occupant)).to be_valid }
+  subject { build(:occupant) }
 
-  it { is_expected.to validate_presence_of(:nom) }
-  it { is_expected.to validate_presence_of(:prenom) }
   it { is_expected.to have_db_column(:lien_demandeur) }
   it { is_expected.to have_db_column(:civilite) }
   it { is_expected.to have_db_column(:demandeur) }
-  it { is_expected.to validate_presence_of(:date_de_naissance) }
   it { is_expected.to belong_to(:projet) }
+
+  describe "validations" do
+    it { is_expected.to be_valid }
+    it { is_expected.to validate_presence_of(:nom) }
+    it { is_expected.to validate_presence_of(:prenom) }
+    it { is_expected.to validate_presence_of(:date_de_naissance) }
+
+    context "pour un nouvel occupant" do
+      subject { build(:occupant) }
+      it { is_expected.not_to validate_presence_of(:civilite) }
+    end
+
+    context "pour un occupant existant" do
+      context "qui n'est pas le demandeur principal" do
+        subject { create(:occupant) }
+        it { is_expected.not_to validate_presence_of(:civilite) }
+      end
+
+      context "qui est le demandeur principal" do
+        subject { create(:projet).demandeur_principal }
+        it { is_expected.to validate_presence_of(:civilite) }
+      end
+    end
+  end
 end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -182,7 +182,7 @@ describe Projet do
       it { expect(projet.description_adresse).to eq adresse.description }
     end
     context "quand l'adresse est vide" do
-      let(:projet) { build :projet, adresse_postale: nil }
+      let(:projet) { build :projet, adresse_postale: nil, adresse_a_renover: nil }
       it { expect(projet.description_adresse).to be nil }
     end
   end

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -1,18 +1,73 @@
 require 'rails_helper'
-require 'support/opal_helper'
+
+class OpalClientMock
+  attr_accessor :url
+  attr_accessor :body
+
+  def post(url, options)
+    @url  = url
+    @body = options[:body]
+    response
+  end
+
+private
+  include RSpec::Mocks::ExampleMethods
+
+  def response
+    data = {
+      dosNumero: "09500840",
+      dosId:     959496
+    }
+    response = Net::HTTPResponse.new(1.1, 201, "OK")
+    allow(response).to receive(:body).and_return(data.to_json)
+    response
+  end
+end
 
 describe Opal do
-  subject { Opal.new(OpalClient) }
+  let(:client) { OpalClientMock.new }
 
   describe "#creer_dossier" do
     let(:projet) {            create :projet }
     let(:instructeur) {       create :instructeur }
     let(:agent_instructeur) { create :agent, intervenant: instructeur }
 
-    it do
-      subject.creer_dossier(projet, agent_instructeur)
-      expect(projet.opal_id).to eq('959496')
-      expect(projet.opal_numero).to eq('09500840')
+    subject! { Opal.new(client).creer_dossier(projet, agent_instructeur) }
+
+    it "envoie les informations sérialisées" do
+      body = JSON.parse(client.body)
+      expect(body["dosNumeroPlateforme"]).to eq projet.numero_plateforme
+      expect(body["dosDateDepot"]).to be_present
+      expect(body["utiIdClavis"]).to eq agent_instructeur.clavis_id
+
+      demandeur = body["demandeur"]
+      expect(demandeur["dmdNbOccupants"]).to eq 1
+      expect(demandeur["dmdRevenuOccupants"]).to eq projet.revenu_fiscal_reference_total
+
+      personne_physique = demandeur["personnePhysique"]
+      expect(personne_physique["civId"]).to eq 4
+      expect(personne_physique["pphPrenom"]).to eq "Jean"
+      expect(personne_physique["pphNom"]).to start_with "MARTIN"
+
+      adresse_postale = personne_physique["adressePostale"]
+      expect(adresse_postale["adpLigne1"]).to eq "65 rue de Rome"
+      expect(adresse_postale["adpLocalite"]).to eq "Paris"
+      expect(adresse_postale["adpCodePostal"]).to eq "75008"
+
+      immeuble = body["immeuble"]
+      expect(immeuble["immAnneeAchevement"]).to eq 1975
+
+      adresse_geographique = immeuble["adresseGeographique"]
+      expect(adresse_geographique["adgLigne1"]).to eq "12 rue de la Mare"
+      expect(adresse_geographique["cdpCodePostal"]).to eq "75010"
+      expect(adresse_geographique["comCodeInsee"]).to eq "010"
+      expect(adresse_geographique["dptNumero"]).to eq "75"
+    end
+
+    it "met à jour le dossier avec la réponse d'Opal" do
+      expect(subject).to be true
+      expect(projet.opal_id).to eq("959496")
+      expect(projet.opal_numero).to eq("09500840")
       expect(projet.statut).to eq('en_cours_d_instruction')
       expect(projet.agent_instructeur).to eq(agent_instructeur)
     end

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -45,7 +45,7 @@ describe Opal do
       expect(demandeur["dmdRevenuOccupants"]).to eq projet.revenu_fiscal_reference_total
 
       personne_physique = demandeur["personnePhysique"]
-      expect(personne_physique["civId"]).to eq 4
+      expect(personne_physique["civId"]).to eq 1
       expect(personne_physique["pphPrenom"]).to eq "Jean"
       expect(personne_physique["pphNom"]).to start_with "MARTIN"
 


### PR DESCRIPTION
- La page de démarrage du projet affiche correctement les erreurs de validation,
- La civilité du demandeur principal est maintenant obligatoire (celle des autres occupants reste optionnelle),
- La civilité du demandeur est transmise à Opal (plutôt que d'être hardcodée à "Monsieur et Madame").

## Dépend de

Ne pas merger avant :

- [x] Améliore le client Opal (#262)