### PR TITLE
PF285 ajoute la sélection des types d’intervention (aka themes)

### DIFF
--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -16,14 +16,8 @@ module ProjetConcern
       end
 
       assign_projet_if_needed
-      @projet_courant.documents.build(label: "Evaluation énergétique")
-      @projet_courant.documents.build(label: "Decision CDAPH ou GIR")
-      @projet_courant.documents.build(label: "Rapport d'ergotherpeute ou diagnostic autonomie")
-      @projet_courant.documents.build(label: "Grille de degradation ou arrêté")
-      @projet_courant.documents.build(label: "Grille d'insalubrité ou arrêté")
-      @projet_courant.documents.build(label: "Devis ou estimation de travaux")
-      @projet_courant.documents.build(label: "Justificatif MDPH")
-      @projet_courant.documents.build(label: "Justificatif CDAPH")
+      @themes = Theme.ordered.all
+      @prestations = Prestation.all
       render "projets/proposition"
     end
 
@@ -61,6 +55,7 @@ private
               :montant_travaux_ht, :montant_travaux_ttc, :pret_bancaire, :reste_a_charge,
               :documents_attributes,
               :prestation_ids => [],
+              :theme_ids => [],
               :suggested_operateur_ids => [],
               :projet_aides_attributes => [:id, :aide_id, :montant])
       attributs[:prestation_ids] = [] if attributs[:prestation_ids].blank?

--- a/app/models/prestation.rb
+++ b/app/models/prestation.rb
@@ -1,4 +1,3 @@
 class Prestation < ActiveRecord::Base
-  belongs_to :projet
-  belongs_to :theme
+  has_and_belongs_to_many :projets
 end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -36,8 +36,9 @@ class Projet < ActiveRecord::Base
   has_many :aides, through: :projet_aides
   accepts_nested_attributes_for :projet_aides, reject_if: :all_blank, allow_destroy: true
 
-  has_and_belongs_to_many :prestations, join_table: 'projet_prestations'
+  has_and_belongs_to_many :prestations
   has_and_belongs_to_many :suggested_operateurs, class_name: 'Intervenant', join_table: 'suggested_operateurs'
+  has_and_belongs_to_many :themes
 
   validates :numero_fiscal, :reference_avis, presence: true
   validates :email, email: true, allow_blank: true
@@ -63,6 +64,7 @@ class Projet < ActiveRecord::Base
     next where(nil) if agent.instructeur?
     joins(:intervenants).where('intervenants.id = ?', agent.intervenant_id).group('projets.id')
   }
+  scope :ordered, -> { order("projets.id desc") }
 
   def self.find_by_locator(locator)
     is_numero_plateforme = locator.try(:include?, '_')

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,7 +1,7 @@
 class Theme < ActiveRecord::Base
   validates :libelle, presence: true
 
-  has_many :prestations
+  has_and_belongs_to_many :projets
 
   scope :ordered, -> { order("themes.libelle, themes.id") }
 

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -1,4 +1,4 @@
-= form_for @projet_courant, url: send("#{@dossier_ou_projet}_proposition_path", @projet_courant), html: { method: :put, class: "edition-demande" } do |f|
+= simple_form_for @projet_courant, url: send("#{@dossier_ou_projet}_proposition_path", @projet_courant), html: { method: :put, class: "edition-demande" } do |f|
   = render "shared/errors", resource: @projet_courant
   section.content-projet
     article.block.projet-ope
@@ -79,23 +79,23 @@
                 = f.label :remarques_diagnostic, t('helpers.label.diagnostic.remarques_diagnostic')
                 = f.text_area :remarques_diagnostic
           fieldset
+            legend Types d’intervention
+            p (2 maximum)
+            = f.association :themes, as: :check_boxes, collection: @themes, label: false
+          fieldset
             legend Description des travaux proposés
             table.pp-table border="0" cellpadding="0" cellspacing="0" width="100%"
               tbody
                 tr
                   th.empty scope="col"  &nbsp;
                   th.top-tab scope="col"  Proposition
-                - Theme.all.each do |theme|
-                  - next if theme.prestations.blank?
+                - @prestations.each do |prestation|
                   tr
