### PR TITLE
PF382 fixe le format des identifiants fiscaux

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -50,7 +50,7 @@ class Projet < ActiveRecord::Base
     self.plateforme_id = Time.now.to_i
   end
 
-  before_save :clean_numero_fiscal
+  before_save :clean_numero_fiscal, :clean_reference_avis
 
   scope :for_agent, ->(agent) {
     next where(nil) if agent.instructeur?
@@ -74,7 +74,11 @@ class Projet < ActiveRecord::Base
   end
 
   def clean_numero_fiscal
-    self.numero_fiscal.to_s.gsub(/[^\w]+/, '').upcase
+    self.numero_fiscal = numero_fiscal.to_s.gsub(/\D+/, '')
+  end
+
+  def clean_reference_avis
+    self.reference_avis = reference_avis.to_s.gsub(/\W+/, '').upcase
   end
 
   def numero_plateforme

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -51,18 +51,38 @@ describe Projet do
 
   describe '#clean_numero_fiscal' do
     let(:projet) { build :projet }
-    it {
-      projet.numero_fiscal = " 123 456 A  "
-      expect(projet.clean_numero_fiscal).to eq("123456A")
-    }
-    it {
-      projet.numero_fiscal = "123t456a"
-      expect(projet.clean_numero_fiscal).to eq("123T456A")
-    }
-    it {
-      projet.numero_fiscal = "é=123ç456à'$"
-      expect(projet.clean_numero_fiscal).to eq("123456")
-    }
+    before do
+      projet.numero_fiscal = numero_fiscal
+      projet.save!
+    end
+    context "supprime les espaces" do
+      let(:numero_fiscal) { " 123 456   " }
+      it { expect(projet.numero_fiscal).to eq("123456") }
+    end
+    context "supprime tout ce qui n’est pas un chiffre" do
+      let(:numero_fiscal) { "é=123çA456à'$" }
+      it { expect(projet.numero_fiscal).to eq("123456") }
+    end
+  end
+
+  describe '#clean_reference_avis' do
+    let(:projet) { build :projet }
+    before do
+      projet.reference_avis = reference_avis
+      projet.save!
+    end
+    context "supprime les espaces" do
+      let(:reference_avis) { " 123 456 A  " }
+      it { expect(projet.reference_avis).to eq("123456A") }
+    end
+    context "passe tout en majuscules" do
+      let(:reference_avis) { "123t456a" }
+      it { expect(projet.reference_avis).to eq("123T456A") }
+    end
+    context "supprime ce qui n’est pas un caractère alphanumérique" do
+      let(:reference_avis) { "é=123çA456à'$" }
+      it { expect(projet.reference_avis).to eq("123A456") }
+    end
   end
 
   describe '#for_agent' do


### PR DESCRIPTION
Des projets sont créés en doublon en production car l’identification est case sensitive et que la lettre de fin du numéro fiscal est facultative pour l’API Particulier.

Corrections :
* Le numéro fiscal ne peut contenir que des chiffres.
* La référence de l’avis ne peut contenir que des caractères alphanumériques.