### PR TITLE
PF424 permet à l'opérateur d'éditer les infos du demandeur

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -87,4 +87,10 @@ class ApplicationController < ActionController::Base
     send("#{@projet_or_dossier}_commentaires_path", projet)
   end
   helper_method :projet_or_dossier_commentaires_path
+
+  def projet_or_dossier_avis_impositions_path(projet)
+    assert_projet_or_dossier_defined
+    send("#{@projet_or_dossier}_avis_impositions_path", projet)
+  end
+  helper_method :projet_or_dossier_avis_impositions_path
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,4 +93,10 @@ class ApplicationController < ActionController::Base
     send("#{@projet_or_dossier}_avis_impositions_path", projet)
   end
   helper_method :projet_or_dossier_avis_impositions_path
+
+  def new_projet_or_dossier_avis_imposition_path(projet)
+    assert_projet_or_dossier_defined
+    send("new_#{@projet_or_dossier}_avis_imposition_path", projet)
+  end
+  helper_method :new_projet_or_dossier_avis_imposition_path
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,6 +94,12 @@ class ApplicationController < ActionController::Base
   end
   helper_method :projet_or_dossier_avis_impositions_path
 
+  def projet_or_dossier_avis_imposition_path(*args)
+    assert_projet_or_dossier_defined
+    send("#{@projet_or_dossier}_avis_imposition_path", *args)
+  end
+  helper_method :projet_or_dossier_avis_imposition_path
+
   def new_projet_or_dossier_avis_imposition_path(projet)
     assert_projet_or_dossier_defined
     send("new_#{@projet_or_dossier}_avis_imposition_path", projet)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,57 +64,43 @@ class ApplicationController < ActionController::Base
     @projet_or_dossier = current_agent ? "dossier" : "projet"
   end
 
-  def assert_projet_or_dossier_defined
-    if @projet_or_dossier.blank?
-      raise "`@projet_or_dossier` must be defined"
-    end
-  end
-
   def projet_or_dossier_path(projet)
-    assert_projet_or_dossier_defined
-    send("#{@projet_or_dossier}_path", projet)
+    send("#{projet_or_dossier}_path", projet)
   end
   helper_method :projet_or_dossier_path
 
   def projet_or_dossier_proposition_path(projet)
-    assert_projet_or_dossier_defined
-    send("#{@projet_or_dossier}_proposition_path", projet)
+    send("#{projet_or_dossier}_proposition_path", projet)
   end
   helper_method :projet_or_dossier_proposition_path
 
   def projet_or_dossier_commentaires_path(projet)
-    assert_projet_or_dossier_defined
-    send("#{@projet_or_dossier}_commentaires_path", projet)
+    send("#{projet_or_dossier}_commentaires_path", projet)
   end
   helper_method :projet_or_dossier_commentaires_path
 
   def projet_or_dossier_avis_impositions_path(projet)
-    assert_projet_or_dossier_defined
-    send("#{@projet_or_dossier}_avis_impositions_path", projet)
+    send("#{projet_or_dossier}_avis_impositions_path", projet)
   end
   helper_method :projet_or_dossier_avis_impositions_path
 
   def projet_or_dossier_avis_imposition_path(*args)
-    assert_projet_or_dossier_defined
-    send("#{@projet_or_dossier}_avis_imposition_path", *args)
+    send("#{projet_or_dossier}_avis_imposition_path", *args)
   end
   helper_method :projet_or_dossier_avis_imposition_path
 
   def new_projet_or_dossier_avis_imposition_path(projet)
-    assert_projet_or_dossier_defined
-    send("new_#{@projet_or_dossier}_avis_imposition_path", projet)
+    send("new_#{projet_or_dossier}_avis_imposition_path", projet)
   end
   helper_method :new_projet_or_dossier_avis_imposition_path
 
   def projet_or_dossier_occupants_path(*args)
-    assert_projet_or_dossier_defined
-    send("#{@projet_or_dossier}_occupants_path", *args)
+    send("#{projet_or_dossier}_occupants_path", *args)
   end
   helper_method :projet_or_dossier_occupants_path
 
   def projet_or_dossier_occupant_path(*args)
-    assert_projet_or_dossier_defined
-    send("#{@projet_or_dossier}_occupant_path", *args)
+    send("#{projet_or_dossier}_occupant_path", *args)
   end
   helper_method :projet_or_dossier_occupant_path
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -105,4 +105,16 @@ class ApplicationController < ActionController::Base
     send("new_#{@projet_or_dossier}_avis_imposition_path", projet)
   end
   helper_method :new_projet_or_dossier_avis_imposition_path
+
+  def projet_or_dossier_occupants_path(*args)
+    assert_projet_or_dossier_defined
+    send("#{@projet_or_dossier}_occupants_path", *args)
+  end
+  helper_method :projet_or_dossier_occupants_path
+
+  def projet_or_dossier_occupant_path(*args)
+    assert_projet_or_dossier_defined
+    send("#{@projet_or_dossier}_occupant_path", *args)
+  end
+  helper_method :projet_or_dossier_occupant_path
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,47 +60,32 @@ class ApplicationController < ActionController::Base
 
   # Routing ------------------------
 
+  # Demandeurs access their projects through '/projets/' URLs;
+  # Intervenants access their projects through '/dossiers/' URLs.
   def projet_or_dossier
     @projet_or_dossier = current_agent ? "dossier" : "projet"
   end
 
-  def projet_or_dossier_path(projet)
-    send("#{projet_or_dossier}_path", projet)
+  # Expose a `projet_or_dossier_*_path` helper, which will dynamically
+  # resolve to either `projet_*_path` or `dossier_*_path`, depending
+  # of the currently connected user (demandeur or intervenant).
+  #
+  # The helper is available to both controllers and views.
+  def self.expose_routing_helper(name)
+    define_method name do |*args|
+      resolved_name = name.to_s.sub(/projet_or_dossier/, projet_or_dossier)
+      send(resolved_name, *args)
+    end
+    # Expose the helper to the views
+    helper_method name
   end
