### PR TITLE
PF416 force l’utilisateur à choisir un demandeur explicitement

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,11 +8,9 @@ class ApplicationController < ActionController::Base
   def authentifie_sans_redirection
     if agent_signed_in?
       @role_utilisateur = :agent
-      @utilisateur_courant = current_agent
     elsif @role_utilisateur.blank?
       @role_utilisateur = :demandeur
       if @projet_courant
-        @utilisateur_courant = @projet_courant.demandeur_principal
         @utilisateur_invalide = true if session[:numero_fiscal] != @projet_courant.numero_fiscal
       end
     end

--- a/app/controllers/commentaires_controller.rb
+++ b/app/controllers/commentaires_controller.rb
@@ -5,8 +5,18 @@ class CommentairesController < ApplicationController
 
   def create
     commentaire = @projet_courant.commentaires.build(corps_message: params[:commentaire][:corps_message])
-    commentaire.auteur = @utilisateur_courant
+    commentaire.auteur = author
     commentaire.save
     redirect_to projet_or_dossier_path(@projet_courant)
+  end
+
+private
+
+  def author
+    if agent_signed_in?
+      current_agent
+    else
+      @projet_courant.demandeur_principal
+    end
   end
 end

--- a/app/controllers/demandeurs_controller.rb
+++ b/app/controllers/demandeurs_controller.rb
@@ -94,8 +94,11 @@ private
     end
 
     demandeur_id = params[:projet][:demandeur_id]
-    needs_saving_demandeur = demandeur_id.present?
-    if needs_saving_demandeur && !assign_demandeur(demandeur_id)
+    if demandeur_id.blank?
+      flash.now[:alert] = t('demarrage_projet.demandeur.erreurs.missing_demandeur')
+      return false
+    end
+    if !assign_demandeur(demandeur_id)
       flash.now[:alert] = t('demarrage_projet.demandeur.erreurs.enregistrement_demandeur')
       return false
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
     session[:numero_fiscal] = param_numero_fiscal
     projet = Projet.find_by(numero_fiscal: param_numero_fiscal)
     if projet
-      redirect_to projet
+      redirect_to_next_step(projet)
     else
       create_projet_and_redirect
     end
@@ -52,5 +52,13 @@ private
 
   def param_reference_avis
     params[:reference_avis].to_s.gsub(/\W+/, '').upcase
+  end
+
+  def redirect_to_next_step(projet)
+    if projet.demandeur_principal.blank?
+      redirect_to projet_demandeur_path(projet)
+    else
+      redirect_to projet
+    end
   end
 end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -101,7 +101,7 @@ class Projet < ActiveRecord::Base
   end
 
   def nb_occupants_a_charge
-    occupants.count - demandeurs.count
+    occupants.count - declarants.count
   end
 
   def intervenants_disponibles(role: nil)
@@ -163,12 +163,12 @@ class Projet < ActiveRecord::Base
     demandeur
   end
 
-  def demandeurs
-    occupants.where(demandeur: true)
+  def declarants
+    occupants.where(declarant: true)
   end
 
   def demandeur_principal
-    demandeurs.first
+    occupants.where(demandeur: true).first
   end
 
   def demandeur_principal_nom

--- a/app/services/projet_initializer.rb
+++ b/app/services/projet_initializer.rb
@@ -47,7 +47,7 @@ class ProjetInitializer
         prenom: declarant[:prenom],
         date_de_naissance: "#{declarant[:date_de_naissance]}",
         declarant: true,
-        demandeur: is_new_project && 0 == index
+        demandeur: false
       )
     end
 

--- a/app/views/demandeurs/show.html.slim
+++ b/app/views/demandeurs/show.html.slim
@@ -14,8 +14,8 @@
         = label_tag 'demandeur_principal_civilite_mr', t(:"occupants.civilite.mr")
     ul.dem-info.ins-form
       li.full
