### PR TITLE
PF408 affiche un message d'erreur lors de l'ajout d'un avis d'imposition invalide

### DIFF
--- a/app/controllers/avis_impositions_controller.rb
+++ b/app/controllers/avis_impositions_controller.rb
@@ -17,14 +17,14 @@ class AvisImpositionsController < ApplicationController
     avis_imposition = @projet_courant.avis_impositions.new(strong_params_hash)
     @avis_imposition = ProjetInitializer.new.initialize_avis_imposition(@projet_courant, avis_imposition.numero_fiscal, avis_imposition.reference_avis)
     unless @avis_imposition
-      flash.now[:alert] = t("sessions.invalid_credentials")
-      return render :new
+      flash[:alert] = t("sessions.invalid_credentials")
+      return redirect_to new_projet_avis_imposition_path(@projet_courant)
     end
     unless @avis_imposition.save
-      return render :new
+      return redirect_to new_projet_avis_imposition_path(@projet_courant)
     end
     flash[:notice] = "Avis d’imposition ajouté"
-    redirect_to projet_avis_impositions_path(projet_id: @projet_courant)
+    redirect_to projet_avis_impositions_path(@projet_courant)
   end
 
   def destroy

--- a/app/services/projet_initializer.rb
+++ b/app/services/projet_initializer.rb
@@ -28,6 +28,7 @@ class ProjetInitializer
     unless contribuable
       @service_particulier ||= ApiParticulier.new(numero_fiscal, reference_avis)
       contribuable = @service_particulier.retrouve_contribuable
+      return unless contribuable
     end
     is_new_project = 0 == projet.avis_impositions.length
 

--- a/spec/controllers/avis_impositions_controller_spec.rb
+++ b/spec/controllers/avis_impositions_controller_spec.rb
@@ -44,7 +44,6 @@ describe AvisImpositionsController do
       let(:reference_avis)  { Fakeweb::ApiParticulier::INVALID}
 
       it "n'ajoute pas un avis d'imposition au projet" do
-        skip "TODO PF-410"
         post :create, projet_id: projet.id,
             avis_imposition: { numero_fiscal: numero_fiscal, reference_avis: reference_avis }
         projet.reload
@@ -52,7 +51,7 @@ describe AvisImpositionsController do
         expect(projet.avis_impositions.first).to eq first_avis
 
         expect(flash[:alert]).to be_present
-        expect(response).to redirect_to projet_avis_impositions_path(projet)
+        expect(response).to redirect_to new_projet_avis_imposition_path(projet)
       end
     end
   end

--- a/spec/features/1_demarrage/etape2_avis_imposition_spec.rb
+++ b/spec/features/1_demarrage/etape2_avis_imposition_spec.rb
@@ -20,6 +20,21 @@ feature "Avis d'imposition :" do
       expect(page.current_path).to eq(projet_avis_impositions_path(projet))
       expect(page).to have_content('1 000 000 €')
     end
+
+    scenario "je suis notifié que je ne peux pas ajouter un avis d'imposition invalide" do
+      signin(projet.numero_fiscal, projet.reference_avis)
+      visit projet_avis_impositions_path(projet)
+
+      click_link 'Ajouter un avis d’imposition'
+
+      expect(page.current_path).to eq(new_projet_avis_imposition_path(projet))
+      fill_in 'avis_imposition_numero_fiscal',  with: 'INVALID'
+      fill_in 'avis_imposition_reference_avis', with: 'INVALID'
+      click_button 'Ajouter'
+
+      expect(page.current_path).to eq(new_projet_avis_imposition_path(projet))
+      expect(page).to have_content(I18n.t("sessions.invalid_credentials"))
+    end
   end
 
   context "en tant que demandeur avec un avis d'imposition supplémentaire" do

--- a/spec/services/projet_initializer_spec.rb
+++ b/spec/services/projet_initializer_spec.rb
@@ -99,7 +99,7 @@ describe ProjetInitializer do
 
     context "lorsque les identifiants sont invalides" do
       it "ne crée pas d'avis d'imposition" do
-        skip "TODO PF-410"
+        expect(service_contribuable).to receive(:retrouve_contribuable).and_return(nil)
         expect(projet.avis_impositions.length).to eq(0)
 
         projet_initializer.initialize_avis_imposition(projet, 'INVALID', 'INVALID')


### PR DESCRIPTION
![avis](https://cloud.githubusercontent.com/assets/24429245/24856842/658106da-1de6-11e7-9920-30378b590f14.gif)