-  helper_method :projet_or_dossier_path
 
-  def projet_or_dossier_proposition_path(projet)
-    send("#{projet_or_dossier}_proposition_path", projet)
-  end
-  helper_method :projet_or_dossier_proposition_path
-
-  def projet_or_dossier_commentaires_path(projet)
-    send("#{projet_or_dossier}_commentaires_path", projet)
-  end
-  helper_method :projet_or_dossier_commentaires_path
-
-  def projet_or_dossier_avis_impositions_path(projet)
-    send("#{projet_or_dossier}_avis_impositions_path", projet)
-  end
-  helper_method :projet_or_dossier_avis_impositions_path
-
-  def projet_or_dossier_avis_imposition_path(*args)
-    send("#{projet_or_dossier}_avis_imposition_path", *args)
-  end
-  helper_method :projet_or_dossier_avis_imposition_path
-
-  def new_projet_or_dossier_avis_imposition_path(projet)
-    send("new_#{projet_or_dossier}_avis_imposition_path", projet)
-  end
-  helper_method :new_projet_or_dossier_avis_imposition_path
-
-  def projet_or_dossier_occupants_path(*args)
-    send("#{projet_or_dossier}_occupants_path", *args)
-  end
-  helper_method :projet_or_dossier_occupants_path
-
-  def projet_or_dossier_occupant_path(*args)
-    send("#{projet_or_dossier}_occupant_path", *args)
-  end
-  helper_method :projet_or_dossier_occupant_path
+  expose_routing_helper :projet_or_dossier_path
+  expose_routing_helper :projet_or_dossier_proposition_path
+  expose_routing_helper :projet_or_dossier_commentaires_path
+  expose_routing_helper :projet_or_dossier_avis_impositions_path
+  expose_routing_helper :projet_or_dossier_avis_imposition_path
+  expose_routing_helper :new_projet_or_dossier_avis_imposition_path
+  expose_routing_helper :projet_or_dossier_occupants_path
+  expose_routing_helper :projet_or_dossier_occupant_path
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,7 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     if projet_id = session[:projet_id_from_opal]
-      send("#{@dossier_ou_projet}_path", Projet.find_by_id(projet_id))
+      projet_or_dossier_path(Projet.find_by_id(projet_id))
     else
       stored_location_for(resource) || root_path
     end
@@ -38,10 +38,6 @@ class ApplicationController < ActionController::Base
   def current_ability
     #TODO add user management?
     @current_ability ||= Ability.new(current_agent)
-  end
-
-  def dossier_ou_projet
-    @dossier_ou_projet = current_agent ? "dossier" : "projet"
   end
 
   def assert_projet_courant
@@ -61,4 +57,34 @@ class ApplicationController < ActionController::Base
     end
     true
   end
+
+  # Routing ------------------------
+
+  def projet_or_dossier
+    @projet_or_dossier = current_agent ? "dossier" : "projet"
+  end
+
+  def assert_projet_or_dossier_defined
+    if @projet_or_dossier.blank?
+      raise "`@projet_or_dossier` must be defined"
+    end
+  end
+
+  def projet_or_dossier_path(projet)
+    assert_projet_or_dossier_defined
+    send("#{@projet_or_dossier}_path", projet)
+  end
+  helper_method :projet_or_dossier_path
+
+  def projet_or_dossier_proposition_path(projet)
+    assert_projet_or_dossier_defined
+    send("#{@projet_or_dossier}_proposition_path", projet)
+  end
+  helper_method :projet_or_dossier_proposition_path
+
+  def projet_or_dossier_commentaires_path(projet)
+    assert_projet_or_dossier_defined
+    send("#{@projet_or_dossier}_commentaires_path", projet)
+  end
+  helper_method :projet_or_dossier_commentaires_path
 end

--- a/app/controllers/avis_impositions_controller.rb
+++ b/app/controllers/avis_impositions_controller.rb
@@ -18,13 +18,13 @@ class AvisImpositionsController < ApplicationController
     @avis_imposition = ProjetInitializer.new.initialize_avis_imposition(@projet_courant, avis_imposition.numero_fiscal, avis_imposition.reference_avis)
     unless @avis_imposition
       flash[:alert] = t("sessions.invalid_credentials")
-      return redirect_to new_projet_avis_imposition_path(@projet_courant)
+      return redirect_to new_projet_or_dossier_avis_imposition_path(@projet_courant)
     end
     unless @avis_imposition.save
-      return redirect_to new_projet_avis_imposition_path(@projet_courant)
+      return redirect_to new_projet_or_dossier_avis_imposition_path(@projet_courant)
     end
     flash[:notice] = "Avis d’imposition ajouté"
-    redirect_to projet_avis_impositions_path(@projet_courant)
+    redirect_to projet_or_dossier_avis_impositions_path(@projet_courant)
   end
 
   def destroy
@@ -34,7 +34,7 @@ class AvisImpositionsController < ApplicationController
       @avis_imposition = avis_imposition
       flash[:notice] = "Avis d’imposition supprimé"
     end
-    redirect_to projet_avis_impositions_path(@projet_courant)
+    redirect_to projet_or_dossier_avis_impositions_path(@projet_courant)
   end
 
 private

--- a/app/controllers/avis_impositions_controller.rb
+++ b/app/controllers/avis_impositions_controller.rb
@@ -1,7 +1,7 @@
 class AvisImpositionsController < ApplicationController
   layout "inscription"
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
   before_action :init_view

--- a/app/controllers/choix_operateur_controller.rb
+++ b/app/controllers/choix_operateur_controller.rb
@@ -1,7 +1,7 @@
 class ChoixOperateurController < ApplicationController
   layout 'inscription'
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
   before_action :init_view

--- a/app/controllers/commentaires_controller.rb
+++ b/app/controllers/commentaires_controller.rb
@@ -1,5 +1,5 @@
 class CommentairesController < ApplicationController
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
 
