### PR TITLE
PF340 fixe l’encodage CAS (ISO-8859-1 => UTF8)

### DIFF
--- a/config/initializers/casclient_override.rb
+++ b/config/initializers/casclient_override.rb
@@ -2,8 +2,10 @@ module CASClient
   module XmlResponse
     alias_method :check_and_parse_xml_normally, :check_and_parse_xml
     def check_and_parse_xml(raw_xml)
-      cooked_xml = raw_xml.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+      raw_xml.force_encoding Encoding::ISO_8859_1
+      cooked_xml = raw_xml.encode Encoding::UTF_8
       check_and_parse_xml_normally(cooked_xml)
     end
   end
 end
+


### PR DESCRIPTION
L’encodage fourni par Clavis est de l’XML en ISO-8859-1 qui n’était pas reconnu (ASCII-8BIT par défaut) : les lettres accentuées étaient ignorées.
Solution : on force son encodage puis on le convertit en UTF8.

![pf340](https://cloud.githubusercontent.com/assets/2368859/24199981/d1956742-0f0b-11e7-98a4-5abe5f5a289a.gif)
