### PR TITLE
Affiche les erreurs renvoyées par Opal à l’utilisateur

### DIFF
--- a/app/controllers/dossiers_opal_controller.rb
+++ b/app/controllers/dossiers_opal_controller.rb
@@ -4,13 +4,19 @@ class DossiersOpalController < ApplicationController
   before_action :assert_projet_courant
 
   def create
-    unless Opal.new(OpalClient).creer_dossier(@projet_courant, current_agent)
-      return redirect_to(dossier_path(@projet_courant), alert: t('projets.creation_opal.messages.erreur'))
+    begin
+      opal_api.create_dossier!(@projet_courant, current_agent)
+      redirect_to(dossier_path(@projet_courant), notice: t('projets.creation_opal.messages.succes', id_opal: @projet_courant.opal_numero))
+    rescue => e
+      redirect_to(dossier_path(@projet_courant), alert: t('projets.creation_opal.messages.erreur', message: e.message))
     end
-    redirect_to(dossier_path(@projet_courant), notice: t('projets.creation_opal.messages.succes', id_opal: @projet_courant.opal_numero))
   end
 
 private
+  def opal_api
+    @opal_api ||= Opal.new(OpalClient)
+  end
+
   def check_agent_instructeur
     unless current_agent.instructeur?
       return redirect_to(dossier_path(@projet_courant), alert: t('sessions.access_forbidden'))

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -224,7 +224,7 @@ fr:
       titre_creation_opal: "Créer le dossier dans Opal"
       messages:
         succes: "Le dossier vient d’être créé dans OPAL avec l’identifiant %{id_opal}"
-        erreur: "Une erreur est survenue lors des échanges avec OPAL. Le dossier n’a pas pu être créé"
+        erreur: "Une erreur est survenue lors de la création du dossier dans Opal : « %{message} »"
 
     intervenants:
       messages:

--- a/spec/features/5_creer_dossier_opal/creer_dossier_opal_spec.rb
+++ b/spec/features/5_creer_dossier_opal/creer_dossier_opal_spec.rb
@@ -16,12 +16,25 @@ feature "Créer le dossier dans Opal" do
       scenario "je peux créer un dossier Opal depuis la page projet" do
         visit dossier_path(projet)
         click_button I18n.t('projets.creation_opal.titre_creation_opal')
+        expect(page).to have_current_path dossier_path(projet)
         expect(page).to have_content(I18n.t("projets.creation_opal.messages.succes", id_opal: "09500840"))
 
         visit dossiers_path
         within "#projet_#{projet.id}" do
           expect(page).to have_content(I18n.t("projets.statut.en_cours_d_instruction"))
           expect(page).to have_content("09500840")
+        end
+      end
+
+      context "quand la création du dossier échoue" do
+        before { Fakeweb::Opal.register_create_dossier_failure }
+
+        scenario "je reçois un message d'erreur" do
+          visit dossier_path(projet)
+          click_button I18n.t('projets.creation_opal.titre_creation_opal')
+
+          expect(page).to have_current_path dossier_path(projet)
+          expect(page).to have_content(I18n.t("projets.creation_opal.messages.erreur", message: "Utilisateur inconnu : veuillez-vous connecter à OPAL."))
         end
       end
     end

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -4,6 +4,12 @@ class OpalClientMock
   attr_accessor :url
   attr_accessor :body
 
+  def initialize(http_code, http_status, payload)
+    @http_code = http_code
+    @http_status = http_status
+    @payload = payload
+  end
+
   def post(url, options)
     @url  = url
     @body = options[:body]
@@ -14,69 +20,91 @@ private
   include RSpec::Mocks::ExampleMethods
 
   def response
-    data = {
-      dosNumero: "09500840",
-      dosId:     959496
-    }
-    response = Net::HTTPResponse.new(1.1, 201, "OK")
-    allow(response).to receive(:body).and_return(data.to_json)
+    response = Net::HTTPResponse.new(1.1, @http_code, @http_status)
+    allow(response).to receive(:body).and_return(@payload.to_json)
     response
   end
 end
 
 describe Opal do
