### PR TITLE
Refactore les checkboxes de confirmation

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -89,8 +89,8 @@ $(document).ready(function() {
   }
 
   function updateSubmitButton() {
-    var isChecked = $(".js-engagement").prop("checked");
-    var submit_btn = $('button');
+    var isChecked = $("input[type=checkbox].js-engagement").prop("checked");
+    var submit_btn = $('button.js-engagement');
     if (isChecked) {
       submit_btn.removeProp('disabled');
     } else {

--- a/app/views/choix_operateur/new.html.slim
+++ b/app/views/choix_operateur/new.html.slim
@@ -42,5 +42,5 @@
                   = btn tag: :a, name: t('projets.visualisation.invitation_intervenant')
           hr/
         = render 'demarrage_projet/etape3_disponibilite_form'
-        = btn name: @action_label, class: 'btn-large btn-centered', icon: 'ok'
+        = btn name: @action_label, class: 'btn-large btn-centered js-engagement', icon: 'ok'
     </div><!-- Workaround for allowing slim to honor the scope of the submit tag -->

--- a/app/views/demarrage_projet/etape3_mise_en_relation.html.slim
+++ b/app/views/demarrage_projet/etape3_mise_en_relation.html.slim
@@ -11,5 +11,5 @@
         p.chapo Il pourra vous recommander un opérateur chargé de vous accompagner tout au long de votre démarche.
         = hidden_field_tag :intervenant, @pris_departement.id
         = render 'etape3_disponibilite_form'
-      = btn name: @action_label, class: 'btn-large btn-centered', icon: 'ok'
+      = btn name: @action_label, class: 'btn-large btn-centered js-engagement', icon: 'ok'
     </div><!-- Workaround for allowing slim to honor the scope of the submit tag -->

--- a/app/views/engagement_operateur/new.html.slim
+++ b/app/views/engagement_operateur/new.html.slim
@@ -2,7 +2,7 @@ section.popin-form
   h2 S’engager avec l’opérateur qui vous accompagnera
   ul.ins-form
     li.checkbox
-      input#confirm type="checkbox" class="engagement"
+      input#confirm type="checkbox" class="js-engagement"
       label for="confirm"
         | Je m’engage avec "
         span.operator= @operateur.raison_sociale
@@ -14,5 +14,5 @@ section.popin-form
         br/
         | Je confirmerai par la suite tous les éléments de ma demande de subvention avant transmission au service instructeur.
   = form_tag(projet_engagement_operateur_path(@projet_courant, operateur_id: @operateur.id), method: 'post', class: 'ui form') do
-    = submit_tag t('projets.visualisation.engagement_action'), class:'btn'
+    = btn name: t('projets.visualisation.engagement_action'), class:'js-engagement'
 

--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -41,5 +41,5 @@
     .checkbox-validation
       input#dif1 type="checkbox" class="js-engagement"
       label for="dif1" = t('agrements.attestation_communiquer_infos_occupants')
-  = btn name: 'Valider', class: 'btn-large btn-centered', icon: 'ok'
+  = btn name: 'Valider', class: 'btn-large btn-centered js-engagement', icon: 'ok'
 

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -71,7 +71,7 @@
           abbr.login-fields__mentions-abbr title=("Agence nationale de l’habitat") Anah
           |  à récupérer auprès de la direction générale des finances publiques mes coordonnées ainsi que mon 
           abbr.login-fields__mentions-abbr title=("Revenu fiscal de référence") RFR
-      = btn name: t('sessions.nouvelle.action'), icon: 'log-in', class: 'login-fields__btn js-login-btn'
+      = btn name: t('sessions.nouvelle.action'), icon: 'log-in', class: 'login-fields__btn js-login-btn js-engagement'
 
   - if Tools.demo?
     = render 'demo'

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -75,7 +75,7 @@ fr:
 
   # ----------------------- Liste des messages à caractère juridique ---------------------
   agrements:
-    attestation_communiquer_infos_occupants: "J’atteste avoir obtenu l’accord de l’ensemble des occupants de mon logement pour communiquer leurs informations fiscales, et j’autorise l’Anah à vérifier leur RFR auprès de la direction générale des finances publiques."
+    attestation_communiquer_infos_occupants: "J’atteste avoir obtenu l’accord de l’ensemble des occupants de mon logement pour communiquer leurs informations fiscales, et j’autorise l’Anah à vérifier leur revenu fiscal de référence auprès de la direction générale des finances publiques."
     autorisation_acces_donnees_intervenants: "Je suis informé(e) que les intervenants avec lesquels je vais être mis(e) en relation ou que je vais inviter à consulter mon dossier ont accès aux données que j’ai renseignées."
   # ----------------------- Liste des liens du menu bas ---------------------
   menu_bas:


### PR DESCRIPTION
Aujourd'hui les checkboxes qui activent ou désactivent le bouton de confirmation du formulaire agissent en fait sur _tous les boutons du formulaire_.

Ça devient vite pénible quand on veut plusieurs boutons qui font plusieurs actions. Et je vais en avoir besoin sur la page de CRUD des occupants.

Cette PR refactore ce comportement pour n'activer/désactiver que les boutons marqués comme `js-engagement` (comme les checkboxes).

Normalement c'est transparent, il n'y a pas de modification fonctionnelle.

<img width="556" alt="capture d ecran 2017-03-27 a 11 50 02" src="https://cloud.githubusercontent.com/assets/179923/24350768/c57194d2-12e3-11e7-84c6-0b89a8f1336c.png">
