### PR TITLE
BSR renomme `demandeur_principal` en `demandeur`

### DIFF
--- a/app/controllers/commentaires_controller.rb
+++ b/app/controllers/commentaires_controller.rb
@@ -16,7 +16,7 @@ private
     if agent_signed_in?
       current_agent
     else
-      @projet_courant.demandeur_principal
+      @projet_courant.demandeur
     end
   end
 end

--- a/app/controllers/demandeurs_controller.rb
+++ b/app/controllers/demandeurs_controller.rb
@@ -22,7 +22,7 @@ private
 
   def render_show
     @projet_courant.personne ||= Personne.new
-    @demandeur ||= @projet_courant.demandeur_principal
+    @demandeur ||= @projet_courant.demandeur
 
     @page_heading = 'Inscription'
     @declarants = @projet_courant.occupants.declarants.collect { |o| [ o.fullname, o.id ] }
@@ -54,8 +54,8 @@ private
     )
   end
 
-  def demandeur_principal_params
-    params.fetch(:demandeur_principal, {}).permit(:civilite)
+  def demandeur_params
+    params.fetch(:demandeur, {}).permit(:civilite)
   end
 
   def save_demandeur
@@ -108,7 +108,7 @@ private
 
   def assign_demandeur(demandeur_id)
     @demandeur = @projet_courant.change_demandeur(demandeur_id)
-    @demandeur.assign_attributes(demandeur_principal_params)
+    @demandeur.assign_attributes(demandeur_params)
     @demandeur.save
   end
 end

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -33,7 +33,7 @@ class DossiersController < ApplicationController
       if @projet_courant.suggest_operateurs!(suggested_operateurs_params[:suggested_operateur_ids])
         message = I18n.t('recommander_operateurs.succes',
                           count:     @projet_courant.suggested_operateurs.count,
-                          demandeur: @projet_courant.demandeur_principal.fullname)
+                          demandeur: @projet_courant.demandeur.fullname)
         redirect_to(dossier_path(@projet_courant), notice: message)
       end
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -55,7 +55,7 @@ private
   end
 
   def redirect_to_next_step(projet)
-    if projet.demandeur_principal.blank?
+    if projet.demandeur.blank?
       redirect_to projet_demandeur_path(projet)
     else
       redirect_to projet

--- a/app/mailers/projet_mailer.rb
+++ b/app/mailers/projet_mailer.rb
@@ -5,7 +5,7 @@ class ProjetMailer < ActionMailer::Base
 
   def recommandation_operateurs(projet)
     @projet = projet
-    @demandeur = projet.demandeur_principal
+    @demandeur = projet.demandeur
     @pris = projet.invited_pris
     mail(
       to: projet.email,
@@ -17,7 +17,7 @@ class ProjetMailer < ActionMailer::Base
     @invitation = invitation
     mail(
       to: invitation.intervenant_email,
-      subject: t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur_principal: @invitation.demandeur_principal.fullname)
+      subject: t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur: @invitation.demandeur.fullname)
     )
   end
 
@@ -33,7 +33,7 @@ class ProjetMailer < ActionMailer::Base
     @invitation = invitation
     mail(
       to: invitation.intervenant_email,
-      subject: t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur_principal: @invitation.demandeur_principal.fullname)
+      subject: t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur: @invitation.demandeur.fullname)
     )
   end
 
@@ -42,7 +42,7 @@ class ProjetMailer < ActionMailer::Base
     @invitation = @projet.invitations.find_by_intervenant_id(projet.operateur_id)
     mail(
       to: @projet.operateur.email,
-      subject: t('mailers.projet_mailer.notification_choix_intervenant.sujet', intervenant: @projet.operateur.raison_sociale, demandeur_principal: @projet.demandeur_principal.fullname)
+      subject: t('mailers.projet_mailer.notification_choix_intervenant.sujet', intervenant: @projet.operateur.raison_sociale, demandeur: @projet.demandeur.fullname)
     )
   end
 
@@ -56,7 +56,7 @@ class ProjetMailer < ActionMailer::Base
 
   def accuse_reception(projet)
     @projet = projet
