### PR TITLE
Vérifie le certificat SSL lors des communications avec Opal

### DIFF
--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -4,7 +4,7 @@ class Opal
   end
 
   def creer_dossier(projet, agent_instructeur)
-    response = @client.post('/createDossier', body: serialize_dossier(projet, agent_instructeur).to_json, verify: false)
+    response = @client.post('/createDossier', body: serialize_dossier(projet, agent_instructeur).to_json)
     if response.code == 201
       ajoute_id_opal(projet, response.body)
       met_a_jour_statut(projet)


### PR DESCRIPTION
En ce moment on autorise la communication avec Opal, même si le certificat SSL est invalide. Cette PR ré-active la vérification du certificat.

Ça ne posera pas de problème pour les plateformes Opal actuellement utilisées. Il n'y a que la nouvelle plateforme anonymisée dont le certificat est en cours d'établissement. 