### PR TITLE
PF258 envoi d’un accusé de réception après la transmission du projet

### DIFF
--- a/app/mailers/projet_mailer.rb
+++ b/app/mailers/projet_mailer.rb
@@ -53,4 +53,16 @@ class ProjetMailer < ActionMailer::Base
       subject: t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: @invitation.intermediaire.raison_sociale)
     )
   end
+
+  def accuse_reception(projet)
+    @projet = projet
+    @demandeur = projet.demandeur_principal
+    @instructeur = projet.invited_instructeur
+    @date_depot = projet.date_depot
+    mail(
+      from: projet.invited_instructeur.email,
+      to: projet.email,
+      subject: t('mailers.projet_mailer.accuse_reception.sujet')
+    )
+  end
 end

--- a/app/views/projet_mailer/accuse_reception.html.slim
+++ b/app/views/projet_mailer/accuse_reception.html.slim
@@ -1,0 +1,22 @@
+p Bonjour #{@demandeur.fullname},
+
+p Le #{l(@date_depot, format:'%d %B %Y à %H h %M')}, vous avez déposé auprès de l’Agence nationale de l’habitat – Anah – une demande de subvention.
+
+p Votre demande a été enregistrée sous le numéro « #{@projet.plateforme_id} ». Elle sera instruite par le service suivant :
+
+ul
+  li= @instructeur.raison_sociale
+  li= @instructeur.description_adresse
+  li= @instructeur.email
+
+p La décision d’attribution ou de refus de subvention sera prise en fonction, notamment, des priorités d’actions définies par le Conseil d’administration de l’Anah, des priorités définies localement ainsi que des crédits disponibles.
+
+p L’enregistrement de votre demande de subvention vous permet de commencer les travaux. Il vous est néanmoins rappelé que seule une décision expresse d’attribution vous garantit le bénéfice d’une subvention de l’Anah.
+
+p En l’absence de réponse dans les quatre mois à compter de la réception du présent accusé de réception, votre demande sera réputée rejetée.
+
+p Si votre demande est incomplète, une demande de renseignements et/ou de pièces complémentaires vous sera adressée et suspendra le délai mentionné ci-dessus.
+
+p Cordialement,
+
+p Pour l’Anah, #{@instructeur.raison_sociale}

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -339,17 +339,19 @@ fr:
   mailers:
     projet_mailer:
       recommandation_operateurs:
-        sujet: "[ANAH] Voici nos recommandations pour votre projet de rénovation"
+        sujet: "[Anah] Voici nos recommandations pour votre projet de rénovation"
       invitation_intervenant:
-        sujet: "[ANAH] Invitation de %{demandeur_principal} à consulter son projet"
+        sujet: "[Anah] Invitation de %{demandeur_principal} à consulter son projet"
       notification_invitation_intervenant:
-        sujet: "[ANAH] Invitation de %{intervenant} à consulter votre projet"
+        sujet: "[Anah] Invitation de %{intervenant} à consulter votre projet"
       notification_choix_intervenant:
-        sujet: "[ANAH] Félicitations, %{intervenant}, vous avez été choisi par %{demandeur_principal} pour l’accompagner sur son projet"
+        sujet: "[Anah] Félicitations, %{intervenant}, vous avez été choisi par %{demandeur_principal} pour l’accompagner sur son projet"
       resiliation_operateur:
-        sujet: "[ANAH] %{demandeur_principal} a changé d’opérateur pour son projet"
+        sujet: "[Anah] %{demandeur_principal} a changé d’opérateur pour son projet"
       mise_en_relation_intervenant:
-        sujet: "[ANAH] Mise en relation par %{intermediaire}"
+        sujet: "[Anah] Mise en relation par %{intermediaire}"
+      accuse_reception:
+        sujet: "[Anah] Accusé de réception électronique de votre demande de subvention"
 
   # ----------------------- Gestion d’évènements  ---------------------
   evenements:

--- a/db/migrate/20170329131529_add_timestamps_to_invitations.rb
+++ b/db/migrate/20170329131529_add_timestamps_to_invitations.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToInvitations < ActiveRecord::Migration
+  def change
+    add_timestamps(:invitations)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170327092815) do
+ActiveRecord::Schema.define(version: 20170329131529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,9 +168,11 @@ ActiveRecord::Schema.define(version: 20170327092815) do
   add_index "intervenants", ["themes"], name: "index_intervenants_on_themes", using: :gin
 
   create_table "invitations", force: :cascade do |t|
-    t.integer "projet_id"
-    t.integer "intervenant_id"
-    t.integer "intermediaire_id"
+    t.integer  "projet_id"
+    t.integer  "intervenant_id"
+    t.integer  "intermediaire_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "invitations", ["intermediaire_id"], name: "index_invitations_on_intermediaire_id", using: :btree

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -52,4 +52,17 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.body.encoded).to match(invitation.demandeur_principal.fullname) }
     it { expect(email.body.encoded).to include(dossier_url(projet)) }
    end
