### PR TITLE
PF415 fige le dossier après dépôt

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -74,6 +74,12 @@ module ApplicationHelper
     t("projets.composition_logement.calcul_preeligibilite.#{plafond}")
   end
 
+  def edit_projet_button(projet, path)
+    unless projet.projet_frozen?
+      link_to t('projets.visualisation.lien_edition'), path, class: 'edit'
+    end
+  end
+
   def affiche_demande_souhaitee(demande)
     html = content_tag(:h4, "Adresse du logement")
     html << content_tag(:p, demande.projet.adresse.description)

--- a/app/views/dossiers/_projet_envisage.html.slim
+++ b/app/views/dossiers/_projet_envisage.html.slim
@@ -1,7 +1,7 @@
 article.block.projet
   h3 Projet envisagé
   - if demandeur? || (current_agent && current_agent.operateur?)
-    = link_to t('projets.visualisation.lien_edition'), etape2_description_projet_path(@projet_courant), class: 'edit'
+    = edit_projet_button(@projet_courant, etape2_description_projet_path(@projet_courant))
   .content-block
     - if @projet_courant.demande.blank?
       p Le demandeur n’a pas encore rempli le projet.

--- a/app/views/dossiers/_projet_proposition_proposee.html.slim
+++ b/app/views/dossiers/_projet_proposition_proposee.html.slim
@@ -1,7 +1,7 @@
 article.block.projet-ope
   h3.is-open Projet proposé
   - if current_agent.operateur?
-    = link_to t('projets.visualisation.lien_edition'), dossier_proposition_path(@projet_courant), class: "edit"
+    = edit_projet_button(@projet_courant, dossier_proposition_path(@projet_courant))
   .content-block
     .invoice
       = render 'projets/projet_invoice'

--- a/app/views/projets/_occupants.html.slim
+++ b/app/views/projets/_occupants.html.slim
@@ -1,7 +1,7 @@
 article.block.occupants
   h3 Détails des occupants
   - if demandeur? || current_agent.operateur?
-    = link_to t('projets.visualisation.lien_edition'), etape1_recuperation_infos_path(@projet_courant), class: 'edit'
+    = edit_projet_button(@projet_courant, etape1_recuperation_infos_path(@projet_courant))
   .occupants-recap
     ul
       li

--- a/app/views/projets/_projet_envisage.html.slim
+++ b/app/views/projets/_projet_envisage.html.slim
@@ -1,6 +1,6 @@
 article.block.projet
   h3 Projet envisagé
-  = link_to t('projets.visualisation.lien_edition'), etape2_description_projet_path(@projet_courant), class: 'edit'
+  = edit_projet_button(@projet_courant, etape2_description_projet_path(@projet_courant))
   .content-block
     - if @projet_courant.demande.blank?
       - if current_agent

--- a/app/views/projets/_projet_proposition.html.slim
+++ b/app/views/projets/_projet_proposition.html.slim
@@ -2,7 +2,7 @@
 article.block.projet-ope
   h3.is-open Projet proposé
   - if current_agent && current_agent.operateur?
-    = link_to t('projets.visualisation.lien_edition'), dossier_proposition_path(@projet_courant), class: "edit"
+    = edit_projet_button(@projet_courant, dossier_proposition_path(@projet_courant))
   .content-block
     .invoice
       = render 'projets/projet_details'

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -398,6 +398,7 @@ fr:
     errors:
       models:
         projet:
+          frozen: "Le projet est figé : %{attribute} ne peut pas être modifié"
           attributes:
             note_degradation:
               inclusion: "doit être comprise entre zéro et un."

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -46,7 +46,7 @@ FactoryGirl.define do
     trait :with_invited_pris do
       after(:build) do |projet|
         pris = create(:pris, departements: [projet.departement])
-        create(:invitation, projet: projet, intervenant: pris)
+        projet.invitations << create(:invitation, projet: projet, intervenant: pris)
       end
     end
 
@@ -63,21 +63,35 @@ FactoryGirl.define do
     trait :with_invited_operateur do
       after(:build) do |projet|
         operateur = create(:operateur, departements: [projet.departement])