-    @demandeur = projet.demandeur_principal
+    @demandeur = projet.demandeur
     @instructeur = projet.invited_instructeur
     @date_depot = projet.date_depot
     mail(

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -15,11 +15,11 @@ class Invitation < ActiveRecord::Base
   validates :projet, :intervenant, presence: true
   validates_uniqueness_of :intervenant, scope: :projet_id
 
-  delegate :demandeur_principal,          to: :projet
-  delegate :demandeur_principal_prenom,   to: :projet
-  delegate :demandeur_principal_nom,      to: :projet
-  delegate :demandeur_principal_civilite, to: :projet
-  delegate :description_adresse,          to: :projet
+  delegate :demandeur,           to: :projet
+  delegate :demandeur_prenom,    to: :projet
+  delegate :demandeur_nom,       to: :projet
+  delegate :demandeur_civilite,  to: :projet
+  delegate :description_adresse, to: :projet
 
   def intervenant_email
     intervenant.email

--- a/app/models/occupant.rb
+++ b/app/models/occupant.rb
@@ -16,7 +16,7 @@ class Occupant < ActiveRecord::Base
   scope :sans_revenus, -> { where(revenus: nil) }
 
   def require_civilite?
-    projet && projet.demandeur_principal == self
+    projet && projet.demandeur == self
   end
 
   def fullname

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -171,24 +171,24 @@ class Projet < ActiveRecord::Base
     occupants.where(declarant: true)
   end
 
-  def demandeur_principal
+  def demandeur
     occupants.where(demandeur: true).first
   end
 
-  def demandeur_principal_nom
-    demandeur_principal.nom
+  def demandeur_nom
+    demandeur.nom
   end
 
-  def demandeur_principal_prenom
-    demandeur_principal.prenom
+  def demandeur_prenom
+    demandeur.prenom
   end
 
-  def demandeur_principal_civilite
-    demandeur_principal.civilite
+  def demandeur_civilite
+    demandeur.civilite
   end
 
   def usager
-    occupant = demandeur_principal
+    occupant = demandeur
     occupant.to_s if occupant
   end
 
@@ -345,7 +345,7 @@ class Projet < ActiveRecord::Base
       Projet.for_agent(agent).each do |projet|
         line = [
           projet.numero_plateforme,
-          projet.demandeur_principal.fullname,
+          projet.demandeur.fullname,
           projet.adresse.try(:ville),
           projet.invited_instructeur.try(:raison_sociale),
           projet.themes.map(&:libelle).join(", "),

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -64,9 +64,9 @@ private
         "qdmId": 29,
         "cadId": 2,
         "personnePhysique": {
-          "civId":            serialize_civilite(projet.demandeur_principal),
-          "pphNom":           serialize_nom(projet.demandeur_principal),
-          "pphPrenom":        serialize_prenom(projet.demandeur_principal),
+          "civId":            serialize_civilite(projet.demandeur),
+          "pphNom":           serialize_nom(projet.demandeur),
+          "pphPrenom":        serialize_prenom(projet.demandeur),
           "adressePostale": {
             "payId": 1,
             "adpLigne1":     lignes_adresse_postale[0],

--- a/app/views/demandeurs/show.html.slim
+++ b/app/views/demandeurs/show.html.slim
@@ -7,11 +7,11 @@
     p.chapo= t('demarrage_projet.demandeur.recapitulatif_informations')
     ul.dem-info.ins-form.civilite
       li.radio
-        = radio_button_tag 'demandeur_principal[civilite]', Occupant.civilites.keys[1], (@demandeur.try(:civilite) == Occupant.civilites.keys[1])
-        = label_tag 'demandeur_principal_civilite_mme', t(:"occupants.civilite.mme")
+        = radio_button_tag 'demandeur[civilite]', Occupant.civilites.keys[1], (@demandeur.try(:civilite) == Occupant.civilites.keys[1])
+        = label_tag 'demandeur_civilite_mme', t(:"occupants.civilite.mme")
       li.radio
-        = radio_button_tag 'demandeur_principal[civilite]', Occupant.civilites.keys[0], (@demandeur.try(:civilite) == Occupant.civilites.keys[0])
-        = label_tag 'demandeur_principal_civilite_mr', t(:"occupants.civilite.mr")
+        = radio_button_tag 'demandeur[civilite]', Occupant.civilites.keys[0], (@demandeur.try(:civilite) == Occupant.civilites.keys[0])
+        = label_tag 'demandeur_civilite_mr', t(:"occupants.civilite.mr")
     ul.dem-info.ins-form
       li.full
         = label_tag 'projet[demandeur_id]', t('demarrage_projet.demandeur.demandeur_identity')

--- a/app/views/dossiers/index.html.slim
+++ b/app/views/dossiers/index.html.slim
@@ -37,8 +37,8 @@
             - if current_agent.operateur?
               td= link_to (projet.opal_numero || ' '), edit_url
             td= link_to edit_url
-              span.firstname= projet.demandeur_principal.prenom
-              span.lastname<= projet.demandeur_principal.nom
+              span.firstname= projet.demandeur.prenom
+              span.lastname<= projet.demandeur.nom
             - if current_agent.operateur?
               td= link_to projet.adresse.try(:region), edit_url
               td class='departement' = link_to projet.adresse.try(:departement), edit_url

--- a/app/views/dossiers/recommander_operateurs.html.slim
+++ b/app/views/dossiers/recommander_operateurs.html.slim
@@ -1,7 +1,7 @@
 .main-content-block.recommander_operateurs
   h2.heading Recommander des opérateurs
   = form_for @projet_courant, url: {controller: 'dossiers', action: 'recommander_operateurs' }, method: 'post', html: { class: 'form' } do |f|
-    p #{@projet_courant.demandeur_principal.fullname}, le demandeur de ce projet, recevra un email l'invitant à contacter un opérateur parmi ceux recommandés.
+    p #{@projet_courant.demandeur.fullname}, le demandeur de ce projet, recevra un email l'invitant à contacter un opérateur parmi ceux recommandés.
     = render 'shared/errors', resource: @projet_courant
     ul.checkboxes-list
       - @available_operateurs.each do |operateur|

--- a/app/views/layouts/logged_in.html.slim
+++ b/app/views/layouts/logged_in.html.slim
@@ -9,8 +9,8 @@
             = link_to t('tableau_de_bord.titre_section'), dossiers_path
         section.personal-information
           h2
-            span.firstname= @projet_courant.demandeur_principal.prenom
-            span.lastname<= @projet_courant.demandeur_principal.nom
+            span.firstname= @projet_courant.demandeur.prenom
+            span.lastname<= @projet_courant.demandeur.nom
           ul
             - if @projet_courant.tel.present?
               li= @projet_courant.tel

--- a/app/views/projet_mailer/invitation_intervenant.html.slim
+++ b/app/views/projet_mailer/invitation_intervenant.html.slim
@@ -1,5 +1,5 @@
 p Bonjour,
-p= "#{@invitation.demandeur_principal.fullname} souhaite effectuer des travaux dans son logement (#{@invitation.description_adresse})"
+p= "#{@invitation.demandeur.fullname} souhaite effectuer des travaux dans son logement (#{@invitation.description_adresse})"
 p Voici une description des travaux qu’il souhaite effectuer :
 br
 p= affiche_demande_souhaitee(@invitation.projet.demande)

--- a/app/views/projet_mailer/mise_en_relation_intervenant.html.slim
+++ b/app/views/projet_mailer/mise_en_relation_intervenant.html.slim
@@ -1,6 +1,6 @@
 p Bonjour,
 p= "#{@invitation.intermediaire.raison_sociale} vient de vous mettre en relation avec le projet suivant :"
-p= "#{@invitation.demandeur_principal.fullname} souhaite rénover son habitat #{@invitation.description_adresse}"
+p= "#{@invitation.demandeur.fullname} souhaite rénover son habitat #{@invitation.description_adresse}"
 p Voici une description des travaux qu’il souhaite effectuer :
 p= affiche_demande_souhaitee(@invitation.projet.demande)
 p= link_to "Pour visualiser le projet, cliquer sur ce lien", dossier_url(@invitation.projet)

--- a/app/views/projet_mailer/notification_choix_intervenant.html.slim
+++ b/app/views/projet_mailer/notification_choix_intervenant.html.slim
@@ -1,3 +1,3 @@
 p Bonjour,
-p= "Vous avez été choisi par #{@projet.demandeur_principal.fullname} pour l’accompagner dans son projet."
+p= "Vous avez été choisi par #{@projet.demandeur.fullname} pour l’accompagner dans son projet."
 p= link_to "Pour visualiser le projet, cliquer sur ce lien", dossier_url(@projet)

--- a/app/views/projet_mailer/resiliation_operateur.html.slim
+++ b/app/views/projet_mailer/resiliation_operateur.html.slim
@@ -1,3 +1,3 @@
 p Bonjour,
-p= "#{@invitation.demandeur_principal.fullname} a choisi un autre opérateur sur la plateforme Anah."
+p= "#{@invitation.demandeur.fullname} a choisi un autre opérateur sur la plateforme Anah."
 p Sauf erreur de manipulation de sa part, il n’est donc plus nécessaire de le contacter au sujet de son projet de travaux.

--- a/app/views/projets/_foyer.html.slim
+++ b/app/views/projets/_foyer.html.slim
@@ -17,8 +17,8 @@ article.block.occupants
     h4 Demandeur :
     p
       strong
-        span.firstname= @projet_courant.demandeur_principal.prenom
-        span.lastname<= @projet_courant.demandeur_principal.nom
+        span.firstname= @projet_courant.demandeur.prenom
+        span.lastname<= @projet_courant.demandeur.nom
       - if @projet_courant.adresse_postale.present?
         br/
         = @projet_courant.adresse_postale.description

--- a/app/views/projets/_projet_invoice.html.slim
+++ b/app/views/projets/_projet_invoice.html.slim
@@ -1,8 +1,8 @@
 ul.demandeur-info
   li
     strong
-      span.firstname= @projet_courant.demandeur_principal.prenom
-      span.lastname<= @projet_courant.demandeur_principal.nom
+      span.firstname= @projet_courant.demandeur.prenom
+      span.lastname<= @projet_courant.demandeur.nom
   - if @projet_courant.tel.present?
     li= @projet_courant.tel
   - if @projet_courant.description_adresse.present?

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -2,8 +2,8 @@ fr:
   helpers:
     label:
       projet:
-        demandeur_principal_nom: Nom
-        demandeur_principal_prenom: Prénom
+        demandeur_nom: Nom
+        demandeur_prenom: Prénom
         email: Email
         adresse: Adresse
         adresse_logement: "Adresse du logement à rénover si différente"
@@ -362,13 +362,13 @@ fr:
       recommandation_operateurs:
         sujet: "[Anah] Voici nos recommandations pour votre projet de rénovation"
       invitation_intervenant:
-        sujet: "[Anah] Invitation de %{demandeur_principal} à consulter son projet"
+        sujet: "[Anah] Invitation de %{demandeur} à consulter son projet"
       notification_invitation_intervenant:
         sujet: "[Anah] Invitation de %{intervenant} à consulter votre projet"
       notification_choix_intervenant:
-        sujet: "[Anah] Félicitations, %{intervenant}, vous avez été choisi par %{demandeur_principal} pour l’accompagner sur son projet"
+        sujet: "[Anah] Félicitations, %{intervenant}, vous avez été choisi par %{demandeur} pour l’accompagner sur son projet"
       resiliation_operateur:
-        sujet: "[Anah] %{demandeur_principal} a changé d’opérateur pour son projet"
+        sujet: "[Anah] %{demandeur} a changé d’opérateur pour son projet"
       mise_en_relation_intervenant:
         sujet: "[Anah] Mise en relation par %{intermediaire}"
       accuse_reception:

--- a/db/migrate/20170315170006_add_civilite_to_demandeur_principal.rb
+++ b/db/migrate/20170315170006_add_civilite_to_demandeur_principal.rb
@@ -4,10 +4,10 @@ class AddCiviliteToDemandeurPrincipal < ActiveRecord::Migration
 
     ActiveRecord::Base.transaction do
       Projet.find_each do |projet|
-        if projet.demandeur_principal && projet.demandeur_principal.civilite.blank?
+        if projet.demandeur && projet.demandeur.civilite.blank?
           begin
-            projet.demandeur_principal.civilite = Occupant.civilites.keys[0]
-            projet.demandeur_principal.save!
+            projet.demandeur.civilite = Occupant.civilites.keys[0]
+            projet.demandeur.save!
             print "."
             count += 1
           rescue => e

--- a/spec/controllers/demandeurs_controller_spec.rb
+++ b/spec/controllers/demandeurs_controller_spec.rb
@@ -17,7 +17,7 @@ describe DemandeursController do
     it "affiche le template" do
       expect(response).to render_template(:show)
       expect(assigns(:page_heading)).to eq 'Inscription'
-      expect(assigns(:demandeur)).to eq projet.demandeur_principal
+      expect(assigns(:demandeur)).to eq projet.demandeur
     end
   end
 
@@ -25,7 +25,7 @@ describe DemandeursController do
     let(:projet_params) do {} end
     let(:params) do
       default_params = {
-        demandeur_id: projet.demandeur_principal.id,
+        demandeur_id: projet.demandeur.id,
         adresse_postale: projet.adresse_postale.description
       }
       return {
@@ -53,7 +53,7 @@ describe DemandeursController do
         expect(response).to redirect_to projet_avis_impositions_path(projet)
         expect(projet.tel).to eq   '01 02 03 04 05'
         expect(projet.email).to eq 'particulier@exemple.fr'
-        expect(projet.demandeur_principal).to eq projet.occupants.last
+        expect(projet.demandeur).to eq projet.occupants.last
       end
     end
 
@@ -191,7 +191,7 @@ describe DemandeursController do
 
     it "affiche une erreur" do
       expect(flash[:alert]).to eq I18n.t('demarrage_projet.demandeur.erreurs.adresse_vide')
-      expect(assigns(:demandeur)).to eq projet.demandeur_principal
+      expect(assigns(:demandeur)).to eq projet.demandeur
     end
   end
 end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -117,7 +117,7 @@ FactoryGirl.define do
       with_avis_imposition
 
       after(:create) do |projet, evaluator|
-        projet.demandeur_principal.update_attribute(:civilite, nil)
+        projet.demandeur.update_attribute(:civilite, nil)
       end
     end
 

--- a/spec/features/1_demarrage/etape1_demandeur_spec.rb
+++ b/spec/features/1_demarrage/etape1_demandeur_spec.rb
@@ -25,7 +25,7 @@ feature "En tant que demandeur, je peux vérifier et corriger mes informations p
     click_button I18n.t('demarrage_projet.action')
 
     expect(page).to have_current_path projet_avis_impositions_path(projet)
-    expect(projet.demandeur_principal.civilite).to eq("mr")
+    expect(projet.demandeur.civilite).to eq("mr")
     expect(projet.email).to eq("demandeur@exemple.fr")
     expect(projet.tel).to eq("01 02 03 04 05")
   end

--- a/spec/features/2_choix_operateur/modifier_projet_spec.rb
+++ b/spec/features/2_choix_operateur/modifier_projet_spec.rb
@@ -37,7 +37,7 @@ feature "Modifier le projet :" do
       end
 
       expect(page).to have_current_path resource_demandeur_path(projet)
-      expect(find('#demandeur_principal_civilite_mr')).to be_checked
+      expect(find('#demandeur_civilite_mr')).to be_checked
       expect(page).to have_field('Adresse postale', with: '65 rue de Rome, 75008 Paris')
 
       fill_in :projet_adresse_postale,   with: Fakeweb::ApiBan::ADDRESS_PORT

--- a/spec/features/tableau_de_bord_spec.rb
+++ b/spec/features/tableau_de_bord_spec.rb
@@ -24,7 +24,7 @@ feature "J'ai accès à mes dossiers depuis mon tableau de bord" do
       within "#projet_#{projet.id}" do
         expect(page).to have_content(projet.numero_plateforme)
         expect(page).to have_content(projet.opal_numero)
-        expect(page).to have_content(projet.demandeur_principal.fullname)
+        expect(page).to have_content(projet.demandeur.fullname)
         expect(page).to have_content(projet.adresse.region)
         expect(page).to have_css('td.departement', text: projet.adresse.departement)
         expect(page).to have_content(projet.adresse.ville)
@@ -42,7 +42,7 @@ feature "J'ai accès à mes dossiers depuis mon tableau de bord" do
       visit dossiers_path
       click_link projet.numero_plateforme
       expect(page.current_path).to eq(dossier_path(projet))
-      expect(page).to have_content(projet.demandeur_principal.fullname)
+      expect(page).to have_content(projet.demandeur.fullname)
     end
 
     scenario "je ne peux pas accéder au dossier Opal" do
@@ -60,7 +60,7 @@ feature "J'ai accès à mes dossiers depuis mon tableau de bord" do
       within "#projet_#{projet.id}" do
         expect(page).to     have_content(projet.numero_plateforme)
         expect(page).to     have_content(projet.opal_numero)
-        expect(page).to     have_content(projet.demandeur_principal.fullname)
+        expect(page).to     have_content(projet.demandeur.fullname)
         expect(page).not_to have_content(projet.adresse.region)
         expect(page).not_to have_css('td.departement')
         expect(page).to     have_content(projet.adresse.ville)
@@ -78,7 +78,7 @@ feature "J'ai accès à mes dossiers depuis mon tableau de bord" do
       visit dossiers_path
       click_link projet.numero_plateforme
       expect(page.current_path).to eq(dossier_path(projet))
-      expect(page).to have_content(projet.demandeur_principal.fullname)
+      expect(page).to have_content(projet.demandeur.fullname)
     end
 
     scenario "je peux accéder au dossier Opal" do
@@ -96,7 +96,7 @@ feature "J'ai accès à mes dossiers depuis mon tableau de bord" do
       within "#projet_#{projet.id}" do
         expect(page).to     have_content(projet.plateforme_id)
         expect(page).not_to have_content(projet.opal_numero)
-        expect(page).to     have_content(projet.demandeur_principal.fullname)
+        expect(page).to     have_content(projet.demandeur.fullname)
         expect(page).not_to have_content(projet.adresse.region)
         expect(page).not_to have_css('td.departement')
         expect(page).to     have_content(projet.adresse.ville)
@@ -114,7 +114,7 @@ feature "J'ai accès à mes dossiers depuis mon tableau de bord" do
       visit dossiers_path
       click_link projet.numero_plateforme
       expect(page.current_path).to eq(dossier_path(projet))
-      expect(page).to have_content(projet.demandeur_principal.fullname)
+      expect(page).to have_content(projet.demandeur.fullname)
     end
   end
 end

--- a/spec/features/visualiser_volet_lateral_spec.rb
+++ b/spec/features/visualiser_volet_lateral_spec.rb
@@ -14,7 +14,7 @@ feature "Les information personnelles syntéthiques sont visibles" do
     signin(projet.numero_fiscal, projet.reference_avis)
     visit projet_path(projet)
     within '.personal-information' do
-      expect(page).to have_content(projet.demandeur_principal.fullname)
+      expect(page).to have_content(projet.demandeur.fullname)
       expect(page).to have_content(projet.tel)
       expect(page).to have_content(projet.email)
       expect(page).to have_no_content("très modeste")
@@ -31,7 +31,7 @@ feature "Les information personnelles syntéthiques sont visibles" do
     login_as agent_operateur, scope: :agent
     visit dossier_path(projet)
     within '.personal-information' do
-      expect(page).to have_content(projet.demandeur_principal.fullname)
+      expect(page).to have_content(projet.demandeur.fullname)
       expect(page).to have_content(projet.tel)
       expect(page).to have_content(projet.email)
       expect(page).to have_content("très modeste")

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -7,7 +7,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.recommandation_operateurs.sujet')) }
-    it { expect(email.body.encoded).to match(projet.demandeur_principal.fullname) }
+    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
     it { expect(email.body.encoded).to match(projet_choix_operateur_url(projet)) }
   end
 
@@ -16,8 +16,8 @@ describe ProjetMailer, type: :mailer do
     let(:email) { ProjetMailer.invitation_intervenant(invitation) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([invitation.intervenant_email]) }
-    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur_principal: invitation.demandeur_principal.fullname)) }
-    it { expect(email.body.encoded).to match(invitation.demandeur_principal.fullname) }
+    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur: invitation.demandeur.fullname)) }
+    it { expect(email.body.encoded).to match(invitation.demandeur.fullname) }
     it { expect(email.body.encoded).to match(invitation.description_adresse) }
     it { expect(email.body.encoded).to include("Difficultés rencontrées dans le logement") }
     it { expect(email.body.encoded).to include(dossier_url(invitation.projet)) }
