### PR TITLE
PF342 gère les occupants depuis l’avis d’imposition

### DIFF
--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -59,7 +59,7 @@ private
 
     def projet_params
       attributs = params.require(:projet)
-      .permit(:disponibilite, :description, :email, :tel, :annee_construction, :nb_occupants_a_charge,
+      .permit(:disponibilite, :description, :email, :tel, :annee_construction,
               :type_logement, :etage, :nb_pieces, :surface_habitable, :etiquette_avant_travaux,
               :niveau_gir, :autonomie, :handicap, :demandeur_salarie, :entreprise_plus_10_personnes,
               :note_degradation, :note_insalubrite, :ventilation_adaptee, :presence_humidite, :auto_rehabilitation,

--- a/app/models/avis_imposition.rb
+++ b/app/models/avis_imposition.rb
@@ -1,6 +1,6 @@
 class AvisImposition < ActiveRecord::Base
   belongs_to :projet
-  has_many :occupants, dependent: :destroy
+  has_many :occupants, -> { order "id" }, dependent: :destroy
 
   validates :numero_fiscal, :reference_avis, :annee, presence: true
   validates :numero_fiscal, uniqueness: { scope: :projet_id, case_sensitive: false }

--- a/app/models/occupant.rb
+++ b/app/models/occupant.rb
@@ -4,8 +4,7 @@ class Occupant < ActiveRecord::Base
   enum lien_demandeur: [ 'père/mère', 'enfant', 'frère/soeur', 'conjoint']
 
   belongs_to :avis_imposition
-  belongs_to :projet
-  # TODO: delegate :projet, to: :avis_imposition
+  delegate :projet, to: :avis_imposition
 
   validates :nom, :prenom, :date_de_naissance, presence: true
   validates :civilite, presence: true, on: :update, if: :require_civilite?

--- a/app/services/projet_initializer.rb
+++ b/app/services/projet_initializer.rb
@@ -12,7 +12,6 @@ class ProjetInitializer
 
     projet.reference_avis = reference_avis
     projet.numero_fiscal = numero_fiscal
-    projet.nb_occupants_a_charge = contribuable.nombre_personnes_charge
 
     begin
       projet.adresse_postale = self.precise_adresse(contribuable.adresse)
@@ -46,7 +45,6 @@ class ProjetInitializer
         nom: declarant[:nom],
         prenom: declarant[:prenom],
         date_de_naissance: "#{declarant[:date_de_naissance]}",
-        projet: projet,
         declarant: true,
         demandeur: is_new_project && 0 == index
       )
@@ -54,10 +52,9 @@ class ProjetInitializer
 
     contribuable.nombre_personnes_charge.times do |index|
       avis_imposition.occupants.build(
-        nom: "Occupant #{declarant_count + index + 1}",
+        nom:    "Occupant #{declarant_count + index + 1}",
         prenom: "Occupant #{declarant_count + index + 1}",
         date_de_naissance: "1970-01-01", # TODO: obligatoire :(
-        projet: projet,
         declarant: false,
         demandeur: false
       )

--- a/spec/controllers/demarrage_projet_controller_spec.rb
+++ b/spec/controllers/demarrage_projet_controller_spec.rb
@@ -3,7 +3,7 @@ require 'support/mpal_helper'
 require 'support/api_ban_helper'
 
 describe DemarrageProjetController do
-  let(:projet) { create :projet, :prospect, :with_two_demandeurs }
+  let(:projet) { create :projet, :prospect, demandeurs_count: 2 }
 
   before(:each) do
     authenticate_as_particulier(projet.numero_fiscal)

--- a/spec/factories/avis_impositions.rb
+++ b/spec/factories/avis_impositions.rb
@@ -3,6 +3,19 @@ FactoryGirl.define do
     numero_fiscal 12
     reference_avis 15
     annee 2015
-    projet
+
+    association :projet, strategy: :build
+
+    factory :avis_imposition_with_occupants do
+      transient do
+        demandeurs_count 1
+        occupants_a_charge_count 0
+      end
+
+      after(:create) do |avis_imposition, evaluator|
+        create_list(:demandeur, evaluator.demandeurs_count, avis_imposition: avis_imposition)
+        create_list(:occupant, evaluator.occupants_a_charge_count, avis_imposition: avis_imposition)
+      end
+    end
   end
 end

--- a/spec/factories/occupants.rb
+++ b/spec/factories/occupants.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     prenom 'Jean'
     date_de_naissance '20/06/1977'
     civilite 'mr'
-    projet
+    avis_imposition
   end
 
   factory :demandeur, parent: :occupant do

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -3,19 +3,30 @@ FactoryGirl.define do
     numero_fiscal 12
     reference_avis 15
     email 'prenom.nom@site.com'
-    nb_occupants_a_charge 0
     annee_construction 1975
     association :adresse_postale,   factory: [ :adresse, :rue_de_rome ]
     association :adresse_a_renover, factory: [ :adresse, :rue_de_la_mare ]
 
-    after(:create) do |projet, evaluator|
-      create_list(:demandeur, 1, projet: projet)
+    trait :with_avis_imposition do
+      transient do
+        demandeurs_count 1
+        occupants_a_charge_count 0
+      end
+
+      after(:create) do |projet, evaluator|
+        create(:avis_imposition_with_occupants,
+          projet: projet,
+          numero_fiscal: projet.numero_fiscal,
+          reference_avis: projet.reference_avis,
+          demandeurs_count: evaluator.demandeurs_count,
+          occupants_a_charge_count: evaluator.occupants_a_charge_count)
+      end
     end
 
-    trait :with_two_demandeurs do
-      after(:create) do |projet|
-        create_list(:demandeur, 1, projet: projet)
-      end
+    trait :with_demandeurs do
+      with_avis_imposition
+      demandeurs_count 2
+      occupants_a_charge_count 2
     end
 
     trait :with_demande do
@@ -91,17 +102,20 @@ FactoryGirl.define do
 
     trait :prospect do
       statut :prospect
+      with_demandeurs
       with_demande
     end
 
     trait :en_cours do
       statut :en_cours
+      with_demandeurs
       with_demande
       with_committed_operateur
     end
 
     trait :proposition_enregistree do
       statut :proposition_enregistree
+      with_demandeurs
       with_demande
       with_committed_operateur
       with_prestations
@@ -109,6 +123,7 @@ FactoryGirl.define do
 
     trait :proposition_acceptee do
       statut :proposition_acceptee
+      with_demandeurs
       with_demande
       with_committed_operateur
       with_prestations
@@ -116,6 +131,7 @@ FactoryGirl.define do
 
     trait :transmis_pour_instruction do
       statut :transmis_pour_instruction
+      with_demandeurs
       with_demande
       with_committed_operateur
       with_prestations
@@ -128,6 +144,7 @@ FactoryGirl.define do
     trait :en_cours_d_instruction do
       statut :en_cours_d_instruction
       opal_numero 4567
+      with_demandeurs
       with_demande
       with_committed_operateur
       with_invited_instructeur

--- a/spec/features/2_choix_operateur/changer_occupants_spec.rb
+++ b/spec/features/2_choix_operateur/changer_occupants_spec.rb
@@ -23,7 +23,6 @@ feature "Renseigner et modifier des occupants" do
       signin(projet.numero_fiscal, projet.reference_avis)
       Projet.last.demande = FactoryGirl.create(:demande)
       click_link I18n.t('projets.visualisation.modifier_liste_occupant')
-      fill_in 'projet_nb_occupants_a_charge', with: 2
       click_button I18n.t('projets.composition_logement.edition.action')
       expect(page).to have_content('2 occupants à charge')
     end

--- a/spec/features/informations_legales_spec.rb
+++ b/spec/features/informations_legales_spec.rb
@@ -4,7 +4,7 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature "Les informations légales concernant la plateforme sont disponibles" do
-  let(:projet) { create :projet }
+  let(:projet) { create :projet, :prospect }
 
   context "en tant que visiteur" do
     scenario "je peux consulter les mentions légales" do

--- a/spec/features/service_messagerie_spec.rb
+++ b/spec/features/service_messagerie_spec.rb
@@ -6,7 +6,7 @@ require 'support/api_ban_helper'
 feature 'messagerie' do
   let(:message_demandeur) { "Bonjour ! J'ai une question sur mon projet." }
   let(:message_operateur) { "J'attend votre question." }
-  let(:projet)            { create :projet }
+  let(:projet)            { create :projet, :prospect }
   let(:operateur)         { create :operateur, departements: [projet.departement] }
   let(:agent_operateur)   { create :agent, intervenant: operateur }
   let!(:invitation)       { create :invitation, intervenant: operateur, projet: projet }

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -13,7 +13,7 @@ feature "Identification :" do
 end
 
 feature "Réinitialisation de la session :" do
-  let(:projet) {          create :projet }
+  let(:projet) {          create :projet, :prospect }
   let(:invitation) {      create :invitation }
   let(:operateur) {       create :operateur, departements: [projet.departement] }
   let(:agent_operateur) { create :agent, intervenant: operateur }

--- a/spec/features/visualiser_volet_lateral_spec.rb
+++ b/spec/features/visualiser_volet_lateral_spec.rb
@@ -5,7 +5,7 @@ require 'support/api_ban_helper'
 
 feature "Les information personnelles syntéthiques sont visibles" do
   let(:personne)        { create :personne }
-  let(:projet)          { create :projet, personne: personne }
+  let(:projet)          { create :projet, :prospect, personne: personne }
   let(:operateur)       { create :operateur, departements: [projet.departement] }
   let(:agent_operateur) { create :agent, intervenant: operateur }
   let!(:invitation)     { create :invitation, intervenant: operateur, projet: projet }

--- a/spec/models/avis_imposition_spec.rb
+++ b/spec/models/avis_imposition_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe AvisImposition do
-  it { expect(FactoryGirl.create(:avis_imposition)).to be_valid }
+  it { expect(build(:avis_imposition)).to be_valid }
 
   it { is_expected.to validate_presence_of(:numero_fiscal) }
   it { is_expected.to validate_presence_of(:reference_avis) }

--- a/spec/models/occupant_spec.rb
+++ b/spec/models/occupant_spec.rb
@@ -6,7 +6,6 @@ describe Occupant do
   it { is_expected.to have_db_column(:lien_demandeur) }
   it { is_expected.to have_db_column(:civilite) }
   it { is_expected.to have_db_column(:demandeur) }
-  it { is_expected.to belong_to(:projet) }
 
   describe "validations" do
     it { is_expected.to be_valid }
@@ -26,7 +25,7 @@ describe Occupant do
       end
 
       context "qui est le demandeur principal" do
-        subject { create(:projet).demandeur_principal }
+        subject { create(:projet, :with_demandeurs).demandeur_principal }
         it { is_expected.to validate_presence_of(:civilite) }
       end
     end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -12,7 +12,6 @@ describe Projet do
     it { is_expected.to validate_presence_of(:adresse_postale).on(:update) }
     it { is_expected.not_to validate_presence_of(:email) }
     it { is_expected.not_to validate_presence_of(:tel) }
-    it { is_expected.to validate_numericality_of(:nb_occupants_a_charge).is_greater_than_or_equal_to(0) }
     it { is_expected.to validate_inclusion_of(:note_degradation).in_range(0..1) }
     it { is_expected.to validate_inclusion_of(:note_insalubrite).in_range(0..1) }
     it { is_expected.to have_one :demande }
@@ -111,7 +110,6 @@ describe Projet do
   describe "#find_by_locator" do
     let(:projet) { create :projet }
 
-
     context "avec un id de dossier" do
       let(:locator) { projet.id }
       it { expect(Projet.find_by_locator(locator)).to eq(projet) }
@@ -133,12 +131,9 @@ describe Projet do
     end
   end
 
-  # TODO: `nb_occupants_a_charge` est maintenant le nombre d’occupants créés,
-  # besoin d’un refactoring pour utiliser `projet.occupants.count` en utisant un `through: :avis_impositions`
   describe '#nb_occupants_a_charge' do
-    let(:projet) { create :projet, nb_occupants_a_charge: 1 }
-    let!(:occupant_2) { create :occupant, projet: projet }
-    it { expect(projet.nb_total_occupants).to eq(2) }
+    let(:projet) { create :projet, :with_demandeurs, demandeurs_count: 1, occupants_a_charge_count: 2 }
+    it { expect(projet.nb_occupants_a_charge).to eq(2) }
   end
 
   describe '#annee_fiscale_reference' do
@@ -151,23 +146,21 @@ describe Projet do
 
   describe '#preeligibilite' do
     let(:annee) { 2015 }
-    let(:projet) { create :projet, nb_occupants_a_charge: 2 }
-    let!(:occupant) { create :occupant, projet: projet }
-    let!(:avis_imposition) { create :avis_imposition, projet: projet, annee: annee }
+    let(:projet) { create :projet, :with_avis_imposition, demandeurs_count: 2, occupants_a_charge_count: 2 }
     it { expect(projet.preeligibilite(annee)).to eq(:tres_modeste) }
   end
 
   describe '#nom_occupants' do
-    let(:projet) { create :projet }
+    let(:projet) { create :projet, :with_demandeurs, demandeurs_count: 2, occupants_a_charge_count: 0 }
     let(:occupant_1) { projet.occupants.first }
-    let!(:occupant_2) { create :occupant, projet: projet }
+    let(:occupant_2) { projet.occupants.last }
     it { expect(projet.nom_occupants).to eq("#{occupant_1.nom.upcase} ET #{occupant_2.nom.upcase}") }
   end
 
   describe '#prenom_occupants' do
-    let(:projet) { create :projet }
+    let(:projet) { create :projet, :with_demandeurs, demandeurs_count: 2, occupants_a_charge_count: 0 }
     let(:occupant_1) { projet.occupants.first }
-    let!(:occupant_2) { create :occupant, projet: projet }
+    let(:occupant_2) { projet.occupants.last }
     it { expect(projet.prenom_occupants).to eq("#{occupant_1.prenom.capitalize} et #{occupant_2.prenom.capitalize}") }
   end
 
@@ -219,16 +212,13 @@ describe Projet do
   end
 
   describe "#change_demandeur" do
-    context "avec 2 demandeurs" do
-      let(:projet)    { create :projet, :prospect, :with_two_demandeurs}
+    let(:projet) { create :projet, :with_demandeurs }
 
-      it "change le demandeur" do
-        expect(projet.occupants.count).to be 2
-        expect(projet.demandeur_principal).to eq projet.occupants.first
-        new_demandeur_principal = projet.occupants.last
-        projet.change_demandeur(new_demandeur_principal.id)
-        expect(projet.demandeur_principal).to eq new_demandeur_principal
-      end
+    it "change le demandeur" do
+      expect(projet.demandeur_principal).to eq projet.occupants.first
+      new_demandeur_principal = projet.occupants.last
+      projet.change_demandeur(new_demandeur_principal.id)
+      expect(projet.demandeur_principal).to eq new_demandeur_principal
     end
   end
 

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -28,7 +28,7 @@ describe Opal do
   let(:client) { OpalClientMock.new }
 
   describe "#creer_dossier" do
-    let(:projet) {            create :projet }
+    let(:projet) {            create :projet, :transmis_pour_instruction, demandeurs_count: 1, occupants_a_charge_count: 1 }
     let(:instructeur) {       create :instructeur }
     let(:agent_instructeur) { create :agent, intervenant: instructeur }
 
@@ -41,12 +41,12 @@ describe Opal do
       expect(body["utiIdClavis"]).to eq agent_instructeur.clavis_id
 
       demandeur = body["demandeur"]
-      expect(demandeur["dmdNbOccupants"]).to eq 1
+      expect(demandeur["dmdNbOccupants"]).to eq 2
       expect(demandeur["dmdRevenuOccupants"]).to eq projet.revenu_fiscal_reference_total
 
       personne_physique = demandeur["personnePhysique"]
       expect(personne_physique["civId"]).to eq 1
-      expect(personne_physique["pphPrenom"]).to eq "Jean"
+      expect(personne_physique["pphPrenom"]).to eq "Jean et Jean"
       expect(personne_physique["pphNom"]).to start_with "MARTIN"
 
       adresse_postale = personne_physique["adressePostale"]

--- a/spec/services/projet_initializer_spec.rb
+++ b/spec/services/projet_initializer_spec.rb
@@ -69,7 +69,6 @@ describe ProjetInitializer do
       expect(projet.adresse.description).to eq(adresse)
       expect(projet.numero_fiscal).to eq('15')
       expect(projet.reference_avis).to eq('1515')
-      expect(projet.nb_occupants_a_charge).to eq(3)
       expect(projet.avis_impositions.length).to eq(1)
       expect(projet.avis_impositions.first.occupants.length).to eq(4)
       expect(projet.avis_impositions.first.occupants.first).to be_declarant


### PR DESCRIPTION
Suite des modifications de 5121d2c6f : les occupants sont maintenant rattachés à un avis d’imposition (et non plus directement associés au projet).

Cette PR :

- Redirige `Projet.occupants` vers `Projet.avis_imposition.occupants` de manière transparente,
- Ré-implémente `Projet.nb_occupants_a_charge` de manière transparente,
- Met à jour les factories pour pouvoir créer un projet avec un avis d'imposition et des demandeurs.

À faire après la mise en production :

- Supprimer la colonne Occupant.projet_id
- Supprimer la colonne Projet.nb_occupants_a_charge