### PR TITLE
 PF424 découpe DemarrageProjetController en trois controllers différents

### DIFF
--- a/app/controllers/demandes_controller.rb
+++ b/app/controllers/demandes_controller.rb
@@ -1,0 +1,76 @@
+class DemandesController < ApplicationController
+  layout 'inscription'
+
+  before_action :dossier_ou_projet
+  before_action :assert_projet_courant
+  before_action :authentifie
+
+  def show
+    @demande = projet_demande
+    @page_heading = 'Inscription'
+    @action_label = if needs_next_step? then action_label_create else action_label_update end
+  end
+
+  def update
+    @projet_courant.demande = projet_demande
+    if demande_params_valid?
+      @projet_courant.demande.update_attributes(demande_params)
+      redirect_to_next_step
+    else
+      redirect_to projet_demande_path(@projet_courant), alert: t('demarrage_projet.demande.erreurs.besoin_obligatoire')
+    end
+  end
+
+private
+
+  def action_label_create
+    t('demarrage_projet.action')
+  end
+
+  def action_label_update
+    t('projets.edition.action')
+  end
+
+  def projet_demande
+    @projet_courant.demande || @projet_courant.build_demande
+  end
+
+  def demande_params
+    params.require(:demande).permit(
+      :changement_chauffage,
+      :froid,
+      :probleme_deplacement,
+      :accessibilite,
+      :hospitalisation,
+      :adaptation_salle_de_bain,
+      :autre,
+      :travaux_fenetres,
+      :travaux_isolation,
+      :travaux_chauffage,
+      :travaux_adaptation_sdb,
+      :travaux_monte_escalier,
+      :travaux_amenagement_ext,
+      :travaux_autres,
+      :complement,
+      :annee_construction,
+      :ptz,
+      :date_achevement_15_ans
+    )
+  end
+
+  def demande_params_valid?
+    demande_params.values.include?('1')
+  end
+
+  def needs_next_step?
+    @projet_courant.invited_operateur.blank? && @projet_courant.invited_pris.blank?
+  end
+
+  def redirect_to_next_step
+    if needs_next_step?
+      redirect_to projet_mise_en_relation_path(@projet_courant)
+    else
+      redirect_to projet_path(@projet_courant)
+    end
+  end
+end

--- a/app/controllers/demandeurs_controller.rb
+++ b/app/controllers/demandeurs_controller.rb
@@ -1,0 +1,132 @@
+class DemandeursController < ApplicationController
+  layout 'inscription'
+
+  before_action :dossier_ou_projet
+  before_action :assert_projet_courant
+  before_action :authentifie
+
+  def show
+    render_show
+  end
+
+  def update
+    if save_demandeur
+      return redirect_to_next_step
+    else
+      render_show
+    end
+  end
+
+private
+  # Show -----------------------
+
+  def action_label_create
+    t('demarrage_projet.action')
+  end
+
+  def action_label_update
+    t('projets.edition.action')
+  end
+
+  def render_show
+    @projet_courant.personne ||= Personne.new
+    @demandeur ||= @projet_courant.demandeur_principal
+
+    @page_heading = 'Inscription'
+    @declarants = @projet_courant.occupants.declarants.collect { |o| [ o.fullname, o.id ] }
+    @action_label = if needs_next_step? then action_label_create else action_label_update end
+
+    render :show
+  end
+
+  # Update ---------------------
+
+  def projet_params
+    params.require(:projet).permit(
+      :civilite,
+      :tel,
+      :email,
+    )
+  end
+
+  def projet_personne_params
+    params.require(:projet).permit(
+      personne_attributes: [
+        :id,
+        :prenom,
+        :nom,
+        :tel,
+        :email,
+        :lien_avec_demandeur,
+        :civilite
+      ]
+    )
+  end
+
+  def demandeur_principal_params
+    params.fetch(:demandeur_principal, {}).permit(:civilite)
+  end
+
+  def save_demandeur
+    begin
+      @projet_courant.adresse_postale = ProjetInitializer.new.precise_adresse(
+        params[:projet][:adresse_postale],
+        previous_value: @projet_courant.adresse_postale,
+        required: true
+      )
+
+      @projet_courant.adresse_a_renover = ProjetInitializer.new.precise_adresse(
+        params[:projet][:adresse_a_renover],
+        previous_value: @projet_courant.adresse_a_renover,
+        required: false
+      )
+    rescue => e
+      flash.now[:alert] = e.message
+      return false
+    end
+
+    @projet_courant.assign_attributes(projet_params)
+    if "1" == params[:contact]
+      @projet_courant.assign_attributes(projet_personne_params)
+    else
+      if @projet_courant.personne.present?
+        personne = @projet_courant.personne
+        @projet_courant.update_attribute(:personne_id, nil)
+        personne.destroy!
+      else
+        @projet_courant.personne = nil
+      end
+    end
+    unless @projet_courant.save
+      flash.now[:alert] = t('demarrage_projet.demandeur.erreurs.enregistrement_demandeur')
+      return false
+    end
+
+    demandeur_id = params[:projet][:demandeur_id]
+    needs_saving_demandeur = demandeur_id.present?
+    if needs_saving_demandeur && !assign_demandeur(demandeur_id)
+      flash.now[:alert] = t('demarrage_projet.demandeur.erreurs.enregistrement_demandeur')
+      return false
+    end
+
+    true
+  end
+
+  def assign_demandeur(demandeur_id)
+    @demandeur = @projet_courant.change_demandeur(demandeur_id)
+    @demandeur.assign_attributes(demandeur_principal_params)
+    @demandeur.save
+  end
+
+  def needs_next_step?
+    @projet_courant.demande.blank? || ! @projet_courant.demande.complete?
+  end
+
+  def redirect_to_next_step
+    if needs_next_step?
+      redirect_to projet_avis_impositions_path(@projet_courant)
+    else
+      redirect_to projet_path(@projet_courant)
+    end
+  end
+end

