### PR TITLE
PF376 fix affichage informations instructeur

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -65,6 +65,22 @@ input:-ms-input-placeholder {
   @-ms-viewport { width: device-width; }
 }
 
+/** Lists */
+ul.list {
+  margin-bottom: 1em;
+  li {
+    list-style-type: disc;
+    margin-left: 1.5em;
+  }
+}
+ol.list {
+  margin-bottom: 1em;
+  li {
+    list-style-type: decimal;
+    margin-left: 1.5em;
+  }
+}
+
 /** Tables */
 .table {
   background-color: white;

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -287,6 +287,8 @@ class Projet < ActiveRecord::Base
     occupants.map { |occupant| occupant.prenom.capitalize }.join(' et ')
   end
 
+  # TODO Attention : cette date est importante à conserver alors que les invitations
+  # sont faciles à supprimer. En attente de mise en place de l’historisation.
   def date_depot
     invitation_intervenant = invitations.where(intervenant: invited_instructeur).first
     if invitation_intervenant

--- a/app/views/projets/_projet_transmis_pour_instruction.html.slim
+++ b/app/views/projets/_projet_transmis_pour_instruction.html.slim
@@ -5,5 +5,12 @@ article.block.recap-projet
       = render 'projets/projet_invoice'
 
       h4 État de la demande
-      p= t('projets.transmissions.messages.info_demandeur', instructeur: Intervenant.instructeur_pour(@projet_courant).raison_sociale)
+      p= t('projets.transmission.messages.success', instructeur: '')
+      - instructeur = @projet_courant.invited_instructeur
+      ul.list
+        - [:raison_sociale, :adresse_postale, :phone].each do |field|
+          - if (value = instructeur.send(field)).present?
+            li= value
+      p= t('projets.transmission.messages.info_demandeur')
       = yield (:cta)
+

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -15,7 +15,7 @@
             ul.ins-form
               li
                 = f.label :date_de_visite, "Date de visite (obligatoire)"
-                = f.text_field :date_de_visite, placeholder: "JJ/MM/AAAA", value: @projet_courant.date_de_visite.try(:strftime, "%d/%m/%Y")
+                = f.text_field :date_de_visite, placeholder: "JJ/MM/AAAA", value: format_date(@projet_courant.date_de_visite)
               li
                 = f.label :type_logement, "Type de logement"
                 = f.select :type_logement, options_for_select(["Maison","Appartement"], @projet_courant.type_logement)

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -216,7 +216,7 @@ fr:
       messages:
         success: "Dépôt effectué auprès du service en charge de l’instruction : %{instructeur}"
         error: Une erreur s’est produite lors de la transmission du dossier aux services instructeurs.
-        info_demandeur: "Votre projet a bien été envoyé à %{instructeur}. Vous serez informé par email de l’avancement de votre dossier."
+        info_demandeur: "Vous serez informé par email de l’avancement de votre dossier."
         validation_email_vide: "Veuillez remplir votre email pour déposer votre demande"
         validation_email: "Veuillez saisir une adresse email valide pour déposer votre demande"
 

--- a/db/seeds/001_intervenants.rb
+++ b/db/seeds/001_intervenants.rb
@@ -35,6 +35,7 @@ class Seeder
       raison_sociale: "PRIS-DDT-88",
       clavis_service_id: "5269",
       adresse_postale: "22-26 Avenue Dutac, 88000 Épinal",
+      phone: "03 33 44 55 66",
       email: "pris88@anah.gouv.fr",
       roles: ["pris"]
     },
@@ -43,6 +44,7 @@ class Seeder
       raison_sociale: "DDT des VOSGES",
       clavis_service_id: "5119",
       adresse_postale: "22-26 Avenue Dutac, 88000 Épinal",
+      phone: "03 99 88 77 66",
       email: "delegation88-1@anah.gouv.fr",
       roles: ["instructeur"]
     },
@@ -51,6 +53,7 @@ class Seeder
       raison_sociale: "URBAM CONSEIL SAS",
       clavis_service_id: "5265",
       adresse_postale: "5 Rue Thiers, 88000 Épinal",
+      phone: "03 00 11 22 33",
       email: "operateur88-1@anah.gouv.fr",
       roles: ["operateur"]
     },


### PR DESCRIPTION
Nous affichons les coordonnées du service instructeur de manière "fixe" (dans le corps d’un des blocs), en plus du message de notification.

<img width="875" alt="capture d ecran 2017-04-18 a 16 54 06" src="https://cloud.githubusercontent.com/assets/2368859/25137417/f82f4c22-2457-11e7-8165-0002684d4f51.png">