-                    th.tab-title colspan="3" scope="row" #{theme.libelle.capitalize}
-                  - theme.prestations.each do |prestation|
-                    tr
-                      th scope="row"
-                        label for="prestation_#{prestation.id}"
-                          = prestation.libelle.capitalize
-                      td.plan_travaux(data-prestation-id=prestation.id)
-                        = prestation_checkbox(@projet_courant, prestation)
+                    th scope="row"
+                      label for="prestation_#{prestation.id}"
+                        = prestation.libelle.capitalize
+                    td.plan_travaux(data-prestation-id=prestation.id)
+                      = prestation_checkbox(@projet_courant, prestation)
                 tr
                   th.tab-title colspan="3" scope="row" Efficacité énergétique
                 tr

--- a/config/locales/defaults/technique.fr.yml
+++ b/config/locales/defaults/technique.fr.yml
@@ -12,8 +12,8 @@ fr:
         one: "élément"
         other: "éléments"
       theme:
-        one: "thème"
-        other: "thèmes"
+        one: "type d’intervention"
+        other: "types d’intervention"
   date:
     abbr_day_names:
     - dim

--- a/db/migrate/20170412115754_remove_theme_id_from_prestations.rb
+++ b/db/migrate/20170412115754_remove_theme_id_from_prestations.rb
@@ -1,0 +1,5 @@
+class RemoveThemeIdFromPrestations < ActiveRecord::Migration
+  def change
+    remove_column :prestations, :theme_id
+  end
+end

--- a/db/migrate/20170412115804_remove_projet_id_from_prestations.rb
+++ b/db/migrate/20170412115804_remove_projet_id_from_prestations.rb
@@ -1,0 +1,5 @@
+class RemoveProjetIdFromPrestations < ActiveRecord::Migration
+  def change
+    remove_column :prestations, :projet_id
+  end
+end

--- a/db/migrate/20170412120433_rename_table_projet_prestations_to_prestations_projets.rb
+++ b/db/migrate/20170412120433_rename_table_projet_prestations_to_prestations_projets.rb
@@ -1,0 +1,5 @@
+class RenameTableProjetPrestationsToPrestationsProjets < ActiveRecord::Migration
+  def change
+    rename_table  :projet_prestations, :prestations_projets
+  end
+end