--- a/app/controllers/demarrage_projet_controller.rb
+++ b/app/controllers/demarrage_projet_controller.rb
@@ -6,23 +6,8 @@ class DemarrageProjetController < ApplicationController
   before_action :authentifie
   before_action :init_view
 
-  def demande
-    @demande = projet_demande
-    @action_label = if needs_mise_en_relation_step? then action_label_create else action_label_update end
-  end
-
-  def update_demande
-    @projet_courant.demande = projet_demande
-    if demande_params_valid?
-      @projet_courant.demande.update_attributes(demande_params)
-      demande_redirect_to_next_step
-    else
-      redirect_to projet_demande_path(@projet_courant), alert: t('demarrage_projet.demande.erreurs.besoin_obligatoire')
-    end
-  end
-
   def mise_en_relation
-    @demande = projet_demande
+    @demande = @projet_courant.demande
     @pris_departement = @projet_courant.intervenants_disponibles(role: :pris).first
     if @pris_departement.blank?
       raise "Il n’y a pas de PRIS disponible pour le département #{@projet_courant.departement}"
@@ -51,47 +36,8 @@ private
     @page_heading = 'Inscription'
   end
 
-  def projet_demande
-    @projet_courant.demande || @projet_courant.build_demande
-  end
-
-  def demande_params
-    params.require(:demande).permit(
-      :changement_chauffage,
-      :froid,
-      :probleme_deplacement,
-      :accessibilite,
-      :hospitalisation,
-      :adaptation_salle_de_bain,
-      :autre,
-      :travaux_fenetres,
-      :travaux_isolation,
-      :travaux_chauffage,
-      :travaux_adaptation_sdb,
-      :travaux_monte_escalier,
-      :travaux_amenagement_ext,
-      :travaux_autres,
-      :complement,
-      :annee_construction,
-      :ptz,
-      :date_achevement_15_ans
-    )
-  end
-
-  def demande_params_valid?
-    demande_params.values.include?('1')
-  end
-
   def needs_mise_en_relation_step?
     @projet_courant.invited_operateur.blank? && @projet_courant.invited_pris.blank?
-  end
-
-  def demande_redirect_to_next_step
-    if needs_mise_en_relation_step?
-      redirect_to projet_mise_en_relation_path(@projet_courant)
-    else
-      redirect_to projet_path(@projet_courant)
-    end
   end
 
   def action_label_create

--- a/app/controllers/mises_en_relation_controller.rb
+++ b/app/controllers/mises_en_relation_controller.rb
@@ -1,21 +1,21 @@
-class DemarrageProjetController < ApplicationController
+class MisesEnRelationController < ApplicationController
   layout 'inscription'
 
   before_action :dossier_ou_projet
   before_action :assert_projet_courant
   before_action :authentifie
