### PR TITLE
PF424 Refactore les specs en préparation de l'édition par les opérateurs

### DIFF
--- a/spec/features/2_choix_operateur/dossier_spec.rb
+++ b/spec/features/2_choix_operateur/dossier_spec.rb
@@ -4,29 +4,36 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature "Accéder au informations du dossier :" do
-  let(:projet)      { create(:projet, :prospect, :with_intervenants_disponibles, :with_invited_operateur) }
-  let(:operateur)   { create :operateur,   departements: [projet.departement] }
-  let(:instructeur) { create :instructeur, departements: [projet.departement] }
-  let(:pris)        { create :pris,        departements: [projet.departement] }
-  let!(:invitation) { create :invitation, intervenant: operateur, projet: projet }
+  let(:projet)      { create(:projet, :prospect, :with_invited_operateur, :with_invited_instructeur, :with_invited_pris) }
+  let(:operateur)   { projet.invited_operateur }
+  let(:instructeur) { projet.invited_instructeur }
+  let(:pris)        { projet.invited_pris }
 
-  context "en tant que demandeur" do
-    scenario "je peux consulter mon projet" do
-      signin(projet.numero_fiscal, projet.reference_avis)
+  shared_examples "je peux consulter mon projet" do
+    specify do
       visit projet_path(projet)
       expect(page).to have_current_path projet_path(projet)
       expect(page).to have_content("Jean Martin")
     end
   end
 
+  shared_examples "je peux consulter un dossier" do
+    specify do
+      visit dossier_path(projet)
+      expect(page).to have_current_path dossier_path(projet)
+      expect(page).to have_content("Jean Martin")
+    end
+  end
+
+  context "en tant que demandeur" do
+    before { signin(projet.numero_fiscal, projet.reference_avis) }
+    it_behaves_like "je peux consulter mon projet"
+  end
+
   context "en tant qu'opérateur" do
     let(:agent) { create :agent, intervenant: operateur }
     before { login_as agent, scope: :agent }
-
-    scenario "je peux consulter un dossier" do
-      visit dossier_path(projet)
-      expect(page).to have_content("Jean Martin")
-    end
+    it_behaves_like "je peux consulter un dossier"
 
     scenario "je ne peux pas changer de moi-même l'opérateur du dossier" do
       visit dossier_path(projet)
@@ -37,22 +44,12 @@ feature "Accéder au informations du dossier :" do
   context "en tant qu'instructeur" do
     let(:agent) { create :agent, intervenant: instructeur }
     before { login_as agent, scope: :agent }
-
-    scenario "je peux consulter un dossier" do
-      # TODO
-    end
+    it_behaves_like "je peux consulter un dossier"
   end
 
   context "en tant que PRIS" do
     let(:agent) { create :agent, intervenant: pris }
     before { login_as agent, scope: :agent }
-
-    scenario "je peux consulter un dossier" do
-      # TODO
-    end
-
-    scenario "si je suis saisi par le demandeur, je peux affecter un opérateur au dossier" do
-      # TODO
-    end
+    it_behaves_like "je peux consulter un dossier"
   end
 end

--- a/spec/features/2_choix_operateur/dossier_spec.rb
+++ b/spec/features/2_choix_operateur/dossier_spec.rb
@@ -3,17 +3,25 @@ require 'support/mpal_features_helper'
 require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
-feature "J'ai accès aux données concernant mes dossiers" do
+feature "Accéder au informations du dossier :" do
   let(:projet)      { create(:projet, :prospect, :with_intervenants_disponibles, :with_invited_operateur) }
   let(:operateur)   { create :operateur,   departements: [projet.departement] }
   let(:instructeur) { create :instructeur, departements: [projet.departement] }
   let(:pris)        { create :pris,        departements: [projet.departement] }
   let!(:invitation) { create :invitation, intervenant: operateur, projet: projet }
 
-  before { login_as agent, scope: :agent }
+  context "en tant que demandeur" do
+    scenario "je peux consulter mon projet" do
+      signin(projet.numero_fiscal, projet.reference_avis)
+      visit projet_path(projet)
+      expect(page).to have_current_path projet_path(projet)
+      expect(page).to have_content("Jean Martin")
+    end
+  end
 
   context "en tant qu'opérateur" do
     let(:agent) { create :agent, intervenant: operateur }
