### PR TITLE
PF405-406 corrige les infos nom et prénom envoyées à Opal

### DIFF
--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -30,22 +30,8 @@ private
     projet.statut = :en_cours_d_instruction
   end
 
-  def serialize_civilite_occupants(occupants)
-    # Seule la civilité du demandeur principal est renseignée
-    civilite = occupants.map(&:civilite).compact.first
-    if civilite == Occupant.civilites.keys[0]
-      OPAL_CIVILITE_M
-    else
-      OPAL_CIVILITE_MME
-    end
-  end
-
-  def serialize_prenom_occupants(occupants)
-    occupants.map { |occupant| occupant.prenom.capitalize }.join(' et ')
-  end
-
-  def serialize_noms_occupants(occupants)
-    occupants.map { |occupant| occupant.nom.upcase }.join(' ET ')
+  def serialize_civilite(demandeur)
+    (demandeur.civilite == Occupant.civilites.keys[0]) ? OPAL_CIVILITE_M : OPAL_CIVILITE_MME
   end
 
   def serialize_code_insee(code_insee)
@@ -66,9 +52,9 @@ private
         "qdmId": 29,
         "cadId": 2,
         "personnePhysique": {
-          "civId":     serialize_civilite_occupants(projet.occupants),
-          "pphNom":    serialize_noms_occupants(projet.occupants),
-          "pphPrenom": serialize_prenom_occupants(projet.occupants),
+          "civId":            serialize_civilite(projet.demandeur_principal),
+          "pphNom":           projet.demandeur_principal.nom.upcase,
+          "pphPrenom":        projet.demandeur_principal.prenom.capitalize,
           "adressePostale": {
             "payId": 1,
             "adpLigne1":     lignes_adresse_postale[0],

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -34,6 +34,14 @@ private
     (demandeur.civilite == Occupant.civilites.keys[0]) ? OPAL_CIVILITE_M : OPAL_CIVILITE_MME
   end
 
+  def serialize_prenom(demandeur)
+    demandeur.prenom.mb_chars.capitalize.to_s
+  end
+
+  def serialize_nom(demandeur)
+    demandeur.nom.mb_chars.upcase.to_s
+  end
+
   def serialize_code_insee(code_insee)
     code_insee[2, code_insee.length]
   end
@@ -53,8 +61,8 @@ private
         "cadId": 2,
         "personnePhysique": {
           "civId":            serialize_civilite(projet.demandeur_principal),
-          "pphNom":           projet.demandeur_principal.nom.upcase,
-          "pphPrenom":        projet.demandeur_principal.prenom.capitalize,
+          "pphNom":           serialize_nom(projet.demandeur_principal),
+          "pphPrenom":        serialize_prenom(projet.demandeur_principal),
           "adressePostale": {
             "payId": 1,
             "adpLigne1":     lignes_adresse_postale[0],

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -32,6 +32,8 @@ describe Opal do
     let(:instructeur) {       create :instructeur }
     let(:agent_instructeur) { create :agent, intervenant: instructeur }
 
+    before { projet.demandeur_principal.update(nom: 'Straße', prenom: 'ōlaf') }
+
     subject! { Opal.new(client).creer_dossier(projet, agent_instructeur) }
 
     it "envoie les informations sérialisées" do
@@ -46,8 +48,8 @@ describe Opal do
 
       personne_physique = demandeur["personnePhysique"]
       expect(personne_physique["civId"]).to eq 1
-      expect(personne_physique["pphPrenom"]).to eq "Jean"
-      expect(personne_physique["pphNom"]).to start_with "MARTIN"
+      expect(personne_physique["pphPrenom"]).to eq "Ōlaf"
+      expect(personne_physique["pphNom"]).to eq "STRAßE"
 
       adresse_postale = personne_physique["adressePostale"]
       expect(adresse_postale["adpLigne1"]).to eq "65 rue de Rome"

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -46,7 +46,7 @@ describe Opal do
 
       personne_physique = demandeur["personnePhysique"]
       expect(personne_physique["civId"]).to eq 1
-      expect(personne_physique["pphPrenom"]).to eq "Jean et Jean"
+      expect(personne_physique["pphPrenom"]).to eq "Jean"
       expect(personne_physique["pphNom"]).to start_with "MARTIN"
 
       adresse_postale = personne_physique["adressePostale"]


### PR DESCRIPTION
Corrige les champs nom/prénom du dossier Opal (seul le demandeur est souhaité)

<img width="820" alt="capture d ecran 2017-03-30 a 12 30 12" src="https://cloud.githubusercontent.com/assets/24429245/24500198/bba715f4-1544-11e7-9750-5fd5727d43d1.png">