-  before_action :init_view
 
-  def mise_en_relation
+  def show
     @demande = @projet_courant.demande
     @pris_departement = @projet_courant.intervenants_disponibles(role: :pris).first
     if @pris_departement.blank?
       raise "Il n’y a pas de PRIS disponible pour le département #{@projet_courant.departement}"
     end
-    @action_label = if needs_mise_en_relation_step? then action_label_create else action_label_update end
+    @page_heading = 'Inscription'
+    @action_label = if needs_mise_en_relation? then action_label_create else action_label_update end
   end
 
-  def update_mise_en_relation
+  def update
     begin
       @projet_courant.update_attribute(:disponibilite, params[:projet][:disponibilite])
       intervenant = Intervenant.find_by_id(params[:intervenant])
@@ -27,16 +27,13 @@ class DemarrageProjetController < ApplicationController
       redirect_to projet_path(@projet_courant)
     rescue => e
       logger.error e.message
-      redirect_to projet_mise_en_relation_path(@projet_courant), alert: "Une erreur s’est produite lors de l’enregistrement de l’intervenant."
+      redirect_to projet_mise_en_relation_path(@projet_courant), alert: t('demarrage_projet.mise_en_relation.error')
     end
   end
 
 private
-  def init_view
-    @page_heading = 'Inscription'
-  end
 
-  def needs_mise_en_relation_step?
+  def needs_mise_en_relation?
     @projet_courant.invited_operateur.blank? && @projet_courant.invited_pris.blank?
   end
 

--- a/app/views/choix_operateur/new.html.slim
+++ b/app/views/choix_operateur/new.html.slim
@@ -41,6 +41,6 @@
                   p= operateur.description_adresse
                   = btn tag: :a, name: t('projets.visualisation.invitation_intervenant')
           hr/
-        = render 'demarrage_projet/disponibilite_form'
+        = render 'mises_en_relation/disponibilite_form'
         = btn name: @action_label, class: 'btn-large btn-centered js-engagement', icon: 'ok'
     </div><!-- Workaround for allowing slim to honor the scope of the submit tag -->

--- a/app/views/demandes/show.html.slim
+++ b/app/views/demandes/show.html.slim
@@ -1,4 +1,4 @@
-= form_for @demande, url: {controller: 'demarrage_projet', action: 'update_demande'}, method: 'patch', html: { class:'ui form'}  do |f|
+= form_for @demande, url: { controller: 'demandes', action: 'update' }, method: 'patch', html: { class:'ui form'}  do |f|
   section.projet
     h2 = t('demarrage_projet.demande.section_projet_envisage')
     p.chapo = t('demarrage_projet.demande.titre_besoins')

--- a/app/views/demandeurs/show.html.slim
+++ b/app/views/demandeurs/show.html.slim
@@ -1,5 +1,5 @@
 /! Demandeur
-= form_for @projet_courant, url: { controller: 'demarrage_projet', action: 'demandeur' }, method: 'post', html: { class: 'form' }  do |f|
+= form_for @projet_courant, url: { controller: 'demandeurs', action: 'update' }, html: { class: 'form' }  do |f|
   = render 'shared/errors', resource: @projet_courant
   = render 'shared/errors', resource: @demandeur
   section.demandeur

--- a/app/views/demarrage_projet/mise_en_relation.html.slim
+++ b/app/views/demarrage_projet/mise_en_relation.html.slim
@@ -1,4 +1,4 @@
-= form_for @demande, url: {controller: 'demarrage_projet', action: 'update_mise_en_relation'}, method: 'patch', html: { class:'ui form'}  do |f|
+= form_for @projet_courant, url: {controller: 'demarrage_projet', action: 'update_mise_en_relation'}, method: 'patch', html: { class:'ui form'}  do |f|
     <div>
       /! Eligibilite
       section.eligibilite

--- a/app/views/mises_en_relation/_disponibilite_form.html.slim
+++ b/app/views/mises_en_relation/_disponibilite_form.html.slim
@@ -1,4 +1,4 @@
-= form_for @projet_courant, url: {controller: 'demarrage_projet', action: 'mise_en_relation'}, method: 'patch', html: { class:'ui form'}  do |f|
+= form_for @projet_courant, url: {controller: 'mises_en_relation', action: 'update'}, method: 'patch', html: { class:'ui form'}  do |f|
   ul.ins-form
     li.full
       = f.label :disponibilite, t('helpers.label.projet.disponibilite')

