### PR TITLE
PF336 message éligibilité

### DIFF
--- a/app/views/projets/_projet_envisage.html.slim
+++ b/app/views/projets/_projet_envisage.html.slim
@@ -2,6 +2,8 @@ article.block.projet
   h3 Projet envisagé
   = link_to t('projets.visualisation.lien_edition'), etape2_description_projet_path(@projet_courant), class: 'edit'
   .content-block
+    - if @projet_courant.preeligibilite(@projet_courant.annee_fiscale_reference) == :plafond_depasse
+      p.alert.alert-warning = t('projets.visualisation.non_eligible')
     - if @projet_courant.demande.blank?
       - if current_agent
         p Le demandeur n’a pas encore rempli le projet.

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -235,6 +235,7 @@ fr:
         titre: 'Félicitations %{demandeur_principal}'
         corps: Votre projet démarre aujourd’hui.
     visualisation:
+      non_eligible: "D’après les éléments renseignés, vous n’êtes à priori pas éligible, pour s’en assurer un complément d'étude de votre situation va être prochainement réalisé. Un interlocuteur va prendre contact avec vous. Si vous n’êtes pas recontacté dans un délai d’une semaine merci de bien vouloir contacter le Point Rénovation Infoservice ou l’opérateur de l’opération programmée […] : Tel…"
       lien_edition_projet: 'Modifier le projet'
       lien_edition: 'Modifier'
       lien_edition_coordonnees: 'Modifier mes coordonnées'

--- a/spec/features/2_choix_operateur/changer_projet_spec.rb
+++ b/spec/features/2_choix_operateur/changer_projet_spec.rb
@@ -3,44 +3,57 @@ require 'support/mpal_features_helper'
 require 'support/api_ban_helper'
 
 feature "En tant que demandeur, j'ai accès aux données concernant mon projet" do
-  let(:projet) { create(:projet, :prospect, :with_invited_operateur) }
+  context "quand mon projet est éligible" do
+    let(:projet) { create(:projet, :prospect, :with_invited_operateur) }
 
-  scenario "je peux consulter mon projet en me connectant" do
-    signin(projet.numero_fiscal, projet.reference_avis)
-    @role_utilisateur = :demandeur
-    expect(page).to have_content("Jean Martin")
-    expect(page).to have_content("Total Revenu Fiscal de Référence")
-  end
-
-  scenario "je peux modifier mes données personnelles" do
-    signin(projet.numero_fiscal, projet.reference_avis)
-    within 'article.occupants' do
-      click_link I18n.t('projets.visualisation.lien_edition')
+    scenario "je peux consulter mon projet en me connectant" do
+      signin(projet.numero_fiscal, projet.reference_avis)
+      @role_utilisateur = :demandeur
+      expect(page).to have_content("Jean Martin")
+      expect(page).to have_content("Total Revenu Fiscal de Référence")
+      expect(page).not_to have_content(I18n.t('projets.visualisation.non_eligible'))
     end
 
-    expect(find('#demandeur_principal_civilite_mr')).to be_checked
-    expect(page).to have_field('Adresse postale', with: '65 rue de Rome, 75008 Paris')
+    scenario "je peux modifier mes données personnelles" do
+      signin(projet.numero_fiscal, projet.reference_avis)
+      within 'article.occupants' do
+        click_link I18n.t('projets.visualisation.lien_edition')
+      end
 
-    fill_in :projet_adresse_postale,   with: Fakeweb::ApiBan::ADDRESS_PORT
-    fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_MARE
-    fill_in :projet_tel, with: '01 10 20 30 40'
+      expect(find('#demandeur_principal_civilite_mr')).to be_checked
+      expect(page).to have_field('Adresse postale', with: '65 rue de Rome, 75008 Paris')
 
-    click_button I18n.t('projets.edition.action')
+      fill_in :projet_adresse_postale,   with: Fakeweb::ApiBan::ADDRESS_PORT
+      fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_MARE
+      fill_in :projet_tel, with: '01 10 20 30 40'
 
-    expect(page).to have_content('01 10 20 30 40')
-    expect(page).to have_current_path projet_path(projet)
-    expect(page).to have_content Fakeweb::ApiBan::ADDRESS_PORT
-    expect(page).to have_content Fakeweb::ApiBan::ADDRESS_MARE
+      click_button I18n.t('projets.edition.action')
+
+      expect(page).to have_content('01 10 20 30 40')
+      expect(page).to have_current_path projet_path(projet)
+      expect(page).to have_content Fakeweb::ApiBan::ADDRESS_PORT
+      expect(page).to have_content Fakeweb::ApiBan::ADDRESS_MARE
+    end
+
+    scenario "je peux modifier les données concernant mon habitation et mon projet" do
+      signin(projet.numero_fiscal, projet.reference_avis)
+      within 'article.projet' do
+        click_link I18n.t('projets.visualisation.lien_edition')
+      end
+      fill_in :demande_annee_construction, with: '1950'
+      click_button I18n.t('projets.edition.action')
+      expect(page).to have_content(1950)
+      # TODO: tester la modification des travaux demandés
+    end
   end
 
-  scenario "je peux modifier les données concernant mon habitation et mon projet" do
-    signin(projet.numero_fiscal, projet.reference_avis)
-    within 'article.projet' do
-      click_link I18n.t('projets.visualisation.lien_edition')
+  context "quand mon projet n'est pas éligible" do
+    let(:projet) { Projet.last }
+
+    scenario "je suis notifié de ma non éligibilité" do
+      signin_for_new_projet_non_eligible
+      visit projet_path(projet)
+      expect(page).to have_content(I18n.t('projets.visualisation.non_eligible'))
     end