@@ -7,6 +7,6 @@ class CommentairesController < ApplicationController
     commentaire = @projet_courant.commentaires.build(corps_message: params[:commentaire][:corps_message])
     commentaire.auteur = @utilisateur_courant
     commentaire.save
-    redirect_to send("#{@dossier_ou_projet}_path", @projet_courant)
+    redirect_to projet_or_dossier_path(@projet_courant)
   end
 end

--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -4,12 +4,12 @@ module ProjetConcern
   included do
     def proposition
       if @projet_courant.prospect?
-        return redirect_to send("#{@dossier_ou_projet}_path", @projet_courant), alert: t('sessions.access_forbidden')
+        return redirect_to projet_or_dossier_path(@projet_courant), alert: t('sessions.access_forbidden')
       end
 
       if request.put?
         if @projet_courant.save_proposition!(projet_params)
-          return redirect_to send("#{@dossier_ou_projet}_path", @projet_courant), notice: t('projets.edition_projet.messages.succes')
+          return redirect_to projet_or_dossier_path(@projet_courant), notice: t('projets.edition_projet.messages.succes')
         else
           flash.now[:alert] = t('projets.edition_projet.messages.erreur')
         end
@@ -24,7 +24,7 @@ module ProjetConcern
     def proposer
       @projet_courant.statut = :proposition_proposee
       if @projet_courant.save
-        return redirect_to send("#{@dossier_ou_projet}_path", @projet_courant)
+        return redirect_to projet_or_dossier_path(@projet_courant)
       end
       render "projets/show"
     end

--- a/app/controllers/demandes_controller.rb
+++ b/app/controllers/demandes_controller.rb
@@ -8,7 +8,7 @@ class DemandesController < ApplicationController
   def show
     @demande = projet_demande
     @page_heading = 'Inscription'
-    @action_label = if needs_next_step? then action_label_create else action_label_update end
+    @action_label = action_label
   end
 
   def update
@@ -23,12 +23,12 @@ class DemandesController < ApplicationController
 
 private
 
-  def action_label_create
-    t('demarrage_projet.action')
-  end
-
-  def action_label_update
-    t('projets.edition.action')
+  def action_label
+    if needs_next_step?
+      t('demarrage_projet.action')
+    else
+      t('projets.edition.action')
+    end
   end
 
   def projet_demande
@@ -70,7 +70,7 @@ private
     if needs_next_step?
       redirect_to projet_mise_en_relation_path(@projet_courant)
     else
-      redirect_to projet_path(@projet_courant)
+      redirect_to projet_or_dossier_path(@projet_courant)
     end
   end
 end

--- a/app/controllers/demandes_controller.rb
+++ b/app/controllers/demandes_controller.rb
@@ -1,7 +1,7 @@
 class DemandesController < ApplicationController
   layout 'inscription'
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
 

--- a/app/controllers/demandeurs_controller.rb
+++ b/app/controllers/demandeurs_controller.rb
@@ -11,7 +11,7 @@ class DemandeursController < ApplicationController
 
   def update
     if save_demandeur
-      return redirect_to_next_step
+      return redirect_to projet_or_dossier_avis_impositions_path(@projet_courant)
     else
       render_show
     end
@@ -20,21 +20,12 @@ class DemandeursController < ApplicationController
 private
   # Show -----------------------
 
-  def action_label
-    if needs_next_step?
-      t('demarrage_projet.action')
-    else
-      t('projets.edition.action')
-    end
-  end
-
   def render_show
     @projet_courant.personne ||= Personne.new
     @demandeur ||= @projet_courant.demandeur_principal
 
     @page_heading = 'Inscription'
     @declarants = @projet_courant.occupants.declarants.collect { |o| [ o.fullname, o.id ] }
-    @action_label = action_label
 
     render :show
   end
@@ -116,17 +107,5 @@ private
     @demandeur = @projet_courant.change_demandeur(demandeur_id)
     @demandeur.assign_attributes(demandeur_principal_params)
     @demandeur.save
-  end
-
-  def needs_next_step?
-    @projet_courant.demande.blank? || ! @projet_courant.demande.complete?
-  end
-
-  def redirect_to_next_step
-    if needs_next_step?
-      redirect_to projet_or_dossier_avis_impositions_path(@projet_courant)
-    else
-      redirect_to projet_or_dossier_path(@projet_courant)
-    end
   end
 end

--- a/app/controllers/demandeurs_controller.rb
+++ b/app/controllers/demandeurs_controller.rb
@@ -20,12 +20,12 @@ class DemandeursController < ApplicationController
 private
   # Show -----------------------
 
-  def action_label_create
-    t('demarrage_projet.action')
-  end
-
-  def action_label_update
-    t('projets.edition.action')
+  def action_label
+    if needs_next_step?
+      t('demarrage_projet.action')
+    else
+      t('projets.edition.action')
+    end
   end
 
   def render_show
@@ -34,7 +34,7 @@ private
 
     @page_heading = 'Inscription'
     @declarants = @projet_courant.occupants.declarants.collect { |o| [ o.fullname, o.id ] }
-    @action_label = if needs_next_step? then action_label_create else action_label_update end
+    @action_label = action_label
 
     render :show
   end
@@ -124,9 +124,9 @@ private
 
   def redirect_to_next_step
     if needs_next_step?
-      redirect_to projet_avis_impositions_path(@projet_courant)
+      redirect_to projet_or_dossier_avis_impositions_path(@projet_courant)
     else
-      redirect_to projet_path(@projet_courant)
+      redirect_to projet_or_dossier_path(@projet_courant)
     end
   end
 end

--- a/app/controllers/demandeurs_controller.rb
+++ b/app/controllers/demandeurs_controller.rb
@@ -1,7 +1,7 @@
 class DemandeursController < ApplicationController
   layout 'inscription'
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -1,5 +1,5 @@
 class DocumentsController < ApplicationController
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
 

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -2,7 +2,7 @@ class DossiersController < ApplicationController
   include ProjetConcern, CsvProperties
 
   before_action :authenticate_agent!
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant, except: [:index]
 
   def index

