### PR TITLE
PF339 spécifie à Opal une adresse sur plusieurs lignes

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,14 +19,14 @@ ActiveRecord::Schema.define(version: 20170313093933) do
   create_table "adresses", force: :cascade do |t|
     t.decimal  "latitude",               precision: 10, scale: 6
     t.decimal  "longitude",              precision: 10, scale: 6
-    t.string   "ligne_1",                                         null: false
-    t.string   "code_insee",                                      null: false
-    t.string   "code_postal",                                     null: false
-    t.string   "ville",                                           null: false
-    t.string   "departement", limit: 10,                          null: false
-    t.datetime "created_at",                                      null: false
-    t.datetime "updated_at",                                      null: false
-    t.string   "region"
+    t.string   "ligne_1",                                                      null: false
+    t.string   "code_insee",                                                   null: false
+    t.string   "code_postal",                                                  null: false
+    t.string   "ville",                                                        null: false
+    t.string   "departement", limit: 10,                                       null: false
+    t.datetime "created_at",                                                   null: false
+    t.datetime "updated_at",                                                   null: false
+    t.string   "region",                                          default: "", null: false
   end
 
   create_table "agents", force: :cascade do |t|
@@ -252,11 +252,11 @@ ActiveRecord::Schema.define(version: 20170313093933) do
     t.string   "departement"
     t.string   "email"
     t.string   "tel"
-    t.string   "themes",                                   array: true
-    t.integer  "nb_occupants_a_charge",        default: 0
+    t.string   "themes",                                                            array: true
+    t.integer  "nb_occupants_a_charge",                                 default: 0
     t.integer  "annee_construction"
     t.string   "code_insee"
-    t.integer  "statut",                       default: 0
+    t.integer  "statut",                                                default: 0
     t.integer  "operateur_id"
     t.string   "opal_numero"
     t.string   "opal_id"

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -72,5 +72,43 @@ describe Opal do
       expect(projet.agent_instructeur).to eq(agent_instructeur)
     end
   end
+
+  describe ".split_adresse_into_lines" do
+    let(:opal)              { Opal.new(client) }
+
+    subject(:adresse_lines) { opal.send(:split_adresse_into_lines, adresse) }
+
+    context "quand l'adresse est courte" do
+      let(:adresse) { "15 Rue Principale" }
+
+      it "ne fait rien" do
+        expect(adresse_lines[0]).to eq "15 Rue Principale"
+        expect(adresse_lines[1]).to eq ""
+        expect(adresse_lines[2]).to eq ""
+      end
+    end
+
+    context "quand l'adresse est longue" do
+      let(:adresse) { "15 Rue Principale (Bonnevaux le Prieuré)" }
+
+      it "sépare l'adresse selon le dernier espace rencontré" do
+        expect(adresse_lines[0]).to eq "15 Rue Principale (Bonnevaux le "
+        expect(adresse_lines[1]).to eq "Prieuré)"
+        expect(adresse_lines[2]).to eq ""
+      end
+    end
+
+    context "quand l'adresse est très longue" do
+      let(:adresse) { "1080 Boulevard Of Broken Dreams (Endroit-Fantasque-Sorti-Directement-De-Mon-Imagination-Debordante)" }
+
+      it "sépare l'adresse selon le dernier tiret rencontré" do
+        expect(adresse_lines[0]).to eq "1080 Boulevard Of Broken Dreams "
+        expect(adresse_lines[1]).to eq "(Endroit-Fantasque-Sorti-Directement-"
+        expect(adresse_lines[2]).to eq "De-Mon-Imagination-Debordante)"
+      end
+    end
+  end
 end
+
+
 


### PR DESCRIPTION
Avant :
La création d'un dossier dans Opal échouait quand la ligne d'adresse excédait 38 caractères.

Maintenant : 
On peut créer un dossier dans Opal avec une adresse de plus de 38 caractères : celles-ci est découpée en plusieurs lignes (max 3) de 38 caractères maximums