@@ -40,8 +40,8 @@ describe ProjetMailer, type: :mailer do
     let(:email) { ProjetMailer.resiliation_operateur(invitation) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([invitation.intervenant_email]) }
-    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur_principal: invitation.demandeur_principal.fullname)) }
-    it { expect(email.body.encoded).to match(invitation.demandeur_principal.fullname) }
+    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur: invitation.demandeur.fullname)) }
+    it { expect(email.body.encoded).to match(invitation.demandeur.fullname) }
   end
 
   describe "l'intervenant reçoit un email lorsqu'il a été choisi par le demandeur" do
@@ -51,8 +51,8 @@ describe ProjetMailer, type: :mailer do
     let(:email) { ProjetMailer.notification_choix_intervenant(projet) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([projet.operateur.email]) }
-    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_choix_intervenant.sujet', intervenant: operateur.raison_sociale, demandeur_principal: projet.demandeur_principal.fullname)) }
-    it { expect(email.body.encoded).to match(invitation.demandeur_principal.fullname) }
+    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_choix_intervenant.sujet', intervenant: operateur.raison_sociale, demandeur: projet.demandeur.fullname)) }
+    it { expect(email.body.encoded).to match(invitation.demandeur.fullname) }
     it { expect(email.body.encoded).to include(dossier_url(projet)) }
    end
 