--- a/app/controllers/engagement_operateur_controller.rb
+++ b/app/controllers/engagement_operateur_controller.rb
@@ -1,7 +1,7 @@
 class EngagementOperateurController < ApplicationController
   layout 'inscription'
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
   before_action :init_view

--- a/app/controllers/mises_en_relation_controller.rb
+++ b/app/controllers/mises_en_relation_controller.rb
@@ -1,7 +1,7 @@
 class MisesEnRelationController < ApplicationController
   layout 'inscription'
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
 

--- a/app/controllers/mises_en_relation_controller.rb
+++ b/app/controllers/mises_en_relation_controller.rb
@@ -12,7 +12,7 @@ class MisesEnRelationController < ApplicationController
       raise "Il n’y a pas de PRIS disponible pour le département #{@projet_courant.departement}"
     end
     @page_heading = 'Inscription'
-    @action_label = if needs_mise_en_relation? then action_label_create else action_label_update end
+    @action_label = action_label
   end
 
   def update
@@ -33,15 +33,15 @@ class MisesEnRelationController < ApplicationController
 
 private
 
+  def action_label
+    if needs_mise_en_relation?
+      t('demarrage_projet.action')
+    else
+      t('projets.edition.action')
+    end
+  end
+
   def needs_mise_en_relation?
     @projet_courant.invited_operateur.blank? && @projet_courant.invited_pris.blank?
-  end
-
-  def action_label_create
-    t('demarrage_projet.action')
-  end
-
-  def action_label_update
-    t('projets.edition.action')
   end
 end

--- a/app/controllers/occupants_controller.rb
+++ b/app/controllers/occupants_controller.rb
@@ -1,7 +1,7 @@
 class OccupantsController < ApplicationController
   layout 'inscription'
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
 

--- a/app/controllers/occupants_controller.rb
+++ b/app/controllers/occupants_controller.rb
@@ -15,11 +15,12 @@ class OccupantsController < ApplicationController
           @occupant = @projet_courant.avis_impositions.first.occupants.build
         end
       else
-        return redirect_to projet_demande_path(@projet_courant)
+        return redirect_to_next_step
       end
     end
 
     @occupants = @projet_courant.occupants.to_a.find_all(&:persisted?)
+    @action_label = action_label
   end
 
   def destroy
@@ -34,6 +35,15 @@ class OccupantsController < ApplicationController
   end
 
 private