-        create(:invitation, projet: projet, intervenant: operateur)
+        projet.invitations << create(:invitation, projet: projet, intervenant: operateur)
       end
     end
 
     trait :with_committed_operateur do
+      with_invited_operateur
       after(:build) do |projet|
-        projet.operateur = create(:operateur, departements: [projet.departement])
-        create(:invitation, projet: projet, intervenant: projet.operateur)
+        projet.operateur = projet.invited_operateur
+      end
+    end
+
+    trait :with_assigned_operateur do
+      with_committed_operateur
+      after(:build) do |projet|
+        projet.agent_operateur = create(:agent, :operateur, intervenant: projet.operateur)
       end
     end
 
     trait :with_invited_instructeur do
       after(:build) do |projet|
         instructeur = create(:instructeur, departements: [projet.departement])
-        create(:invitation, projet: projet, intervenant: instructeur)
+        projet.invitations << create(:invitation, projet: projet, intervenant: instructeur)
+      end
+    end
+
+    trait :with_committed_instructeur do
+      with_invited_instructeur
+      after(:build) do |projet|
+        projet.agent_instructeur = create(:agent, :instructeur, intervenant: projet.invited_instructeur)
       end
     end
 
@@ -117,7 +131,7 @@ FactoryGirl.define do
       statut :proposition_enregistree
       with_demandeurs
       with_demande
-      with_committed_operateur
+      with_assigned_operateur
       with_prestations
     end
 
@@ -125,31 +139,35 @@ FactoryGirl.define do
       statut :proposition_proposee
       with_demandeurs
       with_demande
-      with_committed_operateur
+      with_assigned_operateur
       with_prestations
     end
 
     trait :transmis_pour_instruction do
-      statut :transmis_pour_instruction
       with_demandeurs
       with_demande
-      with_committed_operateur
+      with_assigned_operateur
       with_prestations
+      with_invited_instructeur
 
       after(:build) do |projet|
-        projet.invitations << create(:invitation, intermediaire: projet.operateur, intervenant: create(:instructeur))
+        projet.statut = :transmis_pour_instruction
       end
     end
 
     trait :en_cours_d_instruction do
-      statut :en_cours_d_instruction
       opal_numero 4567
+      opal_id 8910
       with_demandeurs
       with_demande
-      with_committed_operateur
-      with_invited_instructeur
-      with_invited_pris
+      with_assigned_operateur
       with_prestations
+      with_committed_instructeur
+      with_invited_pris
+
+      after(:build) do |projet|
+        projet.statut = :en_cours_d_instruction
+      end
     end
   end
 end

--- a/spec/features/4_transmission_pour_instruction/transmettre_a_l_instructeur_spec.rb
+++ b/spec/features/4_transmission_pour_instruction/transmettre_a_l_instructeur_spec.rb
@@ -4,37 +4,81 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature "Transmettre à l'instructeur :" do
-  let(:projet) { create :projet, :proposition_proposee, :with_intervenants_disponibles }
+  context "avant que le dossier ne soit transmis" do
+    let(:projet) { create :projet, :proposition_proposee, :with_intervenants_disponibles }
+    let(:instructeur) { projet.invited_instructeur }
 
-  context "en tant que demandeur" do
-    scenario "je transmets mon projet aux services instructeurs" do
-      signin(projet.numero_fiscal, projet.reference_avis)
-      expect(page).to have_current_path(projet_path(projet))
-      click_link I18n.t('projets.transmission.bouton_accepter')
+    context "en tant que demandeur" do
+      scenario "j'accepte la proposition et je transmets mon projet aux services instructeurs" do
+        signin(projet.numero_fiscal, projet.reference_avis)
+        expect(page).to have_current_path(projet_path(projet))
+        click_link I18n.t('projets.transmission.bouton_accepter')
 
