### PR TITLE
PF402 supprime le doublon Occupant #

### DIFF
--- a/app/services/projet_initializer.rb
+++ b/app/services/projet_initializer.rb
@@ -52,8 +52,8 @@ class ProjetInitializer
 
     contribuable.nombre_personnes_charge.times do |index|
       avis_imposition.occupants.build(
-        nom:    "Occupant #{declarant_count + index + 1}",
-        prenom: "Occupant #{declarant_count + index + 1}",
+        nom:    "#{declarant_count + index + 1}",
+        prenom: "Occupant ",
         date_de_naissance: "1970-01-01", # TODO: obligatoire :(
         declarant: false,
         demandeur: false


### PR DESCRIPTION
Supprime le doublon Occupant # dans le nom complet d'un occupant non codéclarant :

<img width="860" alt="capture d ecran 2017-04-06 a 12 12 01" src="https://cloud.githubusercontent.com/assets/24429245/24749145/4647aafc-1ac2-11e7-840a-17fcbddaf187.png">
