### PR TITLE
Bugfix corrige la taille des lignes 39 -> 38

### DIFF
--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -92,14 +92,14 @@ private
   def split_adresse_into_lines(adresse)
     return [adresse, '', ''] if adresse.length <= MAX_ADDRESS_LINE_LENGTH
 
-    split_index = adresse.rindex(/\s|-/, MAX_ADDRESS_LINE_LENGTH)
+    split_index = adresse.rindex(/\s|-/, MAX_ADDRESS_LINE_LENGTH-1)
     ligne_1 = adresse[0..split_index]
     ligne_2 = adresse[(split_index+1)..-1]
 
     return [ligne_1, ligne_2, ''] if ligne_2.length <= MAX_ADDRESS_LINE_LENGTH
 
     old_ligne_2 = ligne_2
-    split_index = old_ligne_2.rindex(/\s|-/, MAX_ADDRESS_LINE_LENGTH)
+    split_index = old_ligne_2.rindex(/\s|-/, MAX_ADDRESS_LINE_LENGTH-1)
     ligne_2 = old_ligne_2[0..split_index]
     ligne_3 = old_ligne_2[(split_index+1)..-1]
 

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -107,6 +107,16 @@ describe Opal do
         expect(adresse_lines[2]).to eq "De-Mon-Imagination-Debordante)"
       end
     end
+
+    context "quand l’adresse est trop longue" do
+      let(:adresse) { "Boulevard du Président John Fitzgerald Kennedy et il faut rajouter des mots" }
+
+      it "découpe en lignes de moins de 38 caractères" do
+        expect(adresse_lines[0].length).to be <= 38
+        expect(adresse_lines[1].length).to be <= 38
+        expect(adresse_lines[2].length).to be <= 38
+      end
+    end
   end
 end
 


### PR DESCRIPTION
J'avais pas assez testé ... La taille des lignes retournées étaient de 39 caractères max au lieu de 38