-      expect(page).to have_current_path(projet_transmission_path(projet))
-      expect(find_field('projet_email').value).to eq 'prenom.nom@site.com'
-      fill_in 'projet_email', with: 'lala@toto.com'
-      check 'confirm'
-      click_button I18n.t('projets.transmission.envoi_demande')
+        expect(page).to have_current_path(projet_transmission_path(projet))
+        expect(find_field('projet_email').value).to eq 'prenom.nom@site.com'
+        fill_in 'projet_email', with: 'lala@toto.com'
+        check 'confirm'
+        click_button I18n.t('projets.transmission.envoi_demande')
 
-      instructeur = Intervenant.instructeur_pour(projet)
-      expect(page).to have_current_path(projet_path(projet))
-      expect(page).to have_content(I18n.t('projets.transmission.messages.success', instructeur: instructeur.raison_sociale))
-      expect(page).to have_content(I18n.t('projets.statut.transmis_pour_instruction').downcase)
+        expect(page).to have_content(I18n.t('projets.transmission.messages.success', instructeur: instructeur.raison_sociale))
+        expect(page).to have_content(I18n.t('projets.statut.transmis_pour_instruction').downcase)
+      end
+
+      scenario "je suis notifié si mon email n'est pas valide" do
+        signin(projet.numero_fiscal, projet.reference_avis)
+        expect(page).to have_current_path(projet_path(projet))
+        click_link I18n.t('projets.transmission.bouton_accepter')
+
+        fill_in 'projet_email', with: 'lalatoto.com'
+        check 'confirm'
+        click_button I18n.t('projets.transmission.envoi_demande')
+
+        expect(page).to have_current_path(projet_transmission_path(projet))
+        expect(page).to have_content(I18n.t('projets.transmission.messages.validation_email'))
+      end
     end
+  end
 
-    scenario "je suis notifié si mon email n'est pas valide" do
-      signin(projet.numero_fiscal, projet.reference_avis)
-      expect(page).to have_current_path(projet_path(projet))
-      click_link I18n.t('projets.transmission.bouton_accepter')
+  context "après transmission aux services instructeurs" do
+    context "pour tous les intervenants" do
+      let(:projet) { create :projet, :transmis_pour_instruction }
 
-      fill_in 'projet_email', with: 'lalatoto.com'
-      check 'confirm'
-      click_button I18n.t('projets.transmission.envoi_demande')
+      shared_examples "le dossier n'est plus modifiable" do
+        specify do
+          within 'article.occupants' do
+            expect(page).not_to have_content I18n.t('projets.visualisation.lien_edition')
+          end
+          within 'article.projet' do
+            expect(page).not_to have_content I18n.t('projets.visualisation.lien_edition')
+          end
+        end
+      end
 
-      expect(page).to have_current_path(projet_transmission_path(projet))
-      expect(page).to have_content(I18n.t('projets.transmission.messages.validation_email'))
+      context "en tant que demandeur" do
+        before do
+          signin(projet.numero_fiscal, projet.reference_avis)
+          visit projet_path(projet.id)
+        end
+        it_behaves_like "le dossier n'est plus modifiable"
+      end
+
+      context "en tant qu'opérateur" do
+        let(:agent_operateur) { create :agent, intervenant: projet.operateur }
+        before do
+          login_as agent_operateur, scope: :agent
+          visit dossier_path(projet.id)
+        end
+        it_behaves_like "le dossier n'est plus modifiable"
+      end
+
+      context "en tant qu'instructeur" do
+        let(:agent_instructeur) { create :agent, intervenant: projet.invited_instructeur }
+        before do
+          login_as agent_instructeur, scope: :agent
+          visit dossier_path(projet.id)
+        end
+        it_behaves_like "le dossier n'est plus modifiable"
+      end
     end
   end
 end

--- a/spec/features/tableau_de_bord_spec.rb
+++ b/spec/features/tableau_de_bord_spec.rb
@@ -8,13 +8,12 @@ feature "J'ai accès à mes dossiers depuis mon tableau de bord" do
   let(:operateur)   { projet.operateur }
   let(:instructeur) { projet.invited_instructeur }
   let(:pris)        { projet.invited_pris }
