### PR TITLE
saute temporairement la page 'avis d’impositions' lors de l’inscription

### DIFF
--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -173,7 +173,8 @@ private
 
   def etape1_redirect_to_next_step
     if needs_etape2?
-      redirect_to projet_avis_impositions_path(@projet_courant)
+      #TODO redirect_to projet_avis_impositions_path(@projet_courant)
+      redirect_to projet_occupants_path(@projet_courant)
     else
       redirect_to projet_path(@projet_courant)
     end

--- a/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
+++ b/spec/features/1_demarrage/etape1_demarrer_projet_spec.rb
@@ -62,7 +62,8 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     click_button I18n.t('demarrage_projet.action')
 
     projet.reload
-    expect(page).to have_current_path projet_avis_impositions_path(projet)
+    #TODO expect(page).to have_current_path projet_avis_impositions_path(projet)
+    expect(page).to have_current_path projet_occupants_path(projet)
     expect(projet.adresse_a_renover.ligne_1).to eq("8 Boulevard du Port")
     expect(projet.adresse_a_renover.code_postal).to eq("80000")
     expect(projet.adresse_a_renover.ville).to eq("Amiens")
@@ -81,7 +82,8 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
       fill_in 'projet_personne_attributes_lien_avec_demandeur', with: "Mon jazzman favori et neanmoins concubin"
     end
     click_button I18n.t('demarrage_projet.action')
-    expect(page.current_path).to eq(projet_avis_impositions_path(projet))
+    #TODO expect(page.current_path).to eq(projet_avis_impositions_path(projet))
+    expect(page.current_path).to eq(projet_occupants_path(projet))
     projet.reload
     expect(projet.personne.civilite).to eq('Mr')
     expect(projet.personne.prenom).to eq("Frank")


### PR DESCRIPTION
Pour réaliser une MEP urgente nous cachons temporairement la page des avis d’imposition lors de l’inscription.