### PR TITLE
PF327 permet de renseigner la date de visite

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -428,6 +428,10 @@ fieldset {
         .page-projet .col-right .content-projet .block.projet-ope legend {
           font-weight: 600;
           padding: 0 10px; }
+        .page-projet .col-right .content-projet .block.projet-ope .field_with_errors {
+          display: inline; }
+          .page-projet .col-right .content-projet .block.projet-ope .field_with_errors label {
+            color: #d72623; }
         .page-projet .col-right .content-projet .block.projet-ope .ins-form li {
           padding: 8px 0; }
           .page-projet .col-right .content-projet .block.projet-ope .ins-form li label, .page-projet .col-right .content-projet .block.projet-ope .ins-form li .like-label {
@@ -452,7 +456,7 @@ fieldset {
           box-shadow: inset 0 1px 2px 0 rgba(0, 0, 0, 0.3);
           border: solid 1px #909eaf;
           padding: 5px 10px 4px;
-          width: 90px; }
+          width: 110px; }
           .page-projet .col-right .content-projet .block.projet-ope .ins-form input[type="text"].disabled, .page-projet .col-right .content-projet .block.projet-ope .ins-form input[type="tel"].disabled, .page-projet .col-right .content-projet .block.projet-ope .ins-form textarea.disabled, .page-projet .col-right .content-projet .block.projet-ope .ins-form select.disabled {
             background-color: #f2f6fa;
             box-shadow: inset 0 1px 2px 0 rgba(0, 0, 0, 0.3);

--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -45,7 +45,7 @@ private
 
     def projet_params
       attributs = params.require(:projet)
-      .permit(:disponibilite, :description, :email, :tel, :annee_construction,
+      .permit(:disponibilite, :description, :email, :tel, :annee_construction, :date_de_visite,
               :type_logement, :etage, :nb_pieces, :surface_habitable, :etiquette_avant_travaux,
               :niveau_gir, :autonomie, :handicap, :demandeur_salarie, :entreprise_plus_10_personnes,
               :note_degradation, :note_insalubrite, :ventilation_adaptee, :presence_humidite, :auto_rehabilitation,

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -45,6 +45,7 @@ class Projet < ActiveRecord::Base
   validates :tel, phone: { :minimum => 10, :maximum => 12 }, allow_blank: true
   validates :adresse_postale, presence: true, on: :update
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true
+  validates :date_de_visite, presence: true, on: :proposition
   validate  :validate_frozen_attributes
 
   localized_numeric_setter :note_degradation
@@ -251,7 +252,7 @@ class Projet < ActiveRecord::Base
   def save_proposition!(attributes)
     assign_attributes(attributes)
     self.statut = :proposition_enregistree
-    save
+    save(context: :proposition)
   end
 
   def transmettre!(instructeur)

--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -1,6 +1,12 @@
 h4= current_agent ? 'Projet proposé' : 'Votre logement'
 ul.ctr-ope
   li
+    = "Date de visite : "
+    - if @projet_courant.date_de_visite.present?
+      span= l(@projet_courant.date_de_visite, format: :long)
+    - else
+      span= "non renseignée"
+  li
     = "Type de logement : "
     span= @projet_courant.type_logement
   li

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -14,6 +14,9 @@
             legend Logement
             ul.ins-form
               li
+                = f.label :date_de_visite, "Date de visite (obligatoire)"
+                = f.text_field :date_de_visite, placeholder: "JJ/MM/AAAA", value: @projet_courant.date_de_visite.try(:strftime, "%d/%m/%Y")
+              li
                 = f.label :type_logement, "Type de logement"
                 = f.select :type_logement, options_for_select(["Maison","Appartement"], @projet_courant.type_logement)
               li
@@ -31,7 +34,7 @@
                 = f.text_field :surface_habitable
                 = " m²"
               li
-                = f.label :etiquette_avant_travaux, "Etiquette énergétique avant travaux"
+                = f.label :etiquette_avant_travaux, "Étiquette énergétique avant travaux"
                 = f.text_field :etiquette_avant_travaux
           fieldset
             legend Diagnostic opérateur

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -390,6 +390,7 @@ fr:
         tel: "Le numéro de téléphone"
         note_degradation: "La note de dégradation"
         note_insalubrite: "La note d’insalubrité"
+        date_de_visite: "La date de visite du logement"
       occupant:
         civilite: "La civilité"
         nom: "Nom"
@@ -400,6 +401,8 @@ fr:
         projet:
           frozen: "Le projet est figé : %{attribute} ne peut pas être modifié"
           attributes:
+            date_de_visite:
+              blank: "doit être renseignée."
             note_degradation:
               inclusion: "doit être comprise entre zéro et un."
             note_insalubrite:

--- a/db/migrate/20170412143013_add_date_de_visite_to_projet.rb
+++ b/db/migrate/20170412143013_add_date_de_visite_to_projet.rb
@@ -1,0 +1,5 @@
+class AddDateDeVisiteToProjet < ActiveRecord::Migration
+  def change
+    add_column :projets, :date_de_visite, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412125511) do
+ActiveRecord::Schema.define(version: 20170412143013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -286,6 +286,7 @@ ActiveRecord::Schema.define(version: 20170412125511) do
     t.integer  "agent_instructeur_id"
     t.integer  "adresse_postale_id"
     t.integer  "adresse_a_renover_id"
+    t.date     "date_de_visite"
   end
 
   add_index "projets", ["adresse_a_renover_id"], name: "index_projets_on_adresse_a_renover_id", using: :btree

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -129,6 +129,7 @@ FactoryGirl.define do
 
     trait :proposition_enregistree do
       statut :proposition_enregistree
+      date_de_visite DateTime.new(2016, 12, 28)
       with_demandeurs
       with_demande
       with_assigned_operateur

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -26,6 +26,7 @@ feature "Remplir la proposition de travaux" do
       expect(page).to have_content(aide.libelle)
 
       # Section "Logement"
+      fill_in 'projet_date_de_visite', with: '28/12/2016'
       select 'Appartement', from: 'projet_type_logement'
       select '2', from: 'projet_etage'
       select 'Plus de 5', from: 'projet_nb_pieces'
@@ -62,9 +63,10 @@ feature "Remplir la proposition de travaux" do
       fill_in 'projet_precisions_financement', with: 'Le prêt sera sans doute accordé.'
 
       click_on 'Enregistrer cette proposition'
+      expect(page.current_path).to eq(dossier_path(projet))
 
       # Section "Logement"
-      expect(page.current_path).to eq(dossier_path(projet))
+      expect(page).to have_content('28 décembre 2016')
       expect(page).to have_content('Appartement')
       expect(page).to have_css('.etage', text: 2)
       expect(page).to have_css('.pieces', text:'Plus de 5')
@@ -120,6 +122,7 @@ feature "Remplir la proposition de travaux" do
     context "quand je ne réponds non/pas aux questions" do
       scenario "elles n'apparaissent pas dans la synthèse" do
         visit dossier_proposition_path(projet)
+        fill_in 'projet_date_de_visite', with: '28/12/2016'
         choose 'projet_ventilation_adaptee_false'
         click_on 'Enregistrer cette proposition'
         expect(page.current_path).to eq(dossier_path(projet))

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -12,6 +12,8 @@ describe Projet do
     it { is_expected.to validate_presence_of(:adresse_postale).on(:update) }
     it { is_expected.not_to validate_presence_of(:email) }
     it { is_expected.not_to validate_presence_of(:tel) }
+    it { is_expected.not_to validate_presence_of(:date_de_visite) }
+    it { is_expected.to validate_presence_of(:date_de_visite).on(:proposition) }
     it { is_expected.to validate_inclusion_of(:note_degradation).in_range(0..1) }
     it { is_expected.to validate_inclusion_of(:note_insalubrite).in_range(0..1) }
     it { is_expected.to have_one :demande }
@@ -376,6 +378,30 @@ describe Projet do
       expect(projet.persisted?).to be true
       expect(projet.operateur).to eq(operateur)
       expect(projet.statut).to eq(:en_cours.to_s)
+    end
+  end
+
+  describe "#save_proposition!" do
+    let(:projet) { create :projet, :en_cours }
+
+    context "quand les attributs sont valides" do
+      let(:attributes) do { note_degradation: 0.1, date_de_visite: Time.now } end
+
+      it "enregistre les modifications au projet" do
+        expect(projet.save_proposition!(attributes)).to be true
+        expect(projet.changed?).to be false
+        expect(projet.statut).to eq(:proposition_enregistree.to_s)
+        expect(projet.note_degradation).to eq 0.1
+      end
+    end
+
+    context "quand des attributs requis sont manquants" do
+      let(:attributes) do { date_de_visite: nil } end
+
+      it "ajoute une erreur de validation" do
+        expect(projet.save_proposition!(attributes)).to be false
+        expect(projet.errors).not_to be_blank
+      end
     end
   end
 


### PR DESCRIPTION
La date de visite doit être renseignée au moment de remplir la proposition.

![date-de-visite](https://cloud.githubusercontent.com/assets/179923/25006457/3c11d896-205d-11e7-954c-97c702a0dde2.gif)