-  let(:client) { OpalClientMock.new }
+  let(:client) { OpalClientMock.new(201, "OK", { dosNumero: "09500840", dosId: 959496 }) }
 
-  describe "#creer_dossier" do
+  describe "#create_dossier!" do
     let(:projet) {            create :projet, :transmis_pour_instruction, demandeurs_count: 1, occupants_a_charge_count: 1 }
     let(:instructeur) {       create :instructeur }
     let(:agent_instructeur) { create :agent, intervenant: instructeur }
 
-    before { projet.demandeur_principal.update(nom: 'Strâbe', prenom: 'ōlaf') }
+    context "en cas de succès" do
+      before { projet.demandeur_principal.update(nom: 'Strâbe', prenom: 'ōlaf') }
+      subject! { Opal.new(client).create_dossier!(projet, agent_instructeur) }
 
-    subject! { Opal.new(client).creer_dossier(projet, agent_instructeur) }
+      it "envoie les informations sérialisées" do
+        body = JSON.parse(client.body)
+        expect(body["dosNumeroPlateforme"]).to eq projet.numero_plateforme
+        expect(body["dosDateDepot"]).to be_present
+        expect(body["utiIdClavis"]).to eq agent_instructeur.clavis_id
 
-    it "envoie les informations sérialisées" do
-      body = JSON.parse(client.body)
-      expect(body["dosNumeroPlateforme"]).to eq projet.numero_plateforme
-      expect(body["dosDateDepot"]).to be_present
-      expect(body["utiIdClavis"]).to eq agent_instructeur.clavis_id
+        demandeur = body["demandeur"]
+        expect(demandeur["dmdNbOccupants"]).to eq 2
+        expect(demandeur["dmdRevenuOccupants"]).to eq projet.revenu_fiscal_reference_total
 
-      demandeur = body["demandeur"]
-      expect(demandeur["dmdNbOccupants"]).to eq 2
-      expect(demandeur["dmdRevenuOccupants"]).to eq projet.revenu_fiscal_reference_total
+        personne_physique = demandeur["personnePhysique"]
+        expect(personne_physique["civId"]).to eq 1
+        expect(personne_physique["pphPrenom"]).to eq "Olaf"
+        expect(personne_physique["pphNom"]).to eq "STRABE"
 
-      personne_physique = demandeur["personnePhysique"]
-      expect(personne_physique["civId"]).to eq 1
-      expect(personne_physique["pphPrenom"]).to eq "Olaf"
-      expect(personne_physique["pphNom"]).to eq "STRABE"
+        adresse_postale = personne_physique["adressePostale"]
+        expect(adresse_postale["adpLigne1"]).to eq "65 rue de Rome"
+        expect(adresse_postale["adpLocalite"]).to eq "Paris"
+        expect(adresse_postale["adpCodePostal"]).to eq "75008"
 
-      adresse_postale = personne_physique["adressePostale"]
-      expect(adresse_postale["adpLigne1"]).to eq "65 rue de Rome"
-      expect(adresse_postale["adpLocalite"]).to eq "Paris"
-      expect(adresse_postale["adpCodePostal"]).to eq "75008"
+        immeuble = body["immeuble"]
+        expect(immeuble["immAnneeAchevement"]).to eq 1975
 
-      immeuble = body["immeuble"]
-      expect(immeuble["immAnneeAchevement"]).to eq 1975
+        adresse_geographique = immeuble["adresseGeographique"]
+        expect(adresse_geographique["adgLigne1"]).to eq "12 rue de la Mare"
+        expect(adresse_geographique["cdpCodePostal"]).to eq "75010"
+        expect(adresse_geographique["comCodeInsee"]).to eq "010"
+        expect(adresse_geographique["dptNumero"]).to eq "75"
+      end
 
-      adresse_geographique = immeuble["adresseGeographique"]
-      expect(adresse_geographique["adgLigne1"]).to eq "12 rue de la Mare"
-      expect(adresse_geographique["cdpCodePostal"]).to eq "75010"
-      expect(adresse_geographique["comCodeInsee"]).to eq "010"
-      expect(adresse_geographique["dptNumero"]).to eq "75"
+      it "met à jour le dossier avec la réponse d'Opal" do
+        expect(subject).to be true
+        expect(projet.opal_id).to eq("959496")
+        expect(projet.opal_numero).to eq("09500840")
+        expect(projet.statut).to eq('en_cours_d_instruction')
+        expect(projet.agent_instructeur).to eq(agent_instructeur)
+      end
     end
 