-  let(:agent_operateur)   { create :agent, :operateur, intervenant: operateur}
-  let(:agent_instructeur) { create :agent, :instructeur, intervenant: instructeur}
+  let(:agent_operateur)   { projet.agent_operateur}
+  let(:agent_instructeur) { projet.agent_instructeur}
   let(:agent_pris)        { create :agent, :pris, intervenant: pris}
 
   before do
     login_as current_agent, scope: :agent
-    projet.update_attributes agent_instructeur: agent_instructeur, agent_operateur: agent_operateur
   end
 
   context "en tant qu'opérateur" do

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -46,6 +46,41 @@ describe Projet do
       projet.valid?
       expect(projet.errors[:tel]).to be_present
     end
+
+    describe "#validate_frozen_attributes" do
+      matcher :allow_updating_of do |attribute|
+        def with(value)
+          @value = value
+          self
+        end
+        match do |projet|
+          projet.send("#{attribute}=", @value || "dummy")
+          projet.validate
+          projet.errors[attribute].blank?
+        end
+        match_when_negated do |projet|
+          projet.send("#{attribute}=", @value || "dummy")
+          projet.validate
+          projet.errors[attribute].present?
+        end
+      end
+
+      context "quand le projet est figé" do
+        subject(:projet) { create :projet, :transmis_pour_instruction }
+        it { is_expected.to allow_updating_of(:statut).with(:en_cours_d_instruction) }
+        it { is_expected.to allow_updating_of(:opal_numero) }
+        it { is_expected.to allow_updating_of(:opal_id) }
+        it { is_expected.to allow_updating_of(:agent_instructeur_id).with(create(:agent).id) }
+        it { is_expected.not_to allow_updating_of(:note_degradation) }
+        it { is_expected.not_to allow_updating_of(:note_insalubrite) }
+        it { is_expected.not_to allow_updating_of(:montant_travaux_ht) }
+        it { is_expected.not_to allow_updating_of(:montant_travaux_ttc) }
+        it { is_expected.not_to allow_updating_of(:reste_a_charge) }
+        it { is_expected.not_to allow_updating_of(:pret_bancaire) }
+        it { is_expected.not_to allow_updating_of(:adresse_postale_id).with(create(:adresse).id) }
+        it { is_expected.not_to allow_updating_of(:adresse_a_renover_id).with(create(:adresse).id) }
+      end
+    end
   end
 
   describe '#clean_numero_fiscal' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,6 +111,9 @@ RSpec.configure do |config|
 
   # Capybara.default_max_wait_time = 600
 
+  # Save an HTML snapshot on test failure
+  Capybara::Screenshot.autosave_on_failure = true
+  # Remove previous HTML snapshots on each new run
   Capybara::Screenshot.prune_strategy = :keep_last_run
   # Make Capybara HTML snapshots of failed tests look better in a browser.
   # (cf. https://github.com/mattheworiordan/capybara-screenshot#better-looking-html-screenshots)


### PR DESCRIPTION
Les liens "Modifier" ne sont plus affichés une fois que le projet a été
transmis au service instructeur.

En plus de ça, pour blinder les cas où un usager naviguerait directement sur
l'URL d'une page d'édition, une validation est rajoutée sur le modèle `Projet`,
qui blackliste la modification de la plupart des attributs une fois que le
projet a été transmis.

Avantages :

- c'est simple
- c'est blindé à assez bas niveau
- ça évite de devoir modifier tous les contrôleurs pour vérifier l'état du
  projet.

Inconvénients :

- les relations has_many restent techniquement modifiables en console
  (même s'il n'y a plus moyen d'y accéder de manière normale depuis le site).

  Si un jour c'est un problème on pourra passer le temps pour blinder ça aussi.

## Capture d'écran

Les liens "Modifier" ne sont pas affichés.

<img width="1209" alt="capture d ecran 2017-04-06 a 15 46 35" src="https://cloud.githubusercontent.com/assets/179923/24757690/3eeea2c4-1ae0-11e7-8844-f12f6bf9f02f.png">
