### PR TITLE
PF344 ajoute une icône au bouton "Ajouter un occupant"

### DIFF
--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -51,7 +51,7 @@
         .occupant-inline-form__field
           = f.label :date_de_naissance
           = f.date_field :date_de_naissance, class: "occupant-inline-form__dob",    placeholder: "JJ/MM/AAAA"
-        = btn name: t('occupants.nouveau.action'), class: "occupant-inline-form__submit"
+        = btn name: t('occupants.nouveau.action'), class: "occupant-inline-form__submit", icon: "plus"
 
     .checkbox-validation
       input#dif1 type="checkbox" class="js-engagement"


### PR DESCRIPTION
Petit oubli de la PR précédente : une icône sur le bouton d'ajout d'un occupant.

![remove-occupant-1 glissees](https://cloud.githubusercontent.com/assets/179923/24404270/0d4aff18-13c1-11e7-86a7-a037ae0d2a95.png)
