### PR TITLE
PF344 permet de supprimer un occupant

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -32,5 +32,6 @@
 @import "login-fields";
 @import "login-intro";
 @import "popin";
+@import "info-point";
 
 @import "occupants";

--- a/app/assets/stylesheets/info-point.scss
+++ b/app/assets/stylesheets/info-point.scss
@@ -1,0 +1,31 @@
+.info-point {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  line-height: 17px;
+  text-align: center;
+  border-width: 2px;
+  border-style: solid;
+  border-radius: 12px;
+  margin-left: 5px;
+  cursor: default;
+
+  color: #56869a;
+  border-color: #56869a;
+  &:hover {
+    color: #CCC;
+    border-color: #CCC;
+  }
+}
+.info-point--light {
+  color: white;
+  border-color: white;
+  &:hover {
+    color: #111;
+    border-color: #111;
+  }
+}
+
+a.info-point {
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/login-fields.scss
+++ b/app/assets/stylesheets/login-fields.scss
@@ -53,21 +53,6 @@
 .login-fields__proprietaire-label {
   margin-right: 20px;
 }
-.login-fields__help {
-  display: inline-block;
-  width: 22px;
-  height: 22px;
-  line-height: 17px;
-  text-align: center;
-  color: white;
-  border: 2px solid white;
-  border-radius: 12px;
-  margin-left: 5px;
-  &:hover {
-    color: #111;
-    border-color: #111;
-  }
-}
 .login-fields__btn {
   display: table;
   margin: 20px 0 0;

--- a/app/controllers/occupants_controller.rb
+++ b/app/controllers/occupants_controller.rb
@@ -51,8 +51,11 @@ class OccupantsController < ApplicationController
 
   def destroy
     @occupant = @projet_courant.occupants.where(id: params[:id]).first
-    if @occupant.destroy
+
+    if @occupant.can_be_deleted? && @occupant.destroy
       flash[:notice] = t("occupants.delete.success", fullname: @occupant.fullname)
+    else
+      flash[:alert] = t("occupants.delete.error")
     end
     redirect_to projet_occupants_path(@projet_courant)
   end

--- a/app/controllers/occupants_controller.rb
+++ b/app/controllers/occupants_controller.rb
@@ -51,8 +51,10 @@ class OccupantsController < ApplicationController
 
   def destroy
     @occupant = @projet_courant.occupants.where(id: params[:id]).first
-    @occupant.destroy
-    redirect_to projet_path(@projet_courant)
+    if @occupant.destroy
+      flash[:notice] = t("occupants.delete.success", fullname: @occupant.fullname)
+    end
+    redirect_to projet_occupants_path(@projet_courant)
   end
 
 private

--- a/app/models/occupant.rb
+++ b/app/models/occupant.rb
@@ -20,4 +20,8 @@ class Occupant < ActiveRecord::Base
   def fullname
     "#{prenom} #{nom}"
   end
+
+  def can_be_deleted?
+    !demandeur && avis_imposition.occupants.count > 1
+  end
 end

--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -18,16 +18,19 @@
       tbody
         tr
           th scope="col"  = t('occupants.occupants')
-          th scope="col"  = t('.occupants.date_naissance')
-          /TODO th scope="col"  = t('occupants.actions.modifier')
+          th scope="col"  = t('occupants.date_naissance')
+          th scope="col"  = t('occupants.actions')
         - @occupants.each do |occupant|
-          tr
+          tr data-occupant-id=occupant.id
             td
               span.firstname= occupant.prenom
               span.lastname<= occupant.nom
             td= occupant.date_de_naissance.year
-            /TODO td
-              = btn name: t('occupants.actions.supprimer'), href: '#'
+            td
+              = link_to t('occupants.delete.action'),
+                  projet_occupant_path(id: occupant.id),
+                  method: :delete,
+                  data: { confirm: t('occupants.delete.confirm', fullname: occupant.fullname) }
 
     .occupant-inline-form
       h3.occupant-inline-form__title Ajouter un occupant

--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -27,10 +27,17 @@
               span.lastname<= occupant.nom
             td= occupant.date_de_naissance.year
             td
-              = link_to t('occupants.delete.action'),
-                  projet_occupant_path(id: occupant.id),
-                  method: :delete,
-                  data: { confirm: t('occupants.delete.confirm', fullname: occupant.fullname) }
+              - if occupant.can_be_deleted?
+                = link_to projet_occupant_path(id: occupant.id),
+                    method: :delete,
+                    title: t('occupants.delete.action'),
+                    class: "btn btn-icon",
+                    data: { confirm: t('occupants.delete.confirm', fullname: occupant.fullname) }
+                    i class="glyphicon glyphicon-remove"
+                    = t('occupants.delete.action')
+
+              - else
+                .info-point title=t('occupants.delete.cant_delete_demandeur') ?
 
     .occupant-inline-form
       h3.occupant-inline-form__title Ajouter un occupant

--- a/app/views/sessions/new.html.slim
+++ b/app/views/sessions/new.html.slim
@@ -59,10 +59,10 @@
         | Non
       br/
       = label_tag "form-nf", "Numéro fiscal", class: "login-fields__label"
-      a.login-fields__help.js-popin data-target="#numero-fiscal" title="Où trouver le numéro fiscal ?" ?
+      a.info-point.info-point--light.js-popin data-target="#numero-fiscal" title="Où trouver le numéro fiscal ?" ?
       = text_field_tag :numero_fiscal, params[:numero_fiscal], placeholder: "Ex : 12 34 567 890 123", id: "form-nf", class: "login-fields__input"
       = label_tag "form-ra", "Référence de l’avis", class: "login-fields__label"
-      a.login-fields__help.js-popin data-target="#reference-avis" title="Où trouver la référence de l’avis ?" ?
+      a.info-point.info-point--light.js-popin data-target="#reference-avis" title="Où trouver la référence de l’avis ?" ?
       = text_field_tag :reference_avis, params[:reference_avis], placeholder: "Ex : 12 34 A123456 78", id: "form-ra", class: "login-fields__input"
       .login-fields__mentions
         = check_box_tag "autorisation", "1", params[:autorisation], class: "login-fields__mentions-input js-engagement", id: "lab-rfr"

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -316,9 +316,7 @@ fr:
     nombre_occupant: "Nombre d’occupants :"
     confirmer_nombre_personnes: "Veuillez confirmer le nombre de personnes occupant le logement ainsi que leurs années de naissance."
     date_naissance: "Date de naissance"
-    actions:
-      modifier: "Modifier"
-      supprimer: "Supprimer"
+    actions: "Actions"
     nouveau:
       titre: "Ajoutez un nouvel occupant à votre logement"
       action: "Ajouter un occupant"
@@ -327,6 +325,10 @@ fr:
       action: "Je modifie %{occupant}"
     modification:
       composition_logement: "Composition du logement"
+    delete:
+      confirm: "Êtes-vous sûr de vouloir retirer %{fullname} de la liste des occupants de votre logement ?"
+      action: "Supprimer"
+      success: "%{fullname} a été retiré de la liste des occupants."
     civilite:
       mme: Madame
       mr: Monsieur

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -329,6 +329,7 @@ fr:
       confirm: "Êtes-vous sûr de vouloir retirer %{fullname} de la liste des occupants de votre logement ?"
       action: "Supprimer"
       success: "%{fullname} a été retiré de la liste des occupants."
+      error: "Une erreur s’est produite lors de la suppression de l’occupant."
     civilite:
       mme: Madame
       mr: Monsieur

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -327,9 +327,10 @@ fr:
       composition_logement: "Composition du logement"
     delete:
       confirm: "Êtes-vous sûr de vouloir retirer %{fullname} de la liste des occupants de votre logement ?"
-      action: "Supprimer"
+      action: "Retirer"
       success: "%{fullname} a été retiré de la liste des occupants."
       error: "Une erreur s’est produite lors de la suppression de l’occupant."
+      cant_delete_demandeur: "Les occupants mentionnés dans l’avis d’imposition ne peuvent pas être retirés de la liste."
     civilite:
       mme: Madame
       mr: Monsieur

--- a/spec/controllers/occupants_controller_spec.rb
+++ b/spec/controllers/occupants_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'support/mpal_helper'
 
 describe OccupantsController do
-  let(:projet) { create :projet, :with_avis_imposition }
+  let(:projet) { create :projet, :with_demandeurs }
 
   before(:each) do
     authenticate_as_particulier(projet.numero_fiscal)
@@ -83,6 +83,22 @@ describe OccupantsController do
         it "passe à l'étape suivante" do
           expect(response).to redirect_to(etape2_description_projet_path(projet))
         end
+      end
+    end
+  end
+
+  describe "#destroy" do
+    context "pour un occupant demandeur" do
+    end
+
+    context "pour un occupant rajouté ultérieurement" do
+      let(:occupant_to_delete) { projet.occupants.last }
+
+      it "supprime l'occupant" do
+        delete :destroy, projet_id: projet.id, id: occupant_to_delete.id
+        expect(projet.occupants).not_to include occupant_to_delete
+        expect(response).to redirect_to(projet_occupants_path(projet))
+        expect(flash[:notice]).to eq I18n.t("occupants.delete.success", fullname: occupant_to_delete.fullname)
       end
     end
   end

--- a/spec/controllers/occupants_controller_spec.rb
+++ b/spec/controllers/occupants_controller_spec.rb
@@ -89,6 +89,14 @@ describe OccupantsController do
 
   describe "#destroy" do
     context "pour un occupant demandeur" do
+      let(:occupant_demandeur) { projet.occupants.first }
+
+      it "affiche une erreur" do
+        delete :destroy, projet_id: projet.id, id: occupant_demandeur.id
+        expect(projet.occupants).to include occupant_demandeur
+        expect(response).to redirect_to(projet_occupants_path(projet))
+        expect(flash[:alert]).to eq I18n.t("occupants.delete.error")
+      end
     end
 
     context "pour un occupant rajouté ultérieurement" do

--- a/spec/features/1_demarrage/etape3_occupants_spec.rb
+++ b/spec/features/1_demarrage/etape3_occupants_spec.rb
@@ -19,8 +19,6 @@ feature "Occupants :" do
     scenario "je peux ajouter un occupant" do
       signin(projet.numero_fiscal, projet.reference_avis)
       visit projet_occupants_path(projet)
-      expect(page).to have_content("Nombre d’occupants : 4")
-
       fill_in "Nom",               with: "Marielle"
       fill_in "Prénom",            with: "Jean-Pierre"
       fill_in "Date de naissance", with: "20/05/2010"
@@ -37,16 +35,21 @@ feature "Occupants :" do
 
     scenario "je peux modifier un occupant", pending: true do
       skip
-      signin(projet.numero_fiscal, projet.reference_avis)
-      Projet.last.demande = FactoryGirl.create(:demande)
-      click_link I18n.t('projets.visualisation.modifier_liste_occupant')
-      fill_in 'projet_nb_occupants_a_charge', with: 2
-      click_button I18n.t('projets.composition_logement.edition.action')
-      expect(page).to have_content('2 occupants à charge')
     end
 
-    scenario "je peux supprimer un occupant", pending: true do
-      skip
+    scenario "je peux supprimer un occupant" do
+      signin(projet.numero_fiscal, projet.reference_avis)
+      visit projet_occupants_path(projet)
+
+      occupant_to_delete = projet.occupants.last
+      expect(page).to have_css("tr[data-occupant-id='#{occupant_to_delete.id}']")
+      within "table tr:last-child" do
+        click_link I18n.t('occupants.delete.action')
+      end
+
+      expect(page).to have_current_path(projet_occupants_path(projet))
+      expect(page).to have_content(I18n.t("occupants.delete.success", fullname: occupant_to_delete.fullname))
+      expect(page).not_to have_css("tr[data-occupant-id='#{occupant_to_delete.id}']")
     end
 
     scenario "je peux passer à l'étape suivante" do


### PR DESCRIPTION
https://anah-produits.atlassian.net/browse/PF-344

- Les occupants ajoutés peuvent être supprimés,
- Les occupants demandeurs ne peuvent pas être supprimés.

Au passage cette PR améliore aussi un peu le style des boutons de la page.

![remove-occupant](https://cloud.githubusercontent.com/assets/179923/24400560/1af928e8-13b1-11e7-97a0-f93d5aa997f6.gif)
