### PR TITLE
PF327 ajoute la date de visite dans les dashboards et exports

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -1,6 +1,6 @@
 class Projet < ActiveRecord::Base
   include LocalizedModelConcern
-  extend CsvProperties
+  extend CsvProperties, ApplicationHelper
 
   enum statut: {
     prospect: 0,
@@ -317,8 +317,9 @@ class Projet < ActiveRecord::Base
         'Demandeur',
         'Ville',
         'Instructeur',
-        'Thèmes',
+        'Types d’intervention',
         'Opérateur',
+        'Date de visite',
         'État',
         'Depuis',
       ]
@@ -334,8 +335,9 @@ class Projet < ActiveRecord::Base
           projet.demandeur_principal.fullname,
           projet.adresse.try(:ville),
           projet.invited_instructeur.try(:raison_sociale),
-          '',
+          projet.themes.map(&:libelle).join(", "),
           projet.invited_operateur.try(:raison_sociale),
+          projet.date_de_visite.present? ? format_date(projet.date_de_visite) : "",
           I18n.t(projet.status_for_operateur, scope: "projets.statut"),
         ]
         line.insert 6, projet.agent_operateur.try(:fullname)   if agent.instructeur? || agent.operateur?

--- a/app/views/dossiers/index.html.slim
+++ b/app/views/dossiers/index.html.slim
@@ -18,10 +18,12 @@
               abbr title="Département" Dép.
           th Ville
           th Instructeur
-          th Thèmes
+          th Types d’intervention
           th Opérateur
+          th Visité le
           th État
-          th Depuis
+          / TODO
+          / th Depuis
       tbody
         - @dossiers.each do |projet|
           tr id="projet_#{projet.id}"
@@ -47,14 +49,20 @@
                 br/
                 span.firstname= projet.agent_instructeur.prenom
                 span.lastname<= projet.agent_instructeur.nom
-            /TODO Themes
-            td= link_to ' ', edit_url
+            td
+              = link_to edit_url do
+                - if projet.themes.present?
+                  = projet.themes.map(&:libelle).join(', ')
             td= link_to edit_url do
               = projet.invited_operateur.raison_sociale rescue ' '
               - if projet.agent_operateur && (current_agent.instructeur? || current_agent.operateur?)
                 br/
                 span.firstname= projet.agent_operateur.prenom
                 span.lastname<= projet.agent_operateur.nom
+            td
+              = link_to edit_url do
+                - if projet.date_de_visite.present?
+                  = format_date(projet.date_de_visite)
             td= link_to t(projet.status_for_operateur, scope: "projets.statut"), edit_url
             /TODO Status Updated At
-            td= link_to ' ', edit_url
+            / td= link_to ' ', edit_url


### PR DESCRIPTION
- ajoute la date de visite dans les dashboards de tous les intervenants ainsi que l’exports CSV
- idem pour les "types d’interventions" (aka "thèmes")

<img width="1183" alt="capture d ecran 2017-04-24 a 19 48 13" src="https://cloud.githubusercontent.com/assets/2368859/25350902/fd00e372-2926-11e7-8a0a-ba950dc72d2e.png">