+    before { login_as agent, scope: :agent }
 
     scenario "je peux consulter un dossier" do
       visit dossier_path(projet)
@@ -28,6 +36,7 @@ feature "J'ai accès aux données concernant mes dossiers" do
 
   context "en tant qu'instructeur" do
     let(:agent) { create :agent, intervenant: instructeur }
+    before { login_as agent, scope: :agent }
 
     scenario "je peux consulter un dossier" do
       # TODO
@@ -36,6 +45,7 @@ feature "J'ai accès aux données concernant mes dossiers" do
 
   context "en tant que PRIS" do
     let(:agent) { create :agent, intervenant: pris }
+    before { login_as agent, scope: :agent }
 
     scenario "je peux consulter un dossier" do
       # TODO

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -2,17 +2,9 @@ require 'rails_helper'
 require 'support/mpal_features_helper'
 require 'support/api_ban_helper'
 
-feature "En tant que demandeur, j'ai accès aux données concernant mon projet" do
-  context "quand mon projet est éligible" do
+feature "Modifier le projet :" do
+  context "en tant que demandeur" do
     let(:projet) { create(:projet, :prospect, :with_invited_operateur) }
-
-    scenario "je peux consulter mon projet en me connectant" do
-      signin(projet.numero_fiscal, projet.reference_avis)
-      @role_utilisateur = :demandeur
-      expect(page).to have_content("Jean Martin")
-      expect(page).to have_content("Total Revenu Fiscal de Référence")
-      expect(page).not_to have_content(I18n.t('projets.visualisation.non_eligible'))
-    end
 
     scenario "je peux modifier mes données personnelles" do
       signin(projet.numero_fiscal, projet.reference_avis)

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -3,15 +3,13 @@ require 'support/mpal_features_helper'
 require 'support/api_ban_helper'
 
 feature "Modifier le projet :" do
-  context "en tant que demandeur" do
-    let(:projet) { create(:projet, :prospect, :with_invited_operateur) }
-
-    scenario "je peux modifier mes données personnelles" do
-      signin(projet.numero_fiscal, projet.reference_avis)
+  shared_examples "je peux modifier les informations personnelles du demandeur" do
+    specify do
       within 'article.occupants' do
         click_link I18n.t('projets.visualisation.lien_edition')
       end
 
+      expect(page).to have_current_path etape1_recuperation_infos_path(projet)
       expect(find('#demandeur_principal_civilite_mr')).to be_checked
       expect(page).to have_field('Adresse postale', with: '65 rue de Rome, 75008 Paris')
 
@@ -26,9 +24,10 @@ feature "Modifier le projet :" do
       expect(page).to have_content Fakeweb::ApiBan::ADDRESS_PORT
       expect(page).to have_content Fakeweb::ApiBan::ADDRESS_MARE
     end
+  end
 
-    scenario "je peux modifier les données concernant mon habitation et mon projet" do
-      signin(projet.numero_fiscal, projet.reference_avis)
+  shared_examples "je peux modifier les informations de l'habitation et de la demande" do
+    specify do
       within 'article.projet' do
         click_link I18n.t('projets.visualisation.lien_edition')
       end
@@ -37,5 +36,13 @@ feature "Modifier le projet :" do
       expect(page).to have_content(1950)
       # TODO: tester la modification des travaux demandés
     end
+  end
+
+  context "en tant que demandeur" do
+    let(:projet) { create(:projet, :prospect, :with_invited_operateur) }
+    before { signin(projet.numero_fiscal, projet.reference_avis) }
+
+    it_behaves_like "je peux modifier les informations personnelles du demandeur"
+    it_behaves_like "je peux modifier les informations de l'habitation et de la demande"
   end
 end


### PR DESCRIPTION
Le travail sur l'édition des infos d'un projet par les opérateurs va prendre un peu de temps. Je commence donc à faire passer les commits au fur et à mesure (pour éviter de trop gros conflits ensuite).

Voici déjà le refactor des specs concernant la visualisation et la modification des dossiers. J'utilise plus de shared_specs, pour pouvoir tester facilement qu'autant les demandeurs que les opérateurs peuvent effectuer des actions similaires.