### PR TITLE
Améliore la connexion Clavis en cas d'intervenant inconnu

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -38,7 +38,11 @@ class Agent < ActiveRecord::Base
       when :Id
         self.clavis_id = valeur
       when :ServiceId
-        self.intervenant = Intervenant.find_by_clavis_service_id(valeur)
+        intervenant = Intervenant.find_by_clavis_service_id(valeur)
+        if intervenant.blank?
+          logger.warn "Agent #{id} : aucun intervenant trouvé pour le ServiceId '#{valeur}'"
+        end
+        self.intervenant = intervenant
       end
     end
   end

--- a/db/seeds/001_intervenants.rb
+++ b/db/seeds/001_intervenants.rb
@@ -41,7 +41,7 @@ class Seeder
     {
       departements: ["88"],
       raison_sociale: "DDT des VOSGES",
-      clavis_service_id: "5519",
+      clavis_service_id: "5119",
       adresse_postale: "22-26 Avenue Dutac, 88000 Épinal",
       email: "delegation88-1@anah.gouv.fr",
       roles: ["instructeur"]


### PR DESCRIPTION
Les comptes `delegation88-1@anah.gouv.fr` et `delegation88-2@anah.gouv.fr` ne pouvaient plus se connecter en intégration.

Après analyse, c'est parce que l'intervenant associé existait, mais n'avait pas le bon Id de service Clavis.

Dans cette PR  :

- Correction de l'id de service de la DDT des Vosges en intégration,
- On enregistre maintenant un message d'avertissement dans les logs en cas de connexion avec un identifiant de service inconnu ; ça aidera à déboguer pour les prochaines fois.