+
+  describe "le demandeur reçoit un email lorsqu'il a transmis sa demande au service instructeur" do
+    let(:projet) { create :projet, :transmis_pour_instruction }
+    subject(:email) { ProjetMailer.accuse_reception(projet) }
+    it { expect(email.from).to eq([projet.invited_instructeur.email]) }
+    it { expect(email.to).to eq([projet.email]) }
+    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.accuse_reception.sujet')) }
+    it { expect(email.body).to include(projet.demandeur_principal.fullname) }
+    it { expect(email.body).to include(projet.plateforme_id) }
+    it { expect(email.body).to include(projet.invited_instructeur.raison_sociale) }
+    it { expect(email.body).to include(projet.invited_instructeur.description_adresse) }
+    it { expect(email.body).to include(projet.invited_instructeur.email) }
+   end
 end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -355,10 +355,10 @@ describe Projet do
         expect(projet.invitations.count).to eq(2)
       end
 
-      it "notifie l'instructeur" do
+      it "notifie l'instructeur et le demandeur" do
         expect(ProjetMailer).to receive(:mise_en_relation_intervenant).and_call_original
+        expect(ProjetMailer).to receive(:accuse_reception).and_call_original
         projet.transmettre!(instructeur)
-        #expect(ProjetMailer).to receive(:resiliation_operateur).and_call_original
       end
     end
 
@@ -370,6 +370,19 @@ describe Projet do
         expect(projet.statut.to_sym).not_to eq(:transmis_pour_instruction)
         expect(projet.invitations.count).to eq(1)
       end
+    end
+  end
+
+  describe "#date_depot" do
+    subject { projet.date_depot }
+    context "avant la transmission du dossier" do
+      let(:projet) { create :projet, :proposition_acceptee }
+      it { is_expected.to be_nil }
+    end
+
+    context "après la transmission du dossier" do
+      let(:projet) { create :projet, :transmis_pour_instruction }
+      it { is_expected.to eq projet.invitations.last.created_at }
     end
   end
 

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -343,6 +343,36 @@ describe Projet do
     end
   end
 
+  describe "#transmettre!" do
+    let(:projet) { create :projet, :proposition_acceptee }
+
+    context "avec un instructeur valide" do
+      let(:instructeur) { create :instructeur }
+      it "rajoute l'instructeur au projet" do
+        result = projet.transmettre!(instructeur)
+        expect(result).to be true
+        expect(projet.statut.to_sym).to eq(:transmis_pour_instruction)
+        expect(projet.invitations.count).to eq(2)
+      end
+
+      it "notifie l'instructeur" do
+        expect(ProjetMailer).to receive(:mise_en_relation_intervenant).and_call_original
+        projet.transmettre!(instructeur)
+        #expect(ProjetMailer).to receive(:resiliation_operateur).and_call_original
+      end
+    end
+
+    context "avec un instructeur invalide" do
+      let(:instructeur) { nil }
+      it "ne change rien" do
+        result = projet.transmettre!(instructeur)
+        expect(result).to be false
+        expect(projet.statut.to_sym).not_to eq(:transmis_pour_instruction)
+        expect(projet.invitations.count).to eq(1)
+      end
+    end
+  end
+
   describe "#status_for_operateur" do
     let(:projet) { build :projet }
     it {
@@ -381,27 +411,5 @@ describe Projet do
       projet.statut = :en_cours_d_instruction
       expect(projet.status_for_operateur).to eq :en_cours_d_instruction
     }
-  end
-
-  describe "#transmettre!" do
-    context "with valid call" do
-      let(:projet) { create :projet }
-      let!(:instructeur) { create :instructeur }
-      it do
-        result = projet.transmettre!(instructeur)
-        expect(result).to be true
-        expect(projet.statut).to eq("transmis_pour_instruction")
-        expect(projet.invitations.count).to eq(1)
-      end
-    end
-    context "with invalid call" do
-      let(:projet) { create :projet }
-      it do
-        result = projet.transmettre!(nil)
-        expect(result).to be false
-        expect(projet.statut).not_to eq("transmis_pour_instruction")
-        expect(projet.invitations.count).to eq(0)
-      end
-    end
   end
 end


### PR DESCRIPTION
https://anah-produits.atlassian.net/browse/PF-258

Au moment où le particulier envoie son dossier au service instructeur, un email d'accusé-réception lui est envoyé.

La date de dépôt utilisée correspond à la date à laquelle l'instructeur a été rattaché au dossier.

<img width="642" alt="capture d ecran 2017-03-29 a 15 53 42" src="https://cloud.githubusercontent.com/assets/179923/24458108/41cfc66a-1498-11e7-8982-920abfd0bbea.png">
