### PR TITLE
PF416 force la sélection du demandeur pour les déclarants uniques

### DIFF
--- a/app/controllers/demandeurs_controller.rb
+++ b/app/controllers/demandeurs_controller.rb
@@ -26,6 +26,7 @@ private
 
     @page_heading = 'Inscription'
     @declarants = @projet_courant.occupants.declarants.collect { |o| [ o.fullname, o.id ] }
+    @declarants_prompt = @declarants.length <= 1 ? nil : t('demarrage_projet.demandeur.select')
 
     render :show
   end

--- a/app/views/demandeurs/show.html.slim
+++ b/app/views/demandeurs/show.html.slim
@@ -15,7 +15,7 @@
     ul.dem-info.ins-form
       li.full
         = label_tag 'projet[demandeur_id]', t('demarrage_projet.demandeur.demandeur_identity')
-        = select_tag 'projet[demandeur_id]', options_for_select(@declarants, @demandeur.try(:id)), class: 'form-control', prompt: t('demarrage_projet.demandeur.select')
+        = select_tag 'projet[demandeur_id]', options_for_select(@declarants, @demandeur.try(:id)), class: 'form-control', prompt: @declarants_prompt
       li.full
         = f.label :adresse_postale
         = text_field_tag "projet[adresse_postale]", @projet_courant.adresse_postale.try(:description)

--- a/spec/controllers/demandeurs_controller_spec.rb
+++ b/spec/controllers/demandeurs_controller_spec.rb
@@ -19,6 +19,20 @@ describe DemandeursController do
       expect(assigns(:page_heading)).to eq 'Inscription'
       expect(assigns(:demandeur)).to eq projet.demandeur
     end
+
+    context "quand il n'y a qu'un seul déclarant" do
+      let(:projet) { create :projet, :prospect, declarants_count: 1 }
+      it "propose l'unique déclarant possible comme demandeur" do
+        expect(assigns(:declarants_prompt)).to be nil
+      end
+    end
+
+    context "quand il y a plusieurs déclarants" do
+      let(:projet) { create :projet, :prospect, declarants_count: 2 }
+      it "laisse l'utilisateur choisir le demandeur" do
+        expect(assigns(:declarants_prompt)).to   eq I18n.t('demarrage_projet.demandeur.select')
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/features/1_demarrage/etape1_demandeur_spec.rb
+++ b/spec/features/1_demarrage/etape1_demandeur_spec.rb
@@ -3,10 +3,10 @@ require 'support/mpal_features_helper'
 require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
-feature "En tant que demandeur, je peux vérifier et corriger mes informations personnelles" do
+feature "Demandeur :" do
   let(:projet) { Projet.last }
 
-  scenario "Depuis la page de connexion, je récupère mes informations principales" do
+  scenario "mes informations personnelles sont récupérées à partir de l'avis d'imposition" do
     signin_for_new_projet
     expect(page.current_path).to eq(projet_demandeur_path(projet))
     expect(page).to have_content(I18n.t('projets.messages.creation.titre'))
@@ -28,21 +28,6 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     expect(projet.demandeur.civilite).to eq("mr")
     expect(projet.email).to eq("demandeur@exemple.fr")
     expect(projet.tel).to eq("01 02 03 04 05")
-  end
-
-  context "quand je rentre des données invalides" do
-    scenario "je vois un message d'erreur" do
-      signin_for_new_projet
-      fill_in :projet_email, with: "invalid-email@lol"
-      fill_in 'projet_tel', with: "999"
-      click_button I18n.t('demarrage_projet.action')
-
-      expect(page).to have_current_path projet_demandeur_path(projet)
-      expect(page).to have_content("L’adresse email n’est pas valide")
-      expect(page).to have_field("Email", with: "invalid-email@lol")
-      expect(page).to have_content("Le numéro de téléphone est trop court")
-      expect(page).to have_field("Téléphone", with: "999")
-    end
   end
 
   scenario "je dois rentrer une adresse" do
@@ -93,12 +78,19 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     expect(projet.personne.lien_avec_demandeur).to eq("Mon jazzman favori et neanmoins concubin")
   end
 
-  scenario "je vois la liste des personnes présentes dans l'avis d'imposition sous forme d'occupants" do
-    signin_for_new_projet
-    visit projet_occupants_path(projet)
-    expect(projet.nb_total_occupants).to eq(4)
-    expect(projet.occupants.count).to eq(4)
-    expect(page).to have_content("Occupant 3")
-    expect(page).to have_content("Occupant 4")
+  context "quand je rentre des données invalides" do
+    scenario "je vois un message d'erreur" do
+      signin_for_new_projet
+      fill_in :projet_email, with: "invalid-email@lol"
+      fill_in 'projet_tel', with: "999"
+      click_button I18n.t('demarrage_projet.action')
+
+      expect(page).to have_current_path projet_demandeur_path(projet)
+      expect(page).to have_content(I18n.t('demarrage_projet.demandeur.erreurs.enregistrement_demandeur'))
+      expect(page).to have_content("L’adresse email n’est pas valide")
+      expect(page).to have_field("Email", with: "invalid-email@lol")
+      expect(page).to have_content("Le numéro de téléphone est trop court")
+      expect(page).to have_field("Téléphone", with: "999")
+    end
   end
 end


### PR DESCRIPTION
## Quand il n'y a qu'un déclarant

Le demandeur est pré-sélectionné.

<img width="541" alt="capture d ecran 2017-05-03 a 17 12 24" src="https://cloud.githubusercontent.com/assets/179923/25667485/ea7fdbe6-3023-11e7-8e94-a8bdc0f2dbde.png">

## Quand il y a plusieurs déclarants

Le demandeur doit être choisi explicitement.

<img width="539" alt="capture d ecran 2017-05-03 a 17 11 52" src="https://cloud.githubusercontent.com/assets/179923/25667476/e4ca6310-3023-11e7-9fab-d7a0fecb7a42.png">
