### PR TITLE
PF400 seed les Review Apps sur chaque PR

### DIFF
--- a/config/initializers/seeds.rb
+++ b/config/initializers/seeds.rb
@@ -1,0 +1,11 @@
+# Seed the database of Review Apps
+#
+# A better way would be to have a postdeploy hook specifically for
+# Review Apps, where we could execute `rake db:seed` cleanly.
+# But such a hook doesn't exist on Scalingo yet (although it does
+# on Heroku) ; hence this workaround.
+
+if ENV['IS_REVIEW_APP'] == "true" && !ActiveRecord::Migrator.needs_migration?
+  Rails.application.load_tasks
+  Rake::Task['db:seed'].invoke
+end

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "IS_REVIEW_APP": {
+      "value": "true"
+    }
+  }
+}


### PR DESCRIPTION
Ce qu'on veut faire ici, c'est exécuter rake db:seed au premier déploiement d'une Review App.

Heroku a un hook qui permet de faire ça – mais Scalingo pas encore : il n'y a qu'un hook postdeploy, mais qui est exécuté après chaque déploiement, sur tous les environnements. Et nous on ne veut pas faire tourner les seeds en production, par exemple.

J'ai contacté le support de Scalingo. Ils me disent que pour l'instant la meilleure manière de faire est de définir une variable d'environnement IS_REVIEW_APP dans un fichier scalingo.json. Cette variable sera disponible uniquement pour les Review Apps. On peut ensuite écrire un initializer qui charge les seeds si cette variable est présente (et que la base de donnée est dans un état cohérent).

tl ; pl : ça marche ! 🙌