--- a/app/views/mises_en_relation/show.html.slim
+++ b/app/views/mises_en_relation/show.html.slim
@@ -1,4 +1,4 @@
-= form_for @projet_courant, url: {controller: 'demarrage_projet', action: 'update_mise_en_relation'}, method: 'patch', html: { class:'ui form'}  do |f|
+= form_for @projet_courant, url: {controller: 'mises_en_relation', action: 'update'}, method: 'patch', html: { class:'ui form'}  do |f|
     <div>
       /! Eligibilite
       section.eligibilite
@@ -18,6 +18,6 @@
             = t('demarrage_projet.mise_en_relation.un_pris_va_vous_contacter', { pris: @pris_departement.raison_sociale})
         p.chapo Il pourra vous recommander un opérateur chargé de vous accompagner tout au long de votre démarche.
         = hidden_field_tag :intervenant, @pris_departement.id
-        = render 'disponibilite_form'
+        = render 'mises_en_relation/disponibilite_form'
       = btn name: @action_label, class: 'btn-large btn-centered js-engagement', icon: 'ok'
     </div><!-- Workaround for allowing slim to honor the scope of the submit tag -->

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,6 +13,7 @@
 # These inflection rules are supported but not enabled by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'API'
-  inflect.irregular 'plan_travaux','plans_travaux'
-  inflect.irregular 'plan_financements','plans_financements'
+  inflect.irregular 'mise_en_relation',  'mises_en_relation'
+  inflect.irregular 'plan_travaux',      'plans_travaux'
+  inflect.irregular 'plan_financements', 'plans_financements'
 end

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -143,6 +143,7 @@ fr:
       non_eligible_recontacter: "Si vous n’êtes pas recontacté dans un délai d’une semaine merci de bien vouloir contacter le Point Rénovation Info Service de votre département, « %{pris} », ou l’opérateur de l’opération programmée"
       un_pris_va_vous_contacter: "Le Point Rénovation Info Service de votre département, « %{pris} », va vous contacter prochainement."
       disponibilite_placeholder: "Le matin, entre 8h et 11h"
+      error: "Une erreur s’est produite lors de l’enregistrement de l’intervenant."
 
   # ----------------------- Page de visualisation du projet ---------------------
   projets:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,8 +37,7 @@ Rails.application.routes.draw do
     resources :projets, only: [], concerns: :projectable do
       resources :avis_impositions, only: :destroy
       resource :demandeur
-      get       :demande,          controller: 'demarrage_projet'
-      patch     :demande,          controller: 'demarrage_projet', action: :update_demande
+      resource :demande
       get       :mise_en_relation, controller: 'demarrage_projet'
       patch     :mise_en_relation, controller: 'demarrage_projet', action: :update_mise_en_relation
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,17 +36,15 @@ Rails.application.routes.draw do
 
     resources :projets, only: [], concerns: :projectable do
       resources :avis_impositions, only: :destroy
-      resource :demandeur
-      resource :demande
-      get       :mise_en_relation, controller: 'demarrage_projet'
-      patch     :mise_en_relation, controller: 'demarrage_projet', action: :update_mise_en_relation
-
-      get       :choix_operateur,      action: :new,    controller: 'choix_operateur'
-      patch     :choix_operateur,      action: :choose, controller: 'choix_operateur'
-      get       :engagement_operateur, action: :new,    controller: 'engagement_operateur'
-      post      :engagement_operateur, action: :create, controller: 'engagement_operateur'
-      get       :transmission,         action: :new,    controller: 'transmission'
-      post      :transmission,         action: :create, controller: 'transmission'
+      resource :demandeur,         only: [:show, :update]
+      resource :demande,           only: [:show, :update]
+      resource :mise_en_relation,  only: [:show, :update]
+      get      :choix_operateur,      action: :new,    controller: 'choix_operateur'
+      patch    :choix_operateur,      action: :choose, controller: 'choix_operateur'
+      get      :engagement_operateur, action: :new,    controller: 'engagement_operateur'
+      post     :engagement_operateur, action: :create, controller: 'engagement_operateur'
+      get      :transmission,         action: :new,    controller: 'transmission'
+      post     :transmission,         action: :create, controller: 'transmission'
     end
     resources :projets, only: [:show, :edit, :update], param: :projet_id
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,8 +36,7 @@ Rails.application.routes.draw do
 
     resources :projets, only: [], concerns: :projectable do
       resources :avis_impositions, only: :destroy