@@ -62,7 +62,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([projet.invited_instructeur.email]) }
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.accuse_reception.sujet')) }
-    it { expect(email.body).to include(projet.demandeur_principal.fullname) }
+    it { expect(email.body).to include(projet.demandeur.fullname) }
     it { expect(email.body).to include(projet.plateforme_id) }
     it { expect(email.body).to include(projet.invited_instructeur.raison_sociale) }
     it { expect(email.body).to include(projet.invited_instructeur.description_adresse) }

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -12,7 +12,7 @@ describe Invitation do
 
   it { is_expected.to be_valid }
 
-  it { is_expected.to delegate_method(:demandeur_principal).to(:projet) }
+  it { is_expected.to delegate_method(:demandeur).to(:projet) }
   it { is_expected.to delegate_method(:description_adresse).to(:projet) }
 
   describe '#projet_email' do

--- a/spec/models/occupant_spec.rb
+++ b/spec/models/occupant_spec.rb
@@ -19,13 +19,13 @@ describe Occupant do
     end
 
     context "pour un occupant existant" do
-      context "qui n'est pas le demandeur principal" do
+      context "qui n'est pas le demandeur" do
         subject { create(:occupant) }
         it { is_expected.not_to validate_presence_of(:civilite) }
       end
 
-      context "qui est le demandeur principal" do
-        subject { create(:projet, :with_demandeur).demandeur_principal }
+      context "qui est le demandeur" do
+        subject { create(:projet, :with_demandeur).demandeur }
         it { is_expected.to validate_presence_of(:civilite) }
       end
     end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -256,10 +256,10 @@ describe Projet do
     let(:projet) { create :projet, :with_demandeur }
 
     it "change le demandeur" do
-      expect(projet.demandeur_principal).to eq projet.occupants.first
-      new_demandeur_principal = projet.occupants.last
-      projet.change_demandeur(new_demandeur_principal.id)
-      expect(projet.demandeur_principal).to eq new_demandeur_principal
+      expect(projet.demandeur).to eq projet.occupants.first
+      new_demandeur = projet.occupants.last
+      projet.change_demandeur(new_demandeur.id)
+      expect(projet.demandeur).to eq new_demandeur
     end
   end
 

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -35,7 +35,7 @@ describe Opal do
     let(:agent_instructeur) { create :agent, intervenant: instructeur }
 
     context "en cas de succès" do
-      before { projet.demandeur_principal.update(nom: 'Strâbe', prenom: 'ōlaf') }
+      before { projet.demandeur.update(nom: 'Strâbe', prenom: 'ōlaf') }
       subject! { Opal.new(client).create_dossier!(projet, agent_instructeur) }
 
       it "envoie les informations sérialisées" do


### PR DESCRIPTION
Maintenant qu’il n’y a forcément qu’un demandeur (même s’il peut y avoir plusieurs déclarants), la notion de « demandeur principal » n’avait plus de sens.