### PR TITLE
Rspec: active les specs avec `focus: true`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,8 +67,8 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  #config.filter_run :focus
-  #config.run_all_when_everything_filtered = true
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
Permet de rajouter `focus: true` à une spec pour lancer uniquement cette spec dans le fichier.

https://www.relishapp.com/rspec/rspec-core/docs/filtering/inclusion-filters