-      get       :demandeur,        controller: 'demarrage_projet'
-      post      :demandeur,        controller: 'demarrage_projet'
+      resource :demandeur
       get       :demande,          controller: 'demarrage_projet'
       patch     :demande,          controller: 'demarrage_projet', action: :update_demande
       get       :mise_en_relation, controller: 'demarrage_projet'

--- a/spec/controllers/demandes_controller_spec.rb
+++ b/spec/controllers/demandes_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'support/mpal_helper'
+require 'support/api_ban_helper'
+
+describe DemandesController do
+  let(:projet) { create :projet, :prospect, demande: nil }
+
+  before(:each) do
+    authenticate_as_particulier(projet.numero_fiscal)
+  end
+
+  describe "#show" do
+    before do
+      get :show, projet_id: projet.id
+    end
+
+    it "renders the template" do
+      expect(response).to render_template(:show)
+      expect(assigns(:page_heading)).to eq 'Inscription'
+    end
+  end
+
+  describe "#update" do
+    context "quand les paramètres sont valides" do
+      it "met à jour la demande" do
+        patch :update, {
+          projet_id: projet.id,
+          demande: {
+            changement_chauffage: '1'
+          }
+        }
+        projet.demande.reload
+        expect(projet.demande.changement_chauffage).to be true
+        expect(response).to redirect_to projet_mise_en_relation_path(projet)
+        expect(flash[:alert]).to be_blank
+      end
+    end
+
+    context "quand aucun besoin n'est sélectionné" do
+      it "affiche une erreur" do
+        patch :update, {
+          projet_id: projet.id,
+          demande: {
+            changement_chauffage: ''
+          }
+        }
+        expect(response).to redirect_to projet_demande_path(projet)
+        expect(flash[:alert]).to eq I18n.t('demarrage_projet.demande.erreurs.besoin_obligatoire')
+      end
+    end
+  end
+end

--- a/spec/controllers/demandeurs_controller_spec.rb
+++ b/spec/controllers/demandeurs_controller_spec.rb
@@ -2,14 +2,25 @@ require 'rails_helper'
 require 'support/mpal_helper'
 require 'support/api_ban_helper'
 
-describe DemarrageProjetController do
+describe DemandeursController do
   let(:projet) { create :projet, :prospect, demandeurs_count: 2 }
 
   before(:each) do
     authenticate_as_particulier(projet.numero_fiscal)
   end
 
-  describe "#demandeur" do
+  describe "#show" do
+    before do
+      get :show, projet_id: projet.id
+    end
+
+    it "renders the template" do
+      expect(response).to render_template(:show)
+      expect(assigns(:page_heading)).to eq 'Inscription'
+    end
+  end
+
+  describe "#update" do
     let(:projet_params) do {} end
     let(:params) do
       default_params = { adresse_postale: projet.adresse_postale.description }
@@ -21,7 +32,7 @@ describe DemarrageProjetController do
     end
 
     before(:each) do
-      post :demandeur, params
+      post :update, params
       projet.reload
     end
 
@@ -67,7 +78,7 @@ describe DemarrageProjetController do
       let(:projet_params) do { adresse_postale: '' } end
 
       it "affiche une erreur" do
-        expect(response).to render_template(:demandeur)
+        expect(response).to render_template(:show)
         expect(flash[:alert]).to eq I18n.t('demarrage_projet.demandeur.erreurs.adresse_vide')
       end
     end
@@ -103,7 +114,7 @@ describe DemarrageProjetController do
       context "et n'est pas disponible dans la BAN" do
         let(:projet_params) do { adresse_postale: Fakeweb::ApiBan::ADDRESS_UNKNOWN } end
         it "affiche une erreur" do
-          expect(response).to render_template(:demandeur)
+          expect(response).to render_template(:show)
           expect(flash[:alert]).to eq I18n.t('demarrage_projet.demandeur.erreurs.adresse_inconnue')
         end
       end
@@ -160,7 +171,7 @@ describe DemarrageProjetController do
   context "lorsque une information est erronée" do
     before do
       projet.demandeur_principal.update_attribute(:civilite, nil)
