### PR TITLE
PF421 met à jour la liste des travaux

### DIFF
--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -17,7 +17,7 @@ module ProjetConcern
 
       assign_projet_if_needed
       @themes = Theme.ordered.all
-      @prestations = Prestation.all
+      @prestations = Prestation.where(active: true) | @projet_courant.prestations
       render "projets/proposition"
     end
 

--- a/app/models/prestation.rb
+++ b/app/models/prestation.rb
@@ -1,3 +1,5 @@
 class Prestation < ActiveRecord::Base
   has_and_belongs_to_many :projets
+
+  validates_uniqueness_of :libelle
 end

--- a/db/migrate/20170412155125_add_active_to_prestations.rb
+++ b/db/migrate/20170412155125_add_active_to_prestations.rb
@@ -1,0 +1,5 @@
+class AddActiveToPrestations < ActiveRecord::Migration
+  def change
+    add_column :prestations, :active, :boolean, null: false, default: true
+  end
+end

--- a/lib/tasks/migrate_prestations.rake
+++ b/lib/tasks/migrate_prestations.rake
@@ -1,5 +1,6 @@
-class Seeder
-  PRESTATION_NAMES = [
+desc "Disable old prestations and add the new ones"
+task migrate_prestations: :environment do
+  new_prestation_names = [
     "Isolation murs par l'extérieur",
     "Isolation murs par l'extérieur partielle",
     "Isolation murs par l'intérieur",
@@ -149,14 +150,13 @@ class Seeder
     "Prévention des inondations",
   ]
 
-  def seed_prestations
-    table_name = 'prestations'
-    seeding table_name
-    progress do
-      PRESTATION_NAMES.each do |libelle_prestation|
-        Prestation.find_or_create_by!(libelle: libelle_prestation)
-        ahead!
-      end
-    end
+  downcased_new_prestation_names = new_prestation_names.map(&:downcase)
+
+  Prestation.all.each do |p|
+    p.update(active: false) unless downcased_new_prestation_names.include?(p.libelle.downcase)
+  end
+
+  new_prestation_names.each do |name|
+    Prestation.create libelle: name unless Prestation.where("lower(libelle) = ?", name.downcase).exists?
   end
 end

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -185,6 +185,20 @@ feature "Remplir la proposition de travaux" do
         expect(page).not_to have_content(prestation.libelle)
         expect(page).not_to have_content(aide.libelle)
       end
+
+      context "avec une prestation dépréciée" do
+        let!(:old_unused_prestation)  { create :prestation, libelle: 'Ancienne prestation non utilisée', active: false }
+        let!(:old_used_prestation)    { create :prestation, libelle: 'Ancienne prestation utilisée', active: false }
+
+        before { projet.prestations << old_used_prestation }
+
+        scenario "j'ai toujours accès à cette prestation" do
+          visit dossier_proposition_path(projet)
+          expect(page).not_to have_content('Ancienne prestation non utilisée')
+          expect(page).to have_content('Ancienne prestation utilisée')
+          expect(find("#prestation_#{old_used_prestation.id}")).to be_checked
+        end
+      end
     end
   end
 end

--- a/spec/lib/tasks/migrate_prestations_spec.rb
+++ b/spec/lib/tasks/migrate_prestations_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require 'support/rake_helper'
+
+describe 'migrate_prestations' do
+  include_context 'rake'
+
+  let(:new_prestations_count)     { 147 }
+  let!(:old_prestation)           { create :prestation, libelle: "Ancienne Prestation" }
+  let!(:current_prestation)       { create :prestation, libelle: "Isolation murs par l'extérieur" }
+  let!(:bold_written_prestation)  { create :prestation, libelle: "VOLETS" }
+  let!(:badly_written_prestation) { create :prestation, libelle: "Isolation murs par l'exterieur partielle" }
+
+  before { subject.invoke }
+
+  it "charge l'environment Rails" do
+    expect(subject.prerequisites).to include 'environment'
+  end
+
+  it "désactive les anciennes prestations" do
+    expect(old_prestation.reload.active).to be false
+    expect(current_prestation.reload.active).to be true
+    expect(bold_written_prestation.reload.active).to be true
+    expect(badly_written_prestation.reload.active).to be false
+  end
+
+  it "ajoute les nouvelles prestations" do
+    expect(Prestation.count > new_prestations_count).to be true
+  end
+
+  it "n'ajoute pas de doublons" do
+    expect(Prestation.where(libelle: current_prestation.libelle).count).to eq 1
+    expect(Prestation.where(["lower(libelle) = ?", bold_written_prestation.libelle.downcase]).count).to eq 1
+  end
+end

--- a/spec/support/rake_helper.rb
+++ b/spec/support/rake_helper.rb
@@ -1,0 +1,19 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end


### PR DESCRIPTION
Pour mettre à jour les travaux : 

- A partir d'une BDD de dev -> rake db:schema:load -> rake db:seed
- A partir d'une BDD en utilisation (prod) -> rake migrate_prestations

![travaux](https://cloud.githubusercontent.com/assets/24429245/25139405/70f544fe-245d-11e7-88f2-ecc771634b26.gif)
