### PR TITLE
PF326 change l’intitulé du bouton de transmission du dossier

### DIFF
--- a/app/views/projets/_projet_proposition_proposee.html.slim
+++ b/app/views/projets/_projet_proposition_proposee.html.slim
@@ -1,4 +1,4 @@
 - content_for :cta do
   .button-group
-    = btn name: t('projets.statut.bouton_accepter'), href: projet_transmission_path(@projet_courant), class: 'proposal'
+    = btn name: t('projets.transmission.bouton_accepter'), href: projet_transmission_path(@projet_courant), class: 'proposal'
 = render 'projet_proposition'

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -146,7 +146,6 @@ fr:
   # ----------------------- Page de visualisation du projet ---------------------
   projets:
     statut:
-      bouton_accepter: "Accepter ce projet"
       depose: "Déposé par le demandeur"
       en_cours: "En cours"
       en_cours_d_instruction: "En cours d’instruction"
@@ -210,6 +209,7 @@ fr:
         info_confirmation_email: "En vu de vous envoyer un accusé de réception et de suivre votre dossier merci de confirmer votre adresse email :"
 
     transmission:
+      bouton_accepter: "Suivant"
       envoi_demande: "Je dépose ma demande de subvention"
       messages:
         success: "Dépôt effectué auprès du service en charge de l’instruction : %{instructeur}"

--- a/spec/features/4_transmission_pour_instruction/transmettre_a_l_instructeur_spec.rb
+++ b/spec/features/4_transmission_pour_instruction/transmettre_a_l_instructeur_spec.rb
@@ -6,11 +6,11 @@ require 'support/api_ban_helper'
 feature "Transmettre à l'instructeur :" do
   let(:projet) { create :projet, :proposition_proposee, :with_intervenants_disponibles }
 
-  context "en tant que demandeur ayant validé mon email" do
+  context "en tant que demandeur" do
     scenario "je transmets mon projet aux services instructeurs" do
       signin(projet.numero_fiscal, projet.reference_avis)
       expect(page).to have_current_path(projet_path(projet))
-      click_link I18n.t('projets.statut.bouton_accepter')
+      click_link I18n.t('projets.transmission.bouton_accepter')
 
       expect(page).to have_current_path(projet_transmission_path(projet))
       expect(find_field('projet_email').value).to eq 'prenom.nom@site.com'
@@ -27,7 +27,7 @@ feature "Transmettre à l'instructeur :" do
     scenario "je suis notifié si mon email n'est pas valide" do
       signin(projet.numero_fiscal, projet.reference_avis)
       expect(page).to have_current_path(projet_path(projet))
-      click_link I18n.t('projets.statut.bouton_accepter')
+      click_link I18n.t('projets.transmission.bouton_accepter')
 
       fill_in 'projet_email', with: 'lalatoto.com'
       check 'confirm'


### PR DESCRIPTION
La crainte est que les utilisateurs croient avoir déjà déposé leur
dossier en cliquant une fois sur le bouton - mais en fermant la page de
confirmation qui s'affiche derrière.

On renomme donc l'intitulé du bouton `Accepter la proposition` en `Suivant` - pour
bien marquer que ce n'est qu'une étape pas encore validée.

![acceptee](https://cloud.githubusercontent.com/assets/179923/24760354/b4d69f70-1ae8-11e7-84fb-f67c85c7a10c.gif)