-      post :demandeur, {
+      post :update, {
         contact: "1",
         projet_id: projet.id,
         projet: {
@@ -168,7 +179,6 @@ describe DemarrageProjetController do
           demandeur_id: projet.demandeur_principal.id
         }
       }
-      projet.reload
     end
 
     it "affiche une erreur" do

--- a/spec/controllers/mises_en_relation_controller_spec.rb
+++ b/spec/controllers/mises_en_relation_controller_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+require 'support/mpal_helper'
+require 'support/api_ban_helper'
+
+describe MisesEnRelationController do
+  let(:projet) { create :projet, :prospect }
+
+  before(:each) do
+    authenticate_as_particulier(projet.numero_fiscal)
+  end
+
+  describe "#show" do
+    before do
+      get :show, projet_id: projet.id
+    end
+
+    it "renders the template" do
+      expect(response).to render_template(:show)
+      expect(assigns(:page_heading)).to eq 'Inscription'
+    end
+  end
+
+  describe "#update" do
+    context "quand les paramètres sont valides" do
+      let(:pris) { create :pris }
+
+      before do
+        patch :update, {
+          projet_id: projet.id,
+          projet: {
+            disponibilite: 'plutôt le matin'
+          },
+          intervenant: pris.id
+        }
+        projet.reload
+      end
+
+      it "met à jour le projet" do
+        expect(projet.disponibilite).to eq "plutôt le matin"
+        expect(projet.invited_pris).to eq pris
+      end
+
+      it "redirige vers la page principale du projet" do
+        expect(response).to redirect_to projet_path(projet)
+        expect(flash[:notice_titre]).to eq I18n.t('invitations.messages.succes_titre')
+        expect(flash[:notice]).to eq I18n.t('invitations.messages.succes', intervenant: pris.raison_sociale)
+      end
+    end
+
+    context "quand une erreur se produit lors de l'enregistrement" do
+      it "affiche une erreur" do
+        patch :update, {
+          projet_id: projet.id,
+          projet: nil,
+          intervenant_id: nil
+        }
+        expect(response).to redirect_to projet_mise_en_relation_path(projet)
+        expect(flash[:alert]).to eq I18n.t('demarrage_projet.mise_en_relation.error')
+      end
+    end
+  end
+end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -43,13 +43,6 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_invited_pris do
-      after(:build) do |projet|
-        pris = create(:pris, departements: [projet.departement])
-        projet.invitations << create(:invitation, projet: projet, intervenant: pris)
-      end
-    end
-
     trait :with_suggested_operateurs do
       after(:build) do |projet|
         operateurA = create(:operateur, departements: [projet.departement])
@@ -98,7 +91,7 @@ FactoryGirl.define do
     trait :with_invited_pris do
       after(:build) do |projet|
         pris = create(:pris, departements: [projet.departement])
-        create(:invitation, projet: projet, intervenant: pris)
+        projet.invitations << create(:invitation, projet: projet, intervenant: pris)
       end
     end
 


### PR DESCRIPTION
À nouveau un autre refactoring, en préparation de l'édition des infos du demandeur par l'opérateur.

Ça se fait en plusieurs étape. On en est ici :

- [x] Refactore les specs (#316 ; déjà fait)
- [x] Renomme les actions de DemarrageController (#318 ; déjà fait)
- [ ] **Sépare les pages du DemarrageProjetController en plusieurs Controller indépendants (cette PR)**
- [ ] _Permet aux opérateur d'accéder aux pages d'édition de la demande (TODO)_

Concrètement, cette PR extrait les trois pages du `DemarrageProjetController` chacune dans un controller différent.

Ça a pour avantage de :

- **Simplifier le routing** : on a juste `resource :demande`, au lieu de tout un pataquès,
- **Ne pas changer les URLs** : les URLs ont été mises à jour dans la PR précédente ; on a donc de nouveaux controllers, mais qui étaient déjà mappés sur des URLs propres précédemment,
- **Simplifier les contrôleurs** : le code de chaque action est mieux isolé,
- **Ajouter des specs** : parce qu'au passage je me suis rendu compte que y'avait pas de spec de controller pour une bonne partie de ces trucs là,
- **Retirer du franglais** : parce qu'on n'a plus besoin de `update_mise_en_relation` 🙌

Et au final ça va permettre dans la prochaine PR de factoriser ces routes dans `projectable` – et donc de laisser les opérateurs accéder aux détails d'un dossier.

@jvignolles 😘 