### PR TITLE
Affiche les logs immédiatements dans foreman

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,7 @@
+# Print console logs immediately (instead of buffering them)
+# See https://github.com/ddollar/foreman/wiki/Missing-Output
+$stdout.sync = true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
Depuis la mise à jour de foreman, les logs Rails ne s'affichent pas immédiatement dans la console.

C'est parce que Ruby met en tampon les données de log. Il faut désactiver manuellement ce comportement en développement pour voir les logs immédiatement.

Cf. https://github.com/ddollar/foreman/wiki/Missing-Output