--- a/db/migrate/20170412125511_create_projets_themes.rb
+++ b/db/migrate/20170412125511_create_projets_themes.rb
@@ -1,0 +1,8 @@
+class CreateProjetsThemes < ActiveRecord::Migration
+  def change
+    create_table :projets_themes, id: false do |t|
+      t.references :projet, index: true
+      t.references :theme,  index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170405160145) do
+ActiveRecord::Schema.define(version: 20170412125511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -216,18 +216,21 @@ ActiveRecord::Schema.define(version: 20170405160145) do
     t.string   "entreprise"
     t.float    "montant"
     t.boolean  "recevable"
-    t.integer  "projet_id"
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
     t.string   "scenario"
     t.boolean  "souhaite",   default: false, null: false
     t.boolean  "preconise",  default: false, null: false
     t.boolean  "retenu",     default: false, null: false
-    t.integer  "theme_id"
   end
 
-  add_index "prestations", ["projet_id"], name: "index_prestations_on_projet_id", using: :btree
-  add_index "prestations", ["theme_id"], name: "index_prestations_on_theme_id", using: :btree
+  create_table "prestations_projets", force: :cascade do |t|
+    t.integer "projet_id"
+    t.integer "prestation_id"
+  end
+
+  add_index "prestations_projets", ["prestation_id"], name: "index_prestations_projets_on_prestation_id", using: :btree
+  add_index "prestations_projets", ["projet_id"], name: "index_prestations_projets_on_projet_id", using: :btree
 
   create_table "projet_aides", force: :cascade do |t|
     t.integer "projet_id"
@@ -237,14 +240,6 @@ ActiveRecord::Schema.define(version: 20170405160145) do
 
   add_index "projet_aides", ["aide_id"], name: "index_projet_aides_on_aide_id", using: :btree
   add_index "projet_aides", ["projet_id"], name: "index_projet_aides_on_projet_id", using: :btree
-
-  create_table "projet_prestations", force: :cascade do |t|
-    t.integer "projet_id"
-    t.integer "prestation_id"
-  end
-
-  add_index "projet_prestations", ["prestation_id"], name: "index_projet_prestations_on_prestation_id", using: :btree
-  add_index "projet_prestations", ["projet_id"], name: "index_projet_prestations_on_projet_id", using: :btree
 
   create_table "projets", force: :cascade do |t|
     t.string   "numero_fiscal"
@@ -301,6 +296,14 @@ ActiveRecord::Schema.define(version: 20170405160145) do
   add_index "projets", ["personne_id"], name: "index_projets_on_personne_id", using: :btree
   add_index "projets", ["themes"], name: "index_projets_on_themes", using: :gin
 
+  create_table "projets_themes", id: false, force: :cascade do |t|
+    t.integer "projet_id"
+    t.integer "theme_id"
+  end
+
+  add_index "projets_themes", ["projet_id"], name: "index_projets_themes_on_projet_id", using: :btree
+  add_index "projets_themes", ["theme_id"], name: "index_projets_themes_on_theme_id", using: :btree
+
   create_table "suggested_operateurs", id: false, force: :cascade do |t|
     t.integer "projet_id"
     t.integer "intervenant_id"
@@ -326,12 +329,10 @@ ActiveRecord::Schema.define(version: 20170405160145) do
   add_foreign_key "invitations", "intervenants"
   add_foreign_key "invitations", "projets"
   add_foreign_key "occupants", "projets"
-  add_foreign_key "prestations", "projets"
-  add_foreign_key "prestations", "themes"
+  add_foreign_key "prestations_projets", "prestations"
+  add_foreign_key "prestations_projets", "projets"
   add_foreign_key "projet_aides", "aides"
   add_foreign_key "projet_aides", "projets"
-  add_foreign_key "projet_prestations", "prestations"
-  add_foreign_key "projet_prestations", "projets"
   add_foreign_key "projets", "adresses", column: "adresse_a_renover_id"
   add_foreign_key "projets", "adresses", column: "adresse_postale_id"
   add_foreign_key "projets", "agents", column: "agent_instructeur_id"

--- a/db/seeds/002_themes.rb
+++ b/db/seeds/002_themes.rb
@@ -1,84 +1,19 @@
 class Seeder
-  THEMES = {
-    "Autonomie" => [
-      "Remplacement d’une baignoire par une douche",
-      "Barre de maintien",
-      "WC surélevé",
-      "Lavabo adapté",
-      "Monte Escalier - Ascenseur - Monte personne",
-      "Meubles PMR",
-      "Unité de vie",
-      "Volets roulants",
-      "Motorisation de volets roulants",
-      "Élargissement de portes",
-      "Transformation d’une pièce non habitable en salle de bain",
-      "Création unité de vie dans annexe",
-      "Élargissement cloisons",
-      "Repères lumineux pour personne malentendante",
-      "Cheminement extérieur",
-    ],
-    "Habiter mieux" => [
-      "Chaudière",
-      "Condensation",
-      "Basse température",
-      "Radiateurs",
-      "Régulation de chauffage",
-      "Vannes thermostatiques",
-      "Poëlle à pellets",
-      "Poëlle bois bûches",
-      "Insert",
-      "Radiateurs électriques",
-      "Chauffe eau électrique",
-      "Chauffe eau thermodynamique",
-      "Production ECS",
-      "Chauffe eau solaire",
-      "VMC simple",
-      "VMC Double flux",
-      "VMC Hygro type A",
-      "VMC Hygro type B",
-      "Fenêtres",
-      "Volets",
-      "Porte d’entrée",
-      "Isolation murs + plancher + toit",
-      "Isolation plancher",
-      "Isolation des combles",
-      "Isolation sous toiture",
-      "Isolation murs extérieurs",
-      "Pompe à chaleur air/air",
-      "Pompe à chaleur air/eau",
-      "Pompe à chaleur eau/air",
-      "Pompe à chaleur eau/eau",
-      "Géothermie",
-    ],
-    "Autres travaux" => [
-      "Couverture",
-      "Charpente",
-      "Fumisterie",
-      "Gros oeuvre (mur, dalles…)",
-      "Carrelages - Faïences",
-      "Plomberie sanitaires",
-      "Électricité",
-      "Mise en sécurité installation électrique",
-      "Plâtrerie",
-      "Menuiseries intérieures",
-      "Réseaux",
-      "Assainissement non collectif",
-      "Peintures",
-      "Suppresssion peinture au plomb",
-    ],
-  }
+  THEMES = [
+    "Énergie",
+    "Autonomie",
+    "Travaux lourds",
+    "SSH - petite LHI",
+    "Autres travaux",
+  ]
 
   def seed_themes
     table_name = 'themes'
     seeding table_name
     progress do
-      THEMES.each do |libelle_theme, prestations|
+      THEMES.each do |libelle_theme|
         theme = Theme.find_or_create_by!(libelle: libelle_theme)
         ahead!
-        prestations.each do |libelle_prestation|
-          Prestation.find_or_create_by!(theme: theme, libelle: libelle_prestation)
-          ahead!('+')
-        end
       end
     end
   end

--- a/db/seeds/004_prestations.rb
+++ b/db/seeds/004_prestations.rb
@@ -1,0 +1,75 @@
+class Seeder
+  PRESTATIONS = [
+    "Remplacement d’une baignoire par une douche",
+    "Barre de maintien",
+    "WC surélevé",
+    "Lavabo adapté",
+    "Monte Escalier - Ascenseur - Monte personne",
+    "Meubles PMR",
+    "Unité de vie",
+    "Volets roulants",
+    "Motorisation de volets roulants",
+    "Élargissement de portes",
+    "Transformation d’une pièce non habitable en salle de bain",
+    "Création unité de vie dans annexe",
+    "Élargissement cloisons",
+    "Repères lumineux pour personne malentendante",
+    "Cheminement extérieur",
+    "Chaudière",
+    "Condensation",
+    "Basse température",
+    "Radiateurs",
+    "Régulation de chauffage",
+    "Vannes thermostatiques",
+    "Poëlle à pellets",
+    "Poëlle bois bûches",
+    "Insert",
+    "Radiateurs électriques",
+    "Chauffe eau électrique",
+    "Chauffe eau thermodynamique",
+    "Production ECS",
+    "Chauffe eau solaire",
+    "VMC simple",
+    "VMC Double flux",
+    "VMC Hygro type A",
+    "VMC Hygro type B",
+    "Fenêtres",
+    "Volets",
+    "Porte d’entrée",
+    "Isolation murs + plancher + toit",
+    "Isolation plancher",
+    "Isolation des combles",
+    "Isolation sous toiture",
+    "Isolation murs extérieurs",
+    "Pompe à chaleur air/air",
+    "Pompe à chaleur air/eau",
+    "Pompe à chaleur eau/air",
+    "Pompe à chaleur eau/eau",
+    "Géothermie",
+    "Couverture",
+    "Charpente",
+    "Fumisterie",
+    "Gros oeuvre (mur, dalles…)",
+    "Carrelages - Faïences",
+    "Plomberie sanitaires",
+    "Électricité",
+    "Mise en sécurité installation électrique",
+    "Plâtrerie",
+    "Menuiseries intérieures",
+    "Réseaux",
+    "Assainissement non collectif",
+    "Peintures",
+    "Suppresssion peinture au plomb",
+  ]
+
+  def seed_prestations
+    table_name = 'prestations'
+    seeding table_name
+    progress do
+      PRESTATIONS.each do |libelle_prestation|
+        Prestation.find_or_create_by!(libelle: libelle_prestation)
+        ahead!
+      end
+    end
+  end
+end

--- a/spec/features/admin/themes_spec.rb
+++ b/spec/features/admin/themes_spec.rb
@@ -8,6 +8,5 @@ feature "Administration des thèmes" do
     visit admin_themes_path
     expect(page).to have_content("Autonomie")
     expect(page).to have_content("Autres travaux")
-    expect(page).to have_content("Habiter mieux")
   end
 end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -20,6 +20,7 @@ describe Projet do
     it { is_expected.to belong_to :operateur }
     it { is_expected.to belong_to :adresse_postale }
     it { is_expected.to have_and_belong_to_many :prestations }
+    it { is_expected.to have_and_belong_to_many :themes }
     it { is_expected.to belong_to :agent_operateur }
     it { is_expected.to belong_to :agent_instructeur }
 

--- a/spec/models/theme_spec.rb
+++ b/spec/models/theme_spec.rb
@@ -5,6 +5,7 @@ describe Theme do
     let(:theme) { build :theme }
     it { expect(theme).to be_valid }
     it { is_expected.to validate_presence_of :libelle }
+    it { is_expected.to have_and_belong_to_many :projets }
   end
 
   describe '#nom' do


### PR DESCRIPTION
Propose au demandeur de sélectionner le(s) type(s) d’intervention de son projet :
- migrations
- nettoyage des relations entre modèles
- mise à jour des `seeds`
- vue minimale

Les types d’intervention ne définissent plus la liste des prestations proposées.

Reste à faire :
- balisage / CSS en simpleform
- limiter la sélection à 2 types maximum