-        = f.label 'Prénom et nom du demandeur'
-        = select_tag 'projet[demandeur_id]', options_for_select(@declarants,@projet_courant.demandeur_principal.id), class: 'form-control'
+        = label_tag 'projet[demandeur_id]', t('demarrage_projet.demandeur.demandeur_identity')
+        = select_tag 'projet[demandeur_id]', options_for_select(@declarants, @demandeur.try(:id)), class: 'form-control', prompt: t('demarrage_projet.demandeur.select')
       li.full
         = f.label :adresse_postale
         = text_field_tag "projet[adresse_postale]", @projet_courant.adresse_postale.try(:description)

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -94,7 +94,10 @@ fr:
         adresse_vide: "Votre adresse doit être renseignée"
         adresse_inconnue: "Nous n’avons pas réussi à localiser votre adresse. Veuillez renseigner une adresse plus précise – ou ré-essayez dans quelques minutes."
         enregistrement_demandeur: "Une erreur s’est produite lors de l’enregistrement de vos informations personnelles."
+        missing_demandeur: "Veuillez sélectionner le prénom et nom du demandeur"
       section_demandeur: "Demandeur"
+      demandeur_identity: "Prénom et nom du propriétaire demandeur"
+      select: "Sélectionnez le propriétaire demandeur"
       recapitulatif_informations: "Veuillez vérifier les champs ci-dessous et les compléter."
       personne_confiance: "Qui contacter pour les démarches à venir ?"
       personne_confiance_choix1: Vous-même

--- a/spec/controllers/demandeurs_controller_spec.rb
+++ b/spec/controllers/demandeurs_controller_spec.rb
@@ -3,7 +3,7 @@ require 'support/mpal_helper'
 require 'support/api_ban_helper'
 
 describe DemandeursController do
-  let(:projet) { create :projet, :prospect, demandeurs_count: 2 }
+  let(:projet) { create :projet, :prospect, declarants_count: 2 }
 
   before(:each) do
     authenticate_as_particulier(projet.numero_fiscal)

--- a/spec/controllers/occupants_controller_spec.rb
+++ b/spec/controllers/occupants_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'support/mpal_helper'
 
 describe OccupantsController do
-  let(:projet) { create :projet, :with_demandeurs }
+  let(:projet) { create :projet, :with_demandeur }
 
   before(:each) do
     authenticate_as_particulier(projet.numero_fiscal)

--- a/spec/factories/avis_impositions.rb
+++ b/spec/factories/avis_impositions.rb
@@ -8,13 +8,13 @@ FactoryGirl.define do
 
     factory :avis_imposition_with_occupants do
       transient do
-        demandeurs_count 1
+        declarants_count 1
         occupants_a_charge_count 0
       end
 
       after(:create) do |avis_imposition, evaluator|
-        create_list(:demandeur, evaluator.demandeurs_count, avis_imposition: avis_imposition)
-        create_list(:occupant, evaluator.occupants_a_charge_count, avis_imposition: avis_imposition)
+        create_list(:declarant, evaluator.declarants_count,         avis_imposition: avis_imposition)
+        create_list(:occupant,  evaluator.occupants_a_charge_count, avis_imposition: avis_imposition)
       end
     end
   end

--- a/spec/factories/avis_impositions.rb
+++ b/spec/factories/avis_impositions.rb
@@ -12,9 +12,9 @@ FactoryGirl.define do
         occupants_a_charge_count 0
       end
 
-      after(:create) do |avis_imposition, evaluator|
-        create_list(:declarant, evaluator.declarants_count,         avis_imposition: avis_imposition)
-        create_list(:occupant,  evaluator.occupants_a_charge_count, avis_imposition: avis_imposition)
+      after(:build) do |avis_imposition, evaluator|
+        avis_imposition.occupants << build_list(:declarant, evaluator.declarants_count,         avis_imposition: avis_imposition)
+        avis_imposition.occupants << build_list(:occupant,  evaluator.occupants_a_charge_count, avis_imposition: avis_imposition)
       end
     end
   end

--- a/spec/factories/occupants.rb
+++ b/spec/factories/occupants.rb
@@ -10,4 +10,9 @@ FactoryGirl.define do
   factory :demandeur, parent: :occupant do
     demandeur true
   end
+
+  factory :declarant, parent: :occupant do
+    demandeur true
+    declarant true
+  end
 end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
 
     trait :with_avis_imposition do
       transient do