-    it "met à jour le dossier avec la réponse d'Opal" do
-      expect(subject).to be true
-      expect(projet.opal_id).to eq("959496")
-      expect(projet.opal_numero).to eq("09500840")
-      expect(projet.statut).to eq('en_cours_d_instruction')
-      expect(projet.agent_instructeur).to eq(agent_instructeur)
+    context "en cas d'erreur de l'API" do
+      let(:client) { OpalClientMock.new(error_code, error_status, payload) }
+      let(:opal) { Opal.new(client) }
+
+      context "quand un message d'erreur détaillé est présent" do
+        let(:error_code) { 422 }
+        let(:error_status) { "Unprocessable Entity" }
+        let(:payload) do [{ message: "Utilisateur inconnu : veuillez-vous connecter à OPAL.", code: 1000 }] end
+
+        it "lève une exception avec le message d'erreur" do
+          expect { opal.create_dossier!(projet, agent_instructeur) }.to raise_error OpalError, "Utilisateur inconnu : veuillez-vous connecter à OPAL."
+        end
+      end
+
+      context "quand aucun message d'erreur n'est présent" do
+        let(:error_code) { 503 }
+        let(:error_status) { "Service Unavailable" }
+        let(:payload) do "<html><body>Server down</body></html>" end
+
+        it "lève une exception avec un message d'erreur par défaut" do
+          expect { opal.create_dossier!(projet, agent_instructeur) }.to raise_error OpalError, "Service Unavailable (503)"
+        end
+      end
     end
   end
 
   describe ".split_adresse_into_lines" do
-    let(:opal)              { Opal.new(client) }
+    let(:opal) { Opal.new(client) }
 
     subject(:adresse_lines) { opal.send(:split_adresse_into_lines, adresse) }
 
@@ -121,6 +149,3 @@ describe Opal do
     end
   end
 end
-
-
-

--- a/spec/support/opal_helper.rb
+++ b/spec/support/opal_helper.rb
@@ -1,15 +1,37 @@
 require 'dotenv'
-RSpec.configure do |config|
-  config.before(:each) do
-    FakeWeb.register_uri(
-      :post, %r|#{ENV['OPAL_API_BASE_URI']}sio/json/createDossier|,
-      content_type: 'application/json',
-      body: JSON.generate({
-        "dosNumero": "09500840",
-        "dosId": 959496
-      }),
-      status: [201, "Created"]
-    )
+
+module Fakeweb
+  class Opal
+    def self.register_create_dossier_success
+      FakeWeb.register_uri(
+        :post, %r|#{ENV['OPAL_API_BASE_URI']}sio/json/createDossier|,
+        content_type: 'application/json',
+        body: JSON.generate({
+          "dosNumero": "09500840",
+          "dosId": 959496
+        }),
+        status: [201, "Created"]
+      )
+    end
+
+    def self.register_create_dossier_failure
+      FakeWeb.register_uri(
+        :post, %r|#{ENV['OPAL_API_BASE_URI']}sio/json/createDossier|,
+        content_type: 'application/json',
+        body: JSON.generate([
+          {
+            message: "Utilisateur inconnu : veuillez-vous connecter à OPAL.",
+            code: 1001
+          }
+        ]),
+        status: [422, "Unprocessable Entity"]
+      )
+    end
   end
 end
 
+RSpec.configure do |config|
+  config.before(:each) do
+    Fakeweb::Opal.register_create_dossier_success
+  end
+end


### PR DESCRIPTION
Affiche le message d'erreur renvoyé par Opal à l'utilisateur.

Pour cela on transforme `Opal#create_dossier` (qui renvoie un booléen) en `Opal#create_dossier!` (qui jette une exception contenant le message d'erreur en cas d'échec).

![opal](https://cloud.githubusercontent.com/assets/179923/24913911/f05c196a-1ed2-11e7-93c6-4443cd32836e.gif)