-    fill_in :demande_annee_construction, with: '1950'
-    click_button I18n.t('projets.edition.action')
-    expect(page).to have_content(1950)
-    # TODO: tester la modification des travaux demandés
   end
 end

--- a/spec/services/api_particulier_spec.rb
+++ b/spec/services/api_particulier_spec.rb
@@ -6,7 +6,7 @@ describe ApiParticulier do
     Rails.cache.clear
   end
 
-  context "on success" do
+  context "eligible" do
     it "renvoie un objet Contribuable" do
       contribuable = subject.retrouve_contribuable(12, 15)
 
@@ -25,6 +25,29 @@ describe ApiParticulier do
       expect(first_response).not_to be_nil
 
       second_response = subject.retrouve_contribuable(12, 15)
+      expect(second_response).not_to be_nil
+    end
+  end
+
+  context "non_eligible" do
+    it "renvoie un objet Contribuable" do
+      contribuable = subject.retrouve_contribuable(13, 16)
+
+      expect(contribuable.declarants[0][:prenom]).to eq('Pierre')
+      expect(contribuable.declarants[0][:nom]).to eq('Martin')
+      expect(contribuable.annee_impots).to eq('2015')
+      expect(contribuable.nombre_personnes_charge).to eq(0)
+      expect(contribuable.adresse).to eq('12 rue de la Mare, 75010 Paris')
+      expect(contribuable.revenu_fiscal_reference).to eq(1000000)
+    end
+
+    it "met en cache le résultat" do
+      expect(subject).to receive(:requete_contribuable).once.and_call_original
+
+      first_response = subject.retrouve_contribuable(13, 16)
+      expect(first_response).not_to be_nil
+
+      second_response = subject.retrouve_contribuable(13, 16)
       expect(second_response).not_to be_nil
     end
   end

--- a/spec/support/api_particulier_helper.rb
+++ b/spec/support/api_particulier_helper.rb
@@ -4,9 +4,11 @@ module Fakeweb
   class ApiParticulier
     NUMERO_FISCAL  = 12
     REFERENCE_AVIS = 15
+    NUMERO_FISCAL_NON_ELIGIBLE = 13
+    REFERENCE_AVIS_NON_ELIGIBLE = 16
     INVALID = 'INVALID'
 
-    def self.register_success
+    def self.register_eligible
       FakeWeb.register_uri(
         :get, "https://#{ENV['API_PARTICULIER_DOMAIN']}/api/impots/svair?numeroFiscal=#{NUMERO_FISCAL}&referenceAvis=#{REFERENCE_AVIS}",
         content_type: 'application/json',
@@ -26,6 +28,26 @@ module Fakeweb
       )
     end
 
+    def self.register_non_eligible
+      FakeWeb.register_uri(
+          :get, "https://#{ENV['API_PARTICULIER_DOMAIN']}/api/impots/svair?numeroFiscal=#{NUMERO_FISCAL_NON_ELIGIBLE}&referenceAvis=#{REFERENCE_AVIS_NON_ELIGIBLE}",
+          content_type: 'application/json',
+          body: JSON.generate({
+            "declarant1": {
+                "nom": "Martin",
+                "prenoms": "Pierre",
+                "dateNaissance": "19/03/1980"
+            },
+            "anneeImpots": "2015",
+            "nombrePersonnesCharge": 0,
+            "foyerFiscal": {
+                "adresse": "12 rue de la Mare, 75010 Paris"
+            },
+            "revenuFiscalReference": 1000000
+        }),
+      )
+    end
+
     def self.register_invalid
       FakeWeb.register_uri(
         :get, "https://#{ENV['API_PARTICULIER_DOMAIN']}/api/impots/svair?numeroFiscal=#{INVALID}&referenceAvis=#{INVALID}",
@@ -39,7 +61,8 @@ end
 
 RSpec.configure do |config|
   config.before(:each) do
-    Fakeweb::ApiParticulier.register_success
+    Fakeweb::ApiParticulier.register_eligible
+    Fakeweb::ApiParticulier.register_non_eligible
     Fakeweb::ApiParticulier.register_invalid
   end
 end

--- a/spec/support/mpal_features_helper.rb
+++ b/spec/support/mpal_features_helper.rb
@@ -11,6 +11,10 @@ def signin_for_new_projet
   signin(Fakeweb::ApiParticulier::NUMERO_FISCAL, Fakeweb::ApiParticulier::REFERENCE_AVIS)
 end
 
+def signin_for_new_projet_non_eligible
+  signin(Fakeweb::ApiParticulier::NUMERO_FISCAL_NON_ELIGIBLE, Fakeweb::ApiParticulier::REFERENCE_AVIS_NON_ELIGIBLE)
+end
+
 def authenticate_as_admin_with_token
   # L'environnement est mocké car CircleCI ne permet pas d'exposer des
   # variables d'environnement lors des builds de Pull requests.


### PR DESCRIPTION
Ajout d'un message prévenant l'agent que le projet n'est à prioris par éligible

<img width="1208" alt="capture d ecran 2017-03-22 a 17 08 02" src="https://cloud.githubusercontent.com/assets/24429245/24207979/ac452fe2-0f22-11e7-937b-4656036ad212.png">