-        demandeurs_count 1
+        declarants_count 1
         occupants_a_charge_count 0
       end
 
@@ -18,14 +18,14 @@ FactoryGirl.define do
           projet: projet,
           numero_fiscal: projet.numero_fiscal,
           reference_avis: projet.reference_avis,
-          demandeurs_count: evaluator.demandeurs_count,
+          declarants_count: evaluator.declarants_count,
           occupants_a_charge_count: evaluator.occupants_a_charge_count)
       end
     end
 
     trait :with_demandeurs do
       with_avis_imposition
-      demandeurs_count 2
+      declarants_count 2
       occupants_a_charge_count 2
     end
 

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -13,12 +13,12 @@ FactoryGirl.define do
         occupants_a_charge_count 0
       end
 
-      after(:create) do |projet, evaluator|
-        create(:avis_imposition_with_occupants,
-          projet: projet,
-          numero_fiscal: projet.numero_fiscal,
-          reference_avis: projet.reference_avis,
-          declarants_count: evaluator.declarants_count,
+      after(:build) do |projet, evaluator|
+        projet.avis_impositions << build(:avis_imposition_with_occupants,
+          projet:                   projet,
+          numero_fiscal:            projet.numero_fiscal,
+          reference_avis:           projet.reference_avis,
+          declarants_count:         evaluator.declarants_count,
           occupants_a_charge_count: evaluator.occupants_a_charge_count)
       end
     end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -111,6 +111,17 @@ FactoryGirl.define do
 
     # Project states
 
+    trait :initial do
+      statut :prospect
+      email nil
+      annee_construction nil
+      with_avis_imposition
+
+      after(:create) do |projet, evaluator|
+        projet.demandeur_principal.update_attribute(:civilite, nil)
+      end
+    end
+
     trait :prospect do
       statut :prospect
       with_demandeur

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -23,10 +23,14 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_demandeurs do
+    trait :with_demandeur do
       with_avis_imposition
       declarants_count 2
       occupants_a_charge_count 2
+
+      after(:build) do |projet|
+        projet.avis_impositions.first.occupants.first.demandeur = true
+      end
     end
 
     trait :with_demande do
@@ -109,14 +113,14 @@ FactoryGirl.define do
 
     trait :prospect do
       statut :prospect
-      with_demandeurs
+      with_demandeur
       with_demande
       with_intervenants_disponibles
     end
 
     trait :en_cours do
       statut :en_cours
-      with_demandeurs
+      with_demandeur
       with_demande
       with_committed_operateur
     end
@@ -124,7 +128,7 @@ FactoryGirl.define do
     trait :proposition_enregistree do
       statut :proposition_enregistree
       date_de_visite DateTime.new(2016, 12, 28)
-      with_demandeurs
+      with_demandeur
       with_demande
       with_assigned_operateur
       with_prestations
@@ -132,14 +136,14 @@ FactoryGirl.define do
 
     trait :proposition_proposee do
       statut :proposition_proposee
-      with_demandeurs
+      with_demandeur
       with_demande
       with_assigned_operateur
       with_prestations
     end
 
     trait :transmis_pour_instruction do
-      with_demandeurs
+      with_demandeur
       with_demande
       with_assigned_operateur
       with_prestations
@@ -153,7 +157,7 @@ FactoryGirl.define do
     trait :en_cours_d_instruction do
       opal_numero 4567
       opal_id 8910
-      with_demandeurs
+      with_demandeur
       with_demande
       with_assigned_operateur
       with_prestations

--- a/spec/features/1_demarrage/etape1_demandeur_spec.rb
+++ b/spec/features/1_demarrage/etape1_demandeur_spec.rb
@@ -9,19 +9,17 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
   scenario "Depuis la page de connexion, je récupère mes informations principales" do
     signin_for_new_projet
     expect(page.current_path).to eq(projet_demandeur_path(projet))
-    expect(page).to have_content("Martin")
-    expect(page).to have_content("Pierre")
-    expect(projet.demandeur_principal_nom).to eq("Martin")
-    expect(projet.demandeur_principal_prenom).to eq("Pierre")
-    expect(page).to have_content(I18n.t('demarrage_projet.demandeur.section_demandeur'))
-    expect(find_field('projet_adresse_postale').value).to eq('12 rue de la Mare, 75010 Paris')
+    expect(page).to have_content(I18n.t('projets.messages.creation.titre'))
     expect(page).to have_content(I18n.t('projets.messages.creation.corps'))
-    expect(page).to have_content(I18n.t('projets.messages.creation.titre', demandeur_principal: projet.demandeur_principal.fullname))
-  end
+    expect(page).to have_content(I18n.t('demarrage_projet.demandeur.section_demandeur'))
+    expect(page).to have_select(I18n.t('demarrage_projet.demandeur.demandeur_identity'))
+    expect(find_field('projet_adresse_postale').value).to eq('12 rue de la Mare, 75010 Paris')
+    end
 
   scenario "je remplis mes informations personnelles" do
     signin_for_new_projet
-    within '.civilite' do choose('Monsieur') end
+    within '.civilite' do choose "Monsieur" end
+    select "Pierre Martin"
     fill_in :projet_email, with: "demandeur@exemple.fr"
     fill_in :projet_tel,   with: "01 02 03 04 05"
     click_button I18n.t('demarrage_projet.action')
@@ -58,6 +56,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
   scenario "je peux ajouter l'adresse du logement à rénover" do
     signin_for_new_projet
     within '.civilite' do choose('Monsieur') end
+    select "Pierre Martin"
     fill_in :projet_email, with: "demandeur@exemple.fr"
     fill_in :projet_adresse_a_renover, with: Fakeweb::ApiBan::ADDRESS_PORT
     click_button I18n.t('demarrage_projet.action')
@@ -72,6 +71,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
   scenario "j'ajoute une personne de confiance" do
     signin_for_new_projet
     within '.civilite' do choose('Monsieur') end
+    select "Pierre Martin"
     fill_in :projet_email, with: "demandeur@exemple.fr"
     page.choose I18n.t('demarrage_projet.demandeur.personne_confiance_choix2')
     within '.dem-diff.ins-form' do

--- a/spec/features/1_demarrage/etape2_avis_imposition_spec.rb
+++ b/spec/features/1_demarrage/etape2_avis_imposition_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'support/mpal_features_helper'
 
 feature "Avis d'imposition :" do
-  let(:projet) { create(:projet, :with_demandeurs) }
+  let(:projet) { create(:projet, :with_demandeur) }
 
   context "en tant que demandeur avec l'avis d'imposition initial" do
     scenario "je peux ajouter un autre avis d'imposition" do

--- a/spec/features/1_demarrage/etape3_occupants_spec.rb
+++ b/spec/features/1_demarrage/etape3_occupants_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'support/mpal_features_helper'
 
 feature "Occupants :" do
-  let(:projet) { create(:projet, :with_demandeurs) }
+  let(:projet) { create(:projet, :with_demandeur) }
 
   context "en tant que demandeur" do
     scenario "je peux voir les occupants récupérés depuis l'avis d'imposition" do

--- a/spec/models/occupant_spec.rb
+++ b/spec/models/occupant_spec.rb
@@ -25,7 +25,7 @@ describe Occupant do
       end
 
       context "qui est le demandeur principal" do
-        subject { create(:projet, :with_demandeurs).demandeur_principal }
+        subject { create(:projet, :with_demandeur).demandeur_principal }
         it { is_expected.to validate_presence_of(:civilite) }
       end
     end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -170,7 +170,7 @@ describe Projet do
   end
 
   describe '#nb_occupants_a_charge' do
-    let(:projet) { create :projet, :with_demandeurs, demandeurs_count: 1, occupants_a_charge_count: 2 }
+    let(:projet) { create :projet, :with_demandeurs, declarants_count: 1, occupants_a_charge_count: 2 }
     it { expect(projet.nb_occupants_a_charge).to eq(2) }
   end
 
@@ -184,19 +184,19 @@ describe Projet do
 
   describe '#preeligibilite' do
     let(:annee) { 2015 }
-    let(:projet) { create :projet, :with_avis_imposition, demandeurs_count: 2, occupants_a_charge_count: 2 }
+    let(:projet) { create :projet, :with_avis_imposition, declarants_count: 2, occupants_a_charge_count: 2 }
     it { expect(projet.preeligibilite(annee)).to eq(:tres_modeste) }
   end
 
   describe '#nom_occupants' do
-    let(:projet) { create :projet, :with_demandeurs, demandeurs_count: 2, occupants_a_charge_count: 0 }
+    let(:projet) { create :projet, :with_demandeurs, declarants_count: 2, occupants_a_charge_count: 0 }
     let(:occupant_1) { projet.occupants.first }
     let(:occupant_2) { projet.occupants.last }
     it { expect(projet.nom_occupants).to eq("#{occupant_1.nom.upcase} ET #{occupant_2.nom.upcase}") }
   end
 
   describe '#prenom_occupants' do
-    let(:projet) { create :projet, :with_demandeurs, demandeurs_count: 2, occupants_a_charge_count: 0 }
+    let(:projet) { create :projet, :with_demandeurs, declarants_count: 2, occupants_a_charge_count: 0 }
     let(:occupant_1) { projet.occupants.first }
     let(:occupant_2) { projet.occupants.last }
     it { expect(projet.prenom_occupants).to eq("#{occupant_1.prenom.capitalize} et #{occupant_2.prenom.capitalize}") }

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -170,7 +170,7 @@ describe Projet do
   end
 
   describe '#nb_occupants_a_charge' do
-    let(:projet) { create :projet, :with_demandeurs, declarants_count: 1, occupants_a_charge_count: 2 }
+    let(:projet) { create :projet, :with_demandeur, declarants_count: 1, occupants_a_charge_count: 2 }
     it { expect(projet.nb_occupants_a_charge).to eq(2) }
   end
 
@@ -189,14 +189,14 @@ describe Projet do
   end
 
   describe '#nom_occupants' do
-    let(:projet) { create :projet, :with_demandeurs, declarants_count: 2, occupants_a_charge_count: 0 }
+    let(:projet) { create :projet, :with_demandeur, declarants_count: 2, occupants_a_charge_count: 0 }
     let(:occupant_1) { projet.occupants.first }
     let(:occupant_2) { projet.occupants.last }
     it { expect(projet.nom_occupants).to eq("#{occupant_1.nom.upcase} ET #{occupant_2.nom.upcase}") }
   end
 
   describe '#prenom_occupants' do
-    let(:projet) { create :projet, :with_demandeurs, declarants_count: 2, occupants_a_charge_count: 0 }
+    let(:projet) { create :projet, :with_demandeur, declarants_count: 2, occupants_a_charge_count: 0 }
     let(:occupant_1) { projet.occupants.first }
     let(:occupant_2) { projet.occupants.last }
     it { expect(projet.prenom_occupants).to eq("#{occupant_1.prenom.capitalize} et #{occupant_2.prenom.capitalize}") }
@@ -250,7 +250,7 @@ describe Projet do
   end
 
   describe "#change_demandeur" do
-    let(:projet) { create :projet, :with_demandeurs }
+    let(:projet) { create :projet, :with_demandeur }
 
     it "change le demandeur" do
       expect(projet.demandeur_principal).to eq projet.occupants.first

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -30,7 +30,7 @@ describe Opal do
   let(:client) { OpalClientMock.new(201, "OK", { dosNumero: "09500840", dosId: 959496 }) }
 
   describe "#create_dossier!" do
-    let(:projet) {            create :projet, :transmis_pour_instruction, demandeurs_count: 1, occupants_a_charge_count: 1 }
+    let(:projet) {            create :projet, :transmis_pour_instruction, declarants_count: 1, occupants_a_charge_count: 1 }
     let(:instructeur) {       create :instructeur }
     let(:agent_instructeur) { create :agent, intervenant: instructeur }
 


### PR DESCRIPTION
La première fois que le demandeur renseigne ses informations, il doit renseigner explicitement l'identité du demandeur.

Les fois suivantes, l'identité du demandeur est correctement pré-remplie.

![demandeur](https://cloud.githubusercontent.com/assets/179923/25397638/3d3f51ea-29e9-11e7-83f5-5b9c41a08aac.gif)
