### PR TITLE
PF432 corrige l'apparition des messages d'erreurs inopportuns

### DIFF
--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -11,7 +11,7 @@ module ProjetConcern
         if @projet_courant.save_proposition!(projet_params)
           return redirect_to send("#{@dossier_ou_projet}_path", @projet_courant), notice: t('projets.edition_projet.messages.succes')
         else
-          flash[:alert] = t('projets.edition_projet.messages.erreur')
+          flash.now[:alert] = t('projets.edition_projet.messages.erreur')
         end
       end
 
@@ -75,7 +75,7 @@ private
     def assign_projet_if_needed
       if !@projet_courant.agent_operateur && current_agent
         if @projet_courant.update_attribute(:agent_operateur, current_agent)
-          flash[:notice] = t('projets.visualisation.projet_affecte')
+          flash.now[:notice] = t('projets.visualisation.projet_affecte')
         end
       end
     end

--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -7,9 +7,8 @@ class DemarrageProjetController < ApplicationController
   before_action :init_view
 
   def etape1_recuperation_infos
-    if request.post?
-      success = etape1_save
-      return etape1_redirect_to_next_step if success
+    if request.post? && etape1_save
+      return etape1_redirect_to_next_step
     end
 
     @projet_courant.personne ||= Personne.new
@@ -134,7 +133,7 @@ private
         required: false
       )
     rescue => e
-      flash[:alert] = e.message
+      flash.now[:alert] = e.message
       return false
     end
 
@@ -155,7 +154,7 @@ private
     end
 
     demandeur_id = params[:projet][:demandeur_id]
-    unless demandeur_id.blank?
+    if demandeur_id.present?
       return define_demandeur(demandeur_id)
     end
 
@@ -166,7 +165,7 @@ private
     @demandeur = @projet_courant.change_demandeur(demandeur_id)
     @demandeur.assign_attributes(demandeur_principal_params)
     unless @demandeur.save
-      flash[:alert] = t('demarrage_projet.etape1_demarrage_projet.erreurs.enregistrement_demandeur')
+      flash.now[:alert] = t('demarrage_projet.etape1_demarrage_projet.erreurs.enregistrement_demandeur')
       return false
     end
     true

--- a/spec/controllers/demarrage_projet_controller_spec.rb
+++ b/spec/controllers/demarrage_projet_controller_spec.rb
@@ -156,4 +156,23 @@ describe DemarrageProjetController do
       end
     end
   end
+
+  context "lorsque une information est erronée" do
+    before do
+      projet.demandeur_principal.update_attribute(:civilite, nil)
+      post :etape1_recuperation_infos, {
+        contact: "1",
+        projet_id: projet.id,
+        projet: {
+          adresse_postale: projet.adresse_postale.description,
+          demandeur_id: projet.demandeur_principal.id
+        }
+      }
+      projet.reload
+    end
+
+    it "affiche une erreur" do
+      expect(flash[:alert]).to eq I18n.t('demarrage_projet.etape1_demarrage_projet.erreurs.enregistrement_demandeur')
+    end
+  end
 end


### PR DESCRIPTION
Bug lié à l'utilisation de flash au lieu de flash.now quand on render une page au lieu de faire un redirect_to.

Du coup j'ai parcouru le code de l'appli et j'ai corrigé tous les flashs par des flashs.now là où c'était nécessaire.