+
+  def action_label
+    if needs_next_step?
+      t('demarrage_projet.action')
+    else
+      t('projets.edition.action')
+    end
+  end
+
   def occupant_params
     params.fetch(:occupant, {}).permit(
       :civilite,
@@ -48,5 +58,17 @@ private
 
   def occupant_params?
     occupant_params.any? { |attribute, value| value.present? }
+  end
+
+  def needs_next_step?
+    @projet_courant.demande.blank? || !@projet_courant.demande.complete?
+  end
+
+  def redirect_to_next_step
+    if needs_next_step?
+      redirect_to projet_demande_path(@projet_courant)
+    else
+      redirect_to projet_or_dossier_path(@projet_courant)
+    end
   end
 end

--- a/app/controllers/occupants_controller.rb
+++ b/app/controllers/occupants_controller.rb
@@ -31,7 +31,7 @@ class OccupantsController < ApplicationController
     else
       flash[:alert] = t("occupants.delete.error")
     end
-    redirect_to projet_occupants_path(@projet_courant)
+    redirect_to projet_or_dossier_occupants_path(@projet_courant)
   end
 
 private

--- a/app/controllers/projets_controller.rb
+++ b/app/controllers/projets_controller.rb
@@ -1,7 +1,7 @@
 class ProjetsController < ApplicationController
   include ProjetConcern
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
 end

--- a/app/controllers/transmission_controller.rb
+++ b/app/controllers/transmission_controller.rb
@@ -1,7 +1,7 @@
 class TransmissionController < ApplicationController
   layout 'inscription'
 
-  before_action :dossier_ou_projet
+  before_action :projet_or_dossier
   before_action :assert_projet_courant
   before_action :authentifie
   before_action :init_view

--- a/app/views/avis_impositions/index.html.slim
+++ b/app/views/avis_impositions/index.html.slim
@@ -24,6 +24,6 @@ section.avis-imposition
               - if 0 < index
                 = link_to "Supprimer", projet_avis_imposition_path(id: avis_imposition), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer cet avis d’imposition ?" }
     p.content__question= "Parmi les occupants du logement actuel y a-t-il d’autres avis d’imposition pour l’année #{@projet_courant.annee_fiscale_reference} ?"
-    = btn name: "Ajouter un avis d’imposition", href: new_projet_avis_imposition_path, icon: "plus"
-= btn name: "Valider", href: projet_occupants_path, class: "btn-large btn-centered", icon: "ok"
+    = btn name: "Ajouter un avis d’imposition", href: new_projet_or_dossier_avis_imposition_path(@projet_courant), icon: "plus"
+= btn name: "Valider", href: projet_occupants_path(@projet_courant), class: "btn-large btn-centered", icon: "ok"
 

--- a/app/views/avis_impositions/index.html.slim
+++ b/app/views/avis_impositions/index.html.slim
@@ -25,5 +25,5 @@ section.avis-imposition
                 = link_to "Supprimer", projet_or_dossier_avis_imposition_path(@projet_courant, avis_imposition), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer cet avis d’imposition ?" }
     p.content__question= "Parmi les occupants du logement actuel y a-t-il d’autres avis d’imposition pour l’année #{@projet_courant.annee_fiscale_reference} ?"
     = btn name: "Ajouter un avis d’imposition", href: new_projet_or_dossier_avis_imposition_path(@projet_courant), icon: "plus"
-= btn name: "Valider", href: projet_occupants_path(@projet_courant), class: "btn-large btn-centered", icon: "ok"
+= btn name: t('demarrage_projet.action'), href: projet_or_dossier_occupants_path(@projet_courant), class: "btn-large btn-centered", icon: "ok"
 

--- a/app/views/avis_impositions/index.html.slim
+++ b/app/views/avis_impositions/index.html.slim
@@ -22,7 +22,7 @@ section.avis-imposition
             td= avis_imposition.nombre_personnes_charge
             td
               - if 0 < index
-                = link_to "Supprimer", projet_avis_imposition_path(id: avis_imposition), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer cet avis d’imposition ?" }
+                = link_to "Supprimer", projet_or_dossier_avis_imposition_path(@projet_courant, avis_imposition), method: :delete, data: { confirm: "Êtes-vous sûr de vouloir supprimer cet avis d’imposition ?" }
     p.content__question= "Parmi les occupants du logement actuel y a-t-il d’autres avis d’imposition pour l’année #{@projet_courant.annee_fiscale_reference} ?"
     = btn name: "Ajouter un avis d’imposition", href: new_projet_or_dossier_avis_imposition_path(@projet_courant), icon: "plus"
 = btn name: "Valider", href: projet_occupants_path(@projet_courant), class: "btn-large btn-centered", icon: "ok"

--- a/app/views/demandeurs/show.html.slim
+++ b/app/views/demandeurs/show.html.slim
@@ -63,5 +63,5 @@
             li
              = ff.label :lien_avec_demandeur
              = ff.text_field :lien_avec_demandeur, placeholder:  t('demarrage_projet.demandeur.personne_de_confiance_placeholder')
-  = btn name: @action_label, class: 'btn-large btn-centered', icon: 'ok'
+  = btn name: t('demarrage_projet.action'), class: 'btn-large btn-centered', icon: 'ok'
 

--- a/app/views/dossiers/_projet_envisage.html.slim
+++ b/app/views/dossiers/_projet_envisage.html.slim
@@ -1,7 +1,9 @@
 article.block.projet
   h3 Projet envisagé
-  - if demandeur? || (current_agent && current_agent.operateur?)
+  - if demandeur?
     = edit_projet_button(@projet_courant, projet_demande_path(@projet_courant))
+  - elsif current_agent && current_agent.operateur?
+    = edit_projet_button(@projet_courant, dossier_demande_path(@projet_courant))
   .content-block
     - if @projet_courant.demande.blank?
       p Le demandeur n’a pas encore rempli le projet.

--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -56,5 +56,5 @@
     .checkbox-validation
       input#dif1 type="checkbox" class="js-engagement"
       label for="dif1" = t('agrements.attestation_communiquer_infos_occupants')
-  = btn name: "Valider", class: "btn-large btn-centered js-engagement", icon: "ok"
+  = btn name: @action_label, class: "btn-large btn-centered js-engagement", icon: "ok"
 

--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -28,7 +28,7 @@
             td= occupant.date_de_naissance.year
             td
               - if occupant.can_be_deleted?
-                = link_to projet_occupant_path(id: occupant.id),
+                = link_to projet_or_dossier_occupant_path(projet: @projet_courant, id: occupant.id),
                     method: :delete,
                     title: t('occupants.delete.action'),
                     class: "btn btn-icon",

--- a/app/views/projets/_foyer.html.slim
+++ b/app/views/projets/_foyer.html.slim
@@ -1,7 +1,9 @@
 article.block.occupants
   h3 Détails du foyer
-  - if demandeur? || current_agent.operateur?
+  - if demandeur?
     = edit_projet_button(@projet_courant, projet_demandeur_path(@projet_courant))
+  - elsif current_agent.operateur?
+    = edit_projet_button(@projet_courant, dossier_demandeur_path(@projet_courant))
   .occupants-recap
     ul
       li

--- a/app/views/projets/_messagerie.html.slim
+++ b/app/views/projets/_messagerie.html.slim
@@ -22,7 +22,7 @@ article#messagerie.block.messagerie
     - else
       p Il n’y a pas de message. Soyez le premier/la première à poser votre question.
       p Vous serez notifié par email dès qu’un nouveau message apparaîtra.
-    = form_for @commentaire, url: send("#{@dossier_ou_projet}_commentaires_path", @projet_courant) do |f|
+    = form_for @commentaire, url: projet_or_dossier_commentaires_path(@projet_courant) do |f|
       = f.text_area :corps_message, class: 'chat-respond'
       = btn name: t('projets.visualisation.lien_ajout_commentaire'), icon: 'envelope'
 

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -1,4 +1,4 @@
-= simple_form_for @projet_courant, url: send("#{@dossier_ou_projet}_proposition_path", @projet_courant), html: { method: :put, class: "edition-demande" } do |f|
+= simple_form_for @projet_courant, url: projet_or_dossier_proposition_path(@projet_courant), html: { method: :put, class: "edition-demande" } do |f|
   = render "shared/errors", resource: @projet_courant
   section.content-projet
     article.block.projet-ope

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     end
     resources :commentaires,       only: :create
     resource  :composition
-    resources :avis_impositions,   only: [:index, :new, :create]
+    resources :avis_impositions,   only: [:index, :new, :create, :destroy]
     resources :documents,          only: [:create, :destroy]
     resources :intervenants
     resource :demandeur,         only: [:show, :update]
@@ -38,7 +38,6 @@ Rails.application.routes.draw do
     resources :dossiers, only: [:show, :edit, :update, :index], param: :dossier_id
 
     resources :projets, only: [], concerns: :projectable do
-      resources :avis_impositions, only: :destroy
       get      :choix_operateur,      action: :new,    controller: 'choix_operateur'
       patch    :choix_operateur,      action: :choose, controller: 'choix_operateur'
       get      :engagement_operateur, action: :new,    controller: 'engagement_operateur'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
     resources :avis_impositions,   only: [:index, :new, :create]
     resources :documents,          only: [:create, :destroy]
     resources :intervenants
+    resource :demandeur,         only: [:show, :update]
+    resource :demande,           only: [:show, :update]
+    resource :mise_en_relation,  only: [:show, :update]
     get       :calcul_revenu_fiscal_reference
     get       :preeligibilite
     get       :proposition
@@ -36,9 +39,6 @@ Rails.application.routes.draw do
 
     resources :projets, only: [], concerns: :projectable do
       resources :avis_impositions, only: :destroy
-      resource :demandeur,         only: [:show, :update]
-      resource :demande,           only: [:show, :update]
-      resource :mise_en_relation,  only: [:show, :update]
       get      :choix_operateur,      action: :new,    controller: 'choix_operateur'
       patch    :choix_operateur,      action: :choose, controller: 'choix_operateur'
       get      :engagement_operateur, action: :new,    controller: 'engagement_operateur'

--- a/spec/controllers/demandeurs_controller_spec.rb
+++ b/spec/controllers/demandeurs_controller_spec.rb
@@ -45,7 +45,7 @@ describe DemandeursController do
       end
 
       it "enregistre les informations modifiées" do
-        expect(response).to redirect_to projet_path(projet)
+        expect(response).to redirect_to projet_avis_impositions_path(projet)
         expect(projet.tel).to eq   '01 02 03 04 05'
         expect(projet.email).to eq 'particulier@exemple.fr'
       end
@@ -65,7 +65,7 @@ describe DemandeursController do
       end
 
       it "enregistre la personne de confiance" do
-        expect(response).to redirect_to projet_path(projet)
+        expect(response).to redirect_to projet_avis_impositions_path(projet)
         expect(projet.personne.civilite).to            eq 'mr'
         expect(projet.personne.prenom).to              eq 'Tyrone'
         expect(projet.personne.nom).to                 eq 'Meehan'
@@ -162,7 +162,7 @@ describe DemandeursController do
       end
 
       it "enregistre les informations modifiées" do
-        expect(response).to redirect_to projet_path(projet)
+        expect(response).to redirect_to projet_avis_impositions_path(projet)
         expect(projet.demandeur_principal).to eq projet.occupants.last
       end
     end

--- a/spec/features/1_demarrage/etape3_occupants_spec.rb
+++ b/spec/features/1_demarrage/etape3_occupants_spec.rb
@@ -51,7 +51,7 @@ feature "Occupants :" do
     scenario "je peux passer à l'étape suivante" do
       signin(projet.numero_fiscal, projet.reference_avis)
       visit projet_occupants_path(projet)
-      click_button "Valider"
+      click_button I18n.t('demarrage_projet.action')
       expect(page.current_path).to match(projet_demande_path(projet))
     end
   end

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -15,6 +15,10 @@ feature "Modifier le projet :" do
     send("#{resource_name}_avis_impositions_path", projet)
   end
 
+  def new_resource_avis_imposition_path(projet)
+    send("new_#{resource_name}_avis_imposition_path", projet)
+  end
+
   def resource_demande_path(projet)
     send("#{resource_name}_demande_path", projet)
   end
@@ -37,12 +41,41 @@ feature "Modifier le projet :" do
       fill_in :projet_tel, with: '01 10 20 30 40'
 
       click_button I18n.t('demarrage_projet.action')
+      expect(page).to have_current_path resource_avis_impositions_path(projet)
 
       visit resource_path(projet)
       expect(page).to have_content('01 10 20 30 40')
       expect(page).to have_current_path resource_path(projet)
       expect(page).to have_content Fakeweb::ApiBan::ADDRESS_PORT
       expect(page).to have_content Fakeweb::ApiBan::ADDRESS_MARE
+    end
+  end
+
+  shared_examples :can_edit_avis_impositions do |resource_name|
+    let(:resource_name) { resource_name }
+
+    scenario "je peux modifier les avis d'impositions du foyer" do
+      visit resource_path(projet)
+      within 'article.occupants' do
+        click_link I18n.t('projets.visualisation.lien_edition')
+      end
+
+      expect(page).to have_current_path resource_demandeur_path(projet)
+      click_button I18n.t('demarrage_projet.action')
+
+      expect(page).to have_current_path resource_avis_impositions_path(projet)
+      click_link 'Ajouter un avis d’imposition'
+      expect(page).to have_current_path new_resource_avis_imposition_path(projet)
+      fill_in 'avis_imposition_numero_fiscal',  with: 13
+      fill_in 'avis_imposition_reference_avis', with: 16
+      click_button 'Ajouter'
+
+      expect(page).to have_current_path resource_avis_impositions_path(projet)
+      expect(page).to have_content('1 000 000 €')
+
+      click_link 'Supprimer'
+      expect(page).to have_current_path resource_avis_impositions_path(projet)
+      expect(page).not_to have_content('1 000 000 €')
     end
   end
 
@@ -71,6 +104,7 @@ feature "Modifier le projet :" do
     before { signin(projet.numero_fiscal, projet.reference_avis) }
 
     it_behaves_like :can_edit_demandeur, "projet"
+    it_behaves_like :can_edit_avis_impositions, "projet"
     it_behaves_like :can_edit_demande, "projet"
   end
 
@@ -79,6 +113,7 @@ feature "Modifier le projet :" do
     before { login_as agent_operateur, scope: :agent }
 
     it_behaves_like :can_edit_demandeur, "dossier"
+    it_behaves_like :can_edit_avis_impositions, "dossier"
     it_behaves_like :can_edit_demande, "dossier"
   end
 end

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -3,13 +3,23 @@ require 'support/mpal_features_helper'
 require 'support/api_ban_helper'
 
 feature "Modifier le projet :" do
-  shared_examples "je peux modifier les informations personnelles du demandeur" do
-    specify do
+
+  shared_examples :can_edit_demandeur do |resource_name|
+    let(:resource_name) { resource_name }
+    def resource_path(projet)
+      send("#{resource_name}_path", projet)
+    end
+    def resource_demandeur_path(projet)
+      send("#{resource_name}_demandeur_path", projet)
+    end
+
+    scenario "je peux modifier les informations personnelles du demandeur" do
+      visit resource_path(projet)
       within 'article.occupants' do
         click_link I18n.t('projets.visualisation.lien_edition')
       end
 
-      expect(page).to have_current_path projet_demandeur_path(projet)
+      expect(page).to have_current_path resource_demandeur_path(projet)
       expect(find('#demandeur_principal_civilite_mr')).to be_checked
       expect(page).to have_field('Adresse postale', with: '65 rue de Rome, 75008 Paris')
 
@@ -20,14 +30,14 @@ feature "Modifier le projet :" do
       click_button I18n.t('projets.edition.action')
 
       expect(page).to have_content('01 10 20 30 40')
-      expect(page).to have_current_path projet_path(projet)
+      expect(page).to have_current_path resource_path(projet)
       expect(page).to have_content Fakeweb::ApiBan::ADDRESS_PORT
       expect(page).to have_content Fakeweb::ApiBan::ADDRESS_MARE
     end
   end
 
-  shared_examples "je peux modifier les informations de l'habitation et de la demande" do
-    specify do
+  shared_examples :can_edit_demande do
+    scenario "je peux modifier les informations de l'habitation et de la demande" do
       within 'article.projet' do
         click_link I18n.t('projets.visualisation.lien_edition')
       end
@@ -42,7 +52,16 @@ feature "Modifier le projet :" do
     let(:projet) { create(:projet, :prospect, :with_invited_operateur) }
     before { signin(projet.numero_fiscal, projet.reference_avis) }
 
-    it_behaves_like "je peux modifier les informations personnelles du demandeur"
-    it_behaves_like "je peux modifier les informations de l'habitation et de la demande"
+    it_behaves_like :can_edit_demandeur, "projet"
+    it_behaves_like :can_edit_demande
+  end
+
+  context "en tant qu'opérateur" do
+    let(:projet) { create(:projet, :prospect, :with_committed_operateur) }
+    let(:agent_operateur) { create :agent, intervenant: projet.operateur }
+
+    before { login_as agent_operateur, scope: :agent }
+
+    it_behaves_like :can_edit_demandeur, "dossier"
   end
 end

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -3,15 +3,20 @@ require 'support/mpal_features_helper'
 require 'support/api_ban_helper'
 
 feature "Modifier le projet :" do
+  def resource_path(projet)
+    send("#{resource_name}_path", projet)
+  end
+
+  def resource_demandeur_path(projet)
+    send("#{resource_name}_demandeur_path", projet)
+  end
+
+  def resource_demande_path(projet)
+    send("#{resource_name}_demande_path", projet)
+  end
 
   shared_examples :can_edit_demandeur do |resource_name|
     let(:resource_name) { resource_name }
-    def resource_path(projet)
-      send("#{resource_name}_path", projet)
-    end
-    def resource_demandeur_path(projet)
-      send("#{resource_name}_demandeur_path", projet)
-    end
 
     scenario "je peux modifier les informations personnelles du demandeur" do
       visit resource_path(projet)
@@ -36,13 +41,20 @@ feature "Modifier le projet :" do
     end
   end
 
-  shared_examples :can_edit_demande do
+  shared_examples :can_edit_demande do |resource_name|
+    let(:resource_name) { resource_name }
+
     scenario "je peux modifier les informations de l'habitation et de la demande" do
+      visit resource_path(projet)
       within 'article.projet' do
         click_link I18n.t('projets.visualisation.lien_edition')
       end
+
+      expect(page).to have_current_path resource_demande_path(projet)
       fill_in :demande_annee_construction, with: '1950'
       click_button I18n.t('projets.edition.action')
+
+      expect(page).to have_current_path resource_path(projet)
       expect(page).to have_content(1950)
       # TODO: tester la modification des travaux demandés
     end
@@ -53,7 +65,7 @@ feature "Modifier le projet :" do
     before { signin(projet.numero_fiscal, projet.reference_avis) }
 
     it_behaves_like :can_edit_demandeur, "projet"
-    it_behaves_like :can_edit_demande
+    it_behaves_like :can_edit_demande, "projet"
   end
 
   context "en tant qu'opérateur" do
@@ -63,5 +75,6 @@ feature "Modifier le projet :" do
     before { login_as agent_operateur, scope: :agent }
 
     it_behaves_like :can_edit_demandeur, "dossier"
+    it_behaves_like :can_edit_demande, "dossier"
   end
 end

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -11,6 +11,10 @@ feature "Modifier le projet :" do
     send("#{resource_name}_demandeur_path", projet)
   end
 
+  def resource_avis_impositions_path(projet)
+    send("#{resource_name}_avis_impositions_path", projet)
+  end
+
   def resource_demande_path(projet)
     send("#{resource_name}_demande_path", projet)
   end
@@ -32,8 +36,9 @@ feature "Modifier le projet :" do
       fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_MARE
       fill_in :projet_tel, with: '01 10 20 30 40'
 
-      click_button I18n.t('projets.edition.action')
+      click_button I18n.t('demarrage_projet.action')
 
+      visit resource_path(projet)
       expect(page).to have_content('01 10 20 30 40')
       expect(page).to have_current_path resource_path(projet)
       expect(page).to have_content Fakeweb::ApiBan::ADDRESS_PORT
@@ -60,8 +65,9 @@ feature "Modifier le projet :" do
     end
   end
 
+  let(:projet) { create(:projet, :prospect, :with_committed_operateur) }
+
   context "en tant que demandeur" do
-    let(:projet) { create(:projet, :prospect, :with_invited_operateur) }
     before { signin(projet.numero_fiscal, projet.reference_avis) }
 
     it_behaves_like :can_edit_demandeur, "projet"
@@ -69,9 +75,7 @@ feature "Modifier le projet :" do
   end
 
   context "en tant qu'opérateur" do
-    let(:projet) { create(:projet, :prospect, :with_committed_operateur) }
     let(:agent_operateur) { create :agent, intervenant: projet.operateur }
-
     before { login_as agent_operateur, scope: :agent }
 
     it_behaves_like :can_edit_demandeur, "dossier"

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -19,6 +19,10 @@ feature "Modifier le projet :" do
     send("new_#{resource_name}_avis_imposition_path", projet)
   end
 
+  def resource_occupants_path(projet)
+    send("#{resource_name}_occupants_path", projet)
+  end
+
   def resource_demande_path(projet)
     send("#{resource_name}_demande_path", projet)
   end
@@ -63,6 +67,7 @@ feature "Modifier le projet :" do
       expect(page).to have_current_path resource_demandeur_path(projet)
       click_button I18n.t('demarrage_projet.action')
 
+      # Add new avis imposition
       expect(page).to have_current_path resource_avis_impositions_path(projet)
       click_link 'Ajouter un avis d’imposition'
       expect(page).to have_current_path new_resource_avis_imposition_path(projet)
@@ -73,9 +78,44 @@ feature "Modifier le projet :" do
       expect(page).to have_current_path resource_avis_impositions_path(projet)
       expect(page).to have_content('1 000 000 €')
 
+      # Delete avis imposition
       click_link 'Supprimer'
       expect(page).to have_current_path resource_avis_impositions_path(projet)
       expect(page).not_to have_content('1 000 000 €')
+    end
+  end
+
+  shared_examples :can_edit_occupants do |resource_name|
+    let(:resource_name) { resource_name }
+
+    scenario "je peux modifier les occupants du foyer" do
+      visit resource_path(projet)
+      within 'article.occupants' do
+        click_link I18n.t('projets.visualisation.lien_edition')
+      end
+
+      expect(page).to have_current_path resource_demandeur_path(projet)
+      click_button I18n.t('demarrage_projet.action')
+
+      expect(page).to have_current_path resource_avis_impositions_path(projet)
+      click_link I18n.t('demarrage_projet.action')
+
+      # Add new occupant
+      expect(page).to have_current_path resource_occupants_path(projet)
+      fill_in "Nom",               with: "Marielle"
+      fill_in "Prénom",            with: "Jean-Pierre"
+      fill_in "Date de naissance", with: "20/05/2010"
+      click_button I18n.t("occupants.nouveau.action")
+
+      expect(page).to have_current_path(resource_occupants_path(projet))
+      expect(page).to have_content("Jean-Pierre Marielle")
+
+      # Delete occupant
+      within "table tr:last-child" do
+        click_link I18n.t('occupants.delete.action')
+      end
+      expect(page).to have_current_path(resource_occupants_path(projet))
+      expect(page).to have_content("Jean-Pierre Marielle")
     end
   end
 
@@ -103,17 +143,19 @@ feature "Modifier le projet :" do
   context "en tant que demandeur" do
     before { signin(projet.numero_fiscal, projet.reference_avis) }
 
-    it_behaves_like :can_edit_demandeur, "projet"
+    it_behaves_like :can_edit_demandeur,        "projet"
     it_behaves_like :can_edit_avis_impositions, "projet"
-    it_behaves_like :can_edit_demande, "projet"
+    it_behaves_like :can_edit_occupants,        "projet"
+    it_behaves_like :can_edit_demande,          "projet"
   end
 
   context "en tant qu'opérateur" do
     let(:agent_operateur) { create :agent, intervenant: projet.operateur }
     before { login_as agent_operateur, scope: :agent }
 
-    it_behaves_like :can_edit_demandeur, "dossier"
+    it_behaves_like :can_edit_demandeur,        "dossier"
     it_behaves_like :can_edit_avis_impositions, "dossier"
-    it_behaves_like :can_edit_demande, "dossier"
+    it_behaves_like :can_edit_occupants,        "dossier"
+    it_behaves_like :can_edit_demande,          "dossier"
   end
 end


### PR DESCRIPTION
Après plusieurs refactorings, cette PR implémente enfin la story https://anah-produits.atlassian.net/browse/PF-424 🙌 

- [x] Refactore les specs (#316 ; déjà fait)
- [x] Renomme les actions de DemarrageController (#318 ; déjà fait)
- [x] Sépare les pages du DemarrageProjetController en plusieurs Controller indépendants (#320 ; déjà fait)
- [ ] **Permet aux opérateur d'accéder aux pages d'édition de la demande (cette PR)**

## Description

Après tout ça, il n'y a finalement plus tant de boulot que ça dans cette PR. C'est essentiellement :

- Faire en sorte que les pages du demandeur (infos persos, avis d'impositions, occupants) soient accessibles à la fois par `/dossiers/*` et par `/projet/*` ;
- Rajouter des tests, qui sont exécutés à la fois en tant que demandeur et en tant qu'opérateur, pour être sûr que ça fonctionne dans les deux cas.

## Notes pour la revue

Pour pouvoir accéder aux pages depuis deux URLs différentes, j'ai écrit pas mal de helpers de la forme `projet_or_dossier_path`. Ces helpers permettent d'écrire dynamiquement `/projets/*` ou `/dossiers/*` en fonction de l'utilisateur connecté.

**Question ouverte 1** : ce n'est peut-être pas une bonne idée, il y a peut-être moyen de simplifier carrément le routage – par exemple avec des URLs relative. @jvignolles une idée ?

**Question ouverte 2** : j'ai deux façons de déclarer ces helpers :
- une simple, mais assez répétitive, avec plein de méthodes similaires déclarées plein de fois (commit "PF424 simplifie les helpers d’URL") ;
- une plus concise et moins répétitive – mais avec une définition dynamique de méthode (commit "PF424 simplifie encore plus les helpers d’URL").

Je veux bien un avis sur ce qui vous semble le plus facile à maintenir sur le long terme :)