### PR TITLE
Reset: supprime les occupants lors d’un reset de base

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -3,6 +3,7 @@ class ToolsController < ApplicationController
     if Tools.demo?
       Invitation.destroy_all
       Demande.destroy_all
+      Occupant.destroy_all
       Projet.destroy_all
       reset_session
       redirect_to root_path, notice: t('reinitialisation.succes')


### PR DESCRIPTION
Corrige une erreur lors du reset de base : certains projets ne peuvent pas être supprimés parce qu’ils référencent des occupants.