### PR TITLE
PF372 Prestations souhaitées/préconisées/retenues

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -591,10 +591,13 @@ fieldset {
   }
   .recap-projet-table {
     td, th {
-      padding: 8px 8px 8px 20px;
+      padding: 8px 8px 8px 8px;
       font-weight: 400;
       text-align: left;
       border: 1px solid #cbd4e7;
+    }
+    td.recap-projet-image-cell {
+      text-align: center;
     }
   }
   .empty {

--- a/app/controllers/concerns/projet_concern.rb
+++ b/app/controllers/concerns/projet_concern.rb
@@ -2,38 +2,6 @@ module ProjetConcern
   extend ActiveSupport::Concern
 
   included do
-    def proposition
-      if @projet_courant.prospect?
-        return redirect_to projet_or_dossier_path(@projet_courant), alert: t('sessions.access_forbidden')
-      end
-
-      if request.put?
-        if @projet_courant.save_proposition!(projet_params)
-          return redirect_to projet_or_dossier_path(@projet_courant), notice: t('projets.edition_projet.messages.succes')
-        else
-          flash.now[:alert] = t('projets.edition_projet.messages.erreur')
-        end
-      end
-
-      assign_projet_if_needed
-      @themes = Theme.ordered.all
-      #TODO prestations = Prestation.active | @projet_courant.prestations
-      @prestations_with_choices = prestations_with_choices
-      @aides_publiques = Aide.public_assistance.active     | @projet_courant.aides.public_assistance
-      @aides_privees   = Aide.not_public_assistance.active | @projet_courant.aides.not_public_assistance
-      render "projets/proposition"
-    end
-
-    def proposer
-      @projet_courant.statut = :proposition_proposee
-      if @projet_courant.save(context: :proposition)
-        return redirect_to projet_or_dossier_path(@projet_courant)
-      else
-        @projet_courant.restore_statut!
-        render_show
-      end
-    end
-
     def show
       render_show
     end
@@ -50,51 +18,6 @@ private
       @pris_departement = @projet_courant.intervenants_disponibles(role: :pris)
       @invitations_demandeur = Invitation.where(projet_id: @projet_courant.id)
       render "projets/show"
-    end
-
-    def projet_params
-      attributs = params.require(:projet)
-      .permit(:disponibilite, :description, :email, :tel, :date_de_visite,
-              :type_logement, :etage, :nb_pieces, :surface_habitable, :etiquette_avant_travaux,
-              :niveau_gir, :autonomie, :handicap, :demandeur_salarie, :entreprise_plus_10_personnes,
-              :note_degradation, :note_insalubrite, :ventilation_adaptee, :presence_humidite, :auto_rehabilitation,
-              :remarques_diagnostic,
-              :consommation_avant_travaux, :consommation_apres_travaux,
-              :etiquette_avant_travaux, :etiquette_apres_travaux,
-              :gain_energetique,
-              :precisions_travaux, :precisions_financement,
-              :localized_amo_amount, :localized_assiette_subventionnable_amount, :localized_maitrise_oeuvre_amount, :localized_travaux_ht_amount, :localized_travaux_ttc_amount,
-              :localized_loan_amount, :localized_personal_funding_amount,
-              :documents_attributes,
-              :theme_ids => [],
-              :suggested_operateur_ids => [],
-              :prestation_choices_attributes => [:id, :prestation_id, :desired, :recommended, :selected],
-              :projet_aides_attributes => [:id, :aide_id, :localized_amount],
-              :demande => [:annee_construction],
-      )
-      if attributs[:projet_aides_attributes].present?
-        attributs[:projet_aides_attributes].values.each do |projet_aide|
-          projet_aide[:_destroy] = true if projet_aide[:localized_amount].blank?
-        end
-      end
-      if attributs[:prestation_choices_attributes].present?
-        attributs[:prestation_choices_attributes].values.each do |prestation_choice|
-          prestation_choice[:_destroy] = true if prestation_choice[:desired].blank? && prestation_choice[:recommended].blank? && prestation_choice[:selected].blank?
-        end
-      end
-      attributs
-    end
-
-    def assign_projet_if_needed
-      if !@projet_courant.agent_operateur && current_agent
-        if @projet_courant.update_attribute(:agent_operateur, current_agent)
-          flash.now[:notice] = t('projets.visualisation.projet_affecte')
-        end
-      end
-    end
-
-    def prestations_with_choices
-      Prestation.joins("LEFT OUTER JOIN prestation_choices ON prestation_choices.prestation_id = prestations.id AND prestation_choices.projet_id = #{ActiveRecord::Base.sanitize(@projet_courant.id)}").distinct.select('prestations.*, prestation_choices.desired AS desired, prestation_choices.recommended AS recommended, prestation_choices.selected AS selected, prestation_choices.id AS prestation_choice_id')
     end
   end
 end

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -28,6 +28,38 @@ class DossiersController < ApplicationController
     redirect_to dossier_path(@projet_courant)
   end
 
+  def proposition
+    if @projet_courant.prospect?
+      return redirect_to projet_or_dossier_path(@projet_courant), alert: t('sessions.access_forbidden')
+    end
+
+    if request.put?
+      if @projet_courant.save_proposition!(projet_params)
+        return redirect_to projet_or_dossier_path(@projet_courant), notice: t('projets.edition_projet.messages.succes')
+      else
+        flash.now[:alert] = t('projets.edition_projet.messages.erreur')
+      end
+    end
+
+    assign_projet_if_needed
+    @themes = Theme.ordered.all
+    #TODO prestations = Prestation.active | @projet_courant.prestations
+    @prestations_with_choices = prestations_with_choices
+    @aides_publiques = Aide.public_assistance.active     | @projet_courant.aides.public_assistance
+    @aides_privees   = Aide.not_public_assistance.active | @projet_courant.aides.not_public_assistance
+    render "projets/proposition"
+  end
+
+  def proposer
+    @projet_courant.statut = :proposition_proposee
+    if @projet_courant.save(context: :proposition)
+      return redirect_to projet_or_dossier_path(@projet_courant)
+    else
+      @projet_courant.restore_statut!
+      render_show
+    end
+  end
+
   def recommander_operateurs
     if request.post?
       if @projet_courant.suggest_operateurs!(suggested_operateurs_params[:suggested_operateur_ids])
@@ -46,8 +78,53 @@ class DossiersController < ApplicationController
 
 private
 
+  def assign_projet_if_needed
+    if !@projet_courant.agent_operateur && current_agent
+      if @projet_courant.update_attribute(:agent_operateur, current_agent)
+        flash.now[:notice] = t('projets.visualisation.projet_affecte')
+      end
+    end
+  end
+
   def export_filename
     "dossiers_#{Time.now.strftime('%Y-%m-%d_%H-%M')}.csv"
+  end
+
+  def prestations_with_choices
+    Prestation.joins("LEFT OUTER JOIN prestation_choices ON prestation_choices.prestation_id = prestations.id AND prestation_choices.projet_id = #{ActiveRecord::Base.sanitize(@projet_courant.id)}").distinct.select('prestations.*, prestation_choices.wished AS wished, prestation_choices.recommended AS recommended, prestation_choices.selected AS selected, prestation_choices.id AS prestation_choice_id')
+  end
+
+  def projet_params
+    attributs = params.require(:projet)
+                .permit(:disponibilite, :description, :email, :tel, :date_de_visite,
+                        :type_logement, :etage, :nb_pieces, :surface_habitable, :etiquette_avant_travaux,
+                        :niveau_gir, :autonomie, :handicap, :demandeur_salarie, :entreprise_plus_10_personnes,
+                        :note_degradation, :note_insalubrite, :ventilation_adaptee, :presence_humidite, :auto_rehabilitation,
+                        :remarques_diagnostic,
+                        :consommation_avant_travaux, :consommation_apres_travaux,
+                        :etiquette_avant_travaux, :etiquette_apres_travaux,
+                        :gain_energetique,
+                        :precisions_travaux, :precisions_financement,
+                        :localized_amo_amount, :localized_assiette_subventionnable_amount, :localized_maitrise_oeuvre_amount, :localized_travaux_ht_amount, :localized_travaux_ttc_amount,
+                        :localized_loan_amount, :localized_personal_funding_amount,
+                        :documents_attributes,
+                        :theme_ids => [],
+                        :suggested_operateur_ids => [],
+                        :prestation_choices_attributes => [:id, :prestation_id, :wished, :recommended, :selected],
+                        :projet_aides_attributes => [:id, :aide_id, :localized_amount],
+                        :demande => [:annee_construction],
+                )
+    if attributs[:projet_aides_attributes].present?
+      attributs[:projet_aides_attributes].values.each do |projet_aide|
+        projet_aide[:_destroy] = true if projet_aide[:localized_amount].blank?
+      end
+    end
+    if attributs[:prestation_choices_attributes].present?
+      attributs[:prestation_choices_attributes].values.each do |prestation_choice|
+        prestation_choice[:_destroy] = true if prestation_choice[:wished].blank? && prestation_choice[:recommended].blank? && prestation_choice[:selected].blank?
+      end
+    end
+    attributs
   end
 
   def suggested_operateurs_params

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -145,7 +145,7 @@ private
   end
 
   def fill_blank_values_with_false(prestation_choice)
-    prestation_choice[:wished]      = prestation_choice[:wished].present?
+    prestation_choice[:desired]     = prestation_choice[:desired].present?
     prestation_choice[:recommended] = prestation_choice[:recommended].present?
     prestation_choice[:selected]    = prestation_choice[:selected].present?
     prestation_choice

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -90,7 +90,7 @@ private
   end
 
   def prestations_with_choices
-    # simplify by .leftjoin when Rails 5
+    # This query be simplified by using `left_joins` once we'll be running on Rails 5
     Prestation
       .active_for_projet(@projet_courant)
       .joins("LEFT OUTER JOIN prestation_choices ON prestation_choices.prestation_id = prestations.id AND prestation_choices.projet_id = #{ActiveRecord::Base.sanitize(@projet_courant.id)}")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,11 +64,6 @@ module ApplicationHelper
     string + " : "
   end
 
-  def prestation_checkbox(projet, prestation)
-    checked = projet.prestations.include?(prestation)
-    check_box_tag 'projet[prestation_ids][]', prestation.id, checked, id: "prestation_#{prestation.id}"
-  end
-
   def calcul_preeligibilite(annee)
     plafond = @projet_courant.preeligibilite(annee)
     t("projets.composition_logement.calcul_preeligibilite.#{plafond}")

--- a/app/models/prestation.rb
+++ b/app/models/prestation.rb
@@ -3,10 +3,9 @@ class Prestation < ActiveRecord::Base
   has_many :projets, through: :prestation_choices
 
   scope :active, -> { where(active: true) }
+  scope :active_for_projet, -> (projet) {
+    where('active = true OR (SELECT COUNT(*) FROM prestation_choices WHERE prestation_choices.prestation_id = prestations.id AND prestation_choices.projet_id = ?) > 0', projet.id)
+  }
 
   validates_uniqueness_of :libelle
-
-  def choice_for_projet(projet)
-    self.prestation_choices.all.find_by(projet_id: projet.id)
-  end
 end

--- a/app/models/prestation.rb
+++ b/app/models/prestation.rb
@@ -1,7 +1,12 @@
 class Prestation < ActiveRecord::Base
-  has_and_belongs_to_many :projets
+  has_many :prestation_choices
+  has_many :projets, through: :prestation_choices
 
   scope :active, -> { where(active: true) }
 
   validates_uniqueness_of :libelle
+
+  def choice_for_projet(projet)
+    self.prestation_choices.all.find_by(projet_id: projet.id)
+  end
 end

--- a/app/models/prestation_choice.rb
+++ b/app/models/prestation_choice.rb
@@ -1,0 +1,4 @@
+class PrestationChoice < ActiveRecord::Base
+  belongs_to :projet
+  belongs_to :prestation
+end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -42,7 +42,10 @@ class Projet < ActiveRecord::Base
   has_many :aides, through: :projet_aides
   accepts_nested_attributes_for :projet_aides, reject_if: :all_blank, allow_destroy: true
 
-  has_and_belongs_to_many :prestations
+  has_many :prestation_choices, dependent: :destroy
+  has_many :prestations, through: :prestation_choices
+  accepts_nested_attributes_for :prestation_choices, reject_if: :all_blank, allow_destroy: true
+
   has_and_belongs_to_many :suggested_operateurs, class_name: 'Intervenant', join_table: 'suggested_operateurs'
   has_and_belongs_to_many :themes
 

--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -83,7 +83,7 @@ table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
       tr
         - prestation = prestation_choice.prestation
         th scope="row" #{prestation.libelle}
-        td.recap-projet-image-cell= image_tag "check.svg", alt: "Souhaitée",  id: "prestation_#{prestation.id}_wished"      if prestation_choice.wished
+        td.recap-projet-image-cell= image_tag "check.svg", alt: "Souhaitée",  id: "prestation_#{prestation.id}_desired"     if prestation_choice.desired
         td.recap-projet-image-cell= image_tag "check.svg", alt: "Préconisée", id: "prestation_#{prestation.id}_recommended" if prestation_choice.recommended
         td.recap-projet-image-cell= image_tag "check.svg", alt: "Retenue",    id: "prestation_#{prestation.id}_selected"    if prestation_choice.selected
 

--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -76,11 +76,23 @@ table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
   tbody
     tr
       th.empty scope="row"  &nbsp;
-      td Proposition
-    - @projet_courant.prestations.each do |prestation|
+      td Souhaitée
+      td Préconisée
+      td Retenue
+    - @projet_courant.prestation_choices.each do |prestation_choice|
       tr
+        - prestation = prestation_choice.prestation
         th scope="row" #{prestation.libelle}
-        td= image_tag "check.svg", alt: "Pris en compte"
+        td.recap-projet-image-cell= image_tag "check.svg", alt: "Souhaitée",  id: "prestation_#{prestation.id}_wished"      if prestation_choice.wished
+        td.recap-projet-image-cell= image_tag "check.svg", alt: "Préconisée", id: "prestation_#{prestation.id}_recommended" if prestation_choice.recommended
+        td.recap-projet-image-cell= image_tag "check.svg", alt: "Retenue",    id: "prestation_#{prestation.id}_selected"    if prestation_choice.selected
+
+h4 Détails travaux
+table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
+  tbody
+    tr
+      th.empty scope="row"  &nbsp;
+      td Proposition
     - if @projet_courant.consommation_apres_travaux.present?
       tr
         th scope="row"= t('helpers.label.proposition.consommation_apres_travaux')

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -72,23 +72,35 @@
               li
                 = f.label :remarques_diagnostic, t('helpers.label.diagnostic.remarques_diagnostic')
                 = f.text_area :remarques_diagnostic
+
           fieldset
             legend Types d’intervention
             = f.input :theme_ids, as: :check_boxes, collection: @themes, label: false
+
           fieldset
             legend Description des travaux proposés
             table.pp-table border="0" cellpadding="0" cellspacing="0" width="100%"
               tbody
                 tr
-                  th.empty scope="col"  &nbsp;
-                  th.top-tab scope="col"  Proposition
-                - @prestations.each do |prestation|
+                  th.empty scope="col"    &nbsp;
+                  th.top-tab scope="col"  Souhaitée
+                  th.top-tab scope="col"  Préconiséee
+                  th.top-tab scope="col"  Sélectionnée
+                - @prestations_with_choices.each do |prestation|
+                  - field_name = "projet[prestation_choices_attributes][#{prestation.id}]" # prestation.id is the Hash key value
                   tr
                     th scope="row"
-                      label for="prestation_#{prestation.id}"
-                        = prestation.libelle.capitalize
-                    td.plan_travaux(data-prestation-id=prestation.id)
-                      = prestation_checkbox(@projet_courant, prestation)
+                      label= prestation.libelle.capitalize
+                      = hidden_field_tag "#{field_name}[id]", prestation.prestation_choice_id
+                      = hidden_field_tag "#{field_name}[prestation_id]", prestation.id
+                    td= check_box_tag "#{field_name}[desired]",     true, prestation.desired,      id: "prestation_#{prestation.id}_desired"
+                    td= check_box_tag "#{field_name}[recommended]", true, prestation.recommended,  id: "prestation_#{prestation.id}_recommended"
+                    td= check_box_tag "#{field_name}[selected]",    true, prestation.selected,     id: "prestation_#{prestation.id}_selected"
+
+          fieldset
+            legend Description des travaux proposés
+            table.pp-table border="0" cellpadding="0" cellspacing="0" width="100%"
+              tbody
                 tr
                   th.tab-title colspan="3" scope="row" Efficacité énergétique
                 tr

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -98,7 +98,7 @@
                     td= check_box_tag "#{field_name}[selected]",    true, prestation.selected,     id: "prestation_#{prestation.id}_selected"
 
           fieldset
-            legend Description des travaux proposés
+            legend Détails des travaux proposés
             table.pp-table border="0" cellpadding="0" cellspacing="0" width="100%"
               tbody
                 tr

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -85,7 +85,7 @@
                   th.empty scope="col"    &nbsp;
                   th.top-tab scope="col"  Souhaitée
                   th.top-tab scope="col"  Préconiséee
-                  th.top-tab scope="col"  Sélectionnée
+                  th.top-tab scope="col"  Retenue
                 - @prestations_with_choices.each do |prestation|
                   - field_name = "projet[prestation_choices_attributes][#{prestation.id}]" # prestation.id is the Hash key value
                   tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,6 @@ Rails.application.routes.draw do
     resource :mise_en_relation,  only: [:show, :update]
     get       :calcul_revenu_fiscal_reference
     get       :preeligibilite
-    get       :proposition
-    put       :proposition
   end
 
   devise_for :agents, controllers: { cas_sessions: 'my_cas' }
@@ -34,6 +32,8 @@ Rails.application.routes.draw do
       get  :recommander_operateurs
       post :recommander_operateurs
       get  :proposer
+      get  :proposition
+      put  :proposition
     end
     resources :dossiers, only: [:show, :edit, :update, :index], param: :dossier_id
 

--- a/db/migrate/20170427135722_remove_unused_columns_from_prestations.rb
+++ b/db/migrate/20170427135722_remove_unused_columns_from_prestations.rb
@@ -1,0 +1,10 @@
+class RemoveUnusedColumnsFromPrestations < ActiveRecord::Migration
+  def change
+    remove_column :prestations, :entreprise
+    remove_column :prestations, :recevable
+    remove_column :prestations, :scenario
+    remove_column :prestations, :souhaite
+    remove_column :prestations, :preconise
+    remove_column :prestations, :retenu
+  end
+end

--- a/db/migrate/20170428095412_add_adjectives_to_prestations_projets.rb
+++ b/db/migrate/20170428095412_add_adjectives_to_prestations_projets.rb
@@ -1,0 +1,7 @@
+class AddAdjectivesToPrestationsProjets < ActiveRecord::Migration
+  def change
+    add_column :prestations_projets, :desired,     :boolean, null: false, default: false
+    add_column :prestations_projets, :recommended, :boolean, null: false, default: false
+    add_column :prestations_projets, :selected,    :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20170502100619_rename_table_prestations_projets_to_prestation_choices.rb
+++ b/db/migrate/20170502100619_rename_table_prestations_projets_to_prestation_choices.rb
@@ -1,0 +1,5 @@
+class RenameTablePrestationsProjetsToPrestationChoices < ActiveRecord::Migration
+  def change
+    rename_table  :prestations_projets, :prestation_choices
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170427130348) do
+ActiveRecord::Schema.define(version: 20170427135722) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -215,15 +215,9 @@ ActiveRecord::Schema.define(version: 20170427130348) do
 
   create_table "prestations", force: :cascade do |t|
     t.string   "libelle"
-    t.string   "entreprise"
-    t.boolean  "recevable"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.string   "scenario"
-    t.boolean  "souhaite",   default: false, null: false
-    t.boolean  "preconise",  default: false, null: false
-    t.boolean  "retenu",     default: false, null: false
-    t.boolean  "active",     default: true,  null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+    t.boolean  "active",     default: true, null: false
   end
 
   create_table "prestations_projets", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,12 +71,6 @@ ActiveRecord::Schema.define(version: 20170502100619) do
 
   add_index "avis_impositions", ["projet_id"], name: "index_avis_impositions_on_projet_id", using: :btree
 
-  create_table "cad_references", force: :cascade do |t|
-    t.integer "opal_id"
-    t.string  "code"
-    t.text    "libelle"
-  end
-
   create_table "commentaires", force: :cascade do |t|
     t.integer  "projet_id"
     t.integer  "auteur_id"
@@ -135,13 +129,6 @@ ActiveRecord::Schema.define(version: 20170502100619) do
 
   add_index "documents", ["projet_id"], name: "index_documents_on_projet_id", using: :btree
 
-  create_table "engagements", force: :cascade do |t|
-    t.string   "nom"
-    t.boolean  "valeur"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "evenements", force: :cascade do |t|
     t.integer  "projet_id"
     t.string   "label"
@@ -181,12 +168,6 @@ ActiveRecord::Schema.define(version: 20170502100619) do
   add_index "invitations", ["intermediaire_id"], name: "index_invitations_on_intermediaire_id", using: :btree
   add_index "invitations", ["intervenant_id"], name: "index_invitations_on_intervenant_id", using: :btree
   add_index "invitations", ["projet_id"], name: "index_invitations_on_projet_id", using: :btree
-
-  create_table "ntr_references", force: :cascade do |t|
-    t.integer "opal_id"
-    t.string  "code"
-    t.text    "libelle"
-  end
 
   create_table "occupants", force: :cascade do |t|
     t.integer  "projet_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170427135722) do
+ActiveRecord::Schema.define(version: 20170502100619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -213,20 +213,23 @@ ActiveRecord::Schema.define(version: 20170427135722) do
     t.string "civilite"
   end
 
+  create_table "prestation_choices", force: :cascade do |t|
+    t.integer "projet_id"
+    t.integer "prestation_id"
+    t.boolean "desired",       default: false, null: false
+    t.boolean "recommended",   default: false, null: false
+    t.boolean "selected",      default: false, null: false
+  end
+
+  add_index "prestation_choices", ["prestation_id"], name: "index_prestation_choices_on_prestation_id", using: :btree
+  add_index "prestation_choices", ["projet_id"], name: "index_prestation_choices_on_projet_id", using: :btree
+
   create_table "prestations", force: :cascade do |t|
     t.string   "libelle"
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
     t.boolean  "active",     default: true, null: false
   end
-
-  create_table "prestations_projets", force: :cascade do |t|
-    t.integer "projet_id"
-    t.integer "prestation_id"
-  end
-
-  add_index "prestations_projets", ["prestation_id"], name: "index_prestations_projets_on_prestation_id", using: :btree
-  add_index "prestations_projets", ["projet_id"], name: "index_prestations_projets_on_projet_id", using: :btree
 
   create_table "projet_aides", force: :cascade do |t|
     t.integer "projet_id"
@@ -330,8 +333,8 @@ ActiveRecord::Schema.define(version: 20170427135722) do
   add_foreign_key "invitations", "intervenants"
   add_foreign_key "invitations", "projets"
   add_foreign_key "occupants", "projets"
-  add_foreign_key "prestations_projets", "prestations"
-  add_foreign_key "prestations_projets", "projets"
+  add_foreign_key "prestation_choices", "prestations"
+  add_foreign_key "prestation_choices", "projets"
   add_foreign_key "projet_aides", "aides"
   add_foreign_key "projet_aides", "projets"
   add_foreign_key "projets", "adresses", column: "adresse_a_renover_id"

--- a/lib/tasks/deployment/20170504092142_migrate_prestation_choices.rake
+++ b/lib/tasks/deployment/20170504092142_migrate_prestation_choices.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_prestation_choices'
+  task migrate_prestation_choices: :environment do
+    puts "Running deploy task 'migrate_prestation_choices'" unless Rake.application.options.quiet
+
+    PrestationChoice.all.each do |prestation_choice|
+      if prestation_choice.projet_id.present? && prestation_choice.prestation_id.present?
+        prestation_choice.update(selected: true) unless prestation_choice.desired || prestation_choice.recommended || prestation_choice.selected
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20170504092142'
+  end
+end

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -27,7 +27,7 @@ describe DossiersController do
         let(:projet_params) do
           {
             prestation_choices_attributes: {
-              '1' => { id: '', prestation_id: prestation_1.id, wished: true },
+              '1' => { id: '', prestation_id: prestation_1.id, desired: true },
               '2' => { id: '', prestation_id: prestation_2.id, recommended: true, selected: true },
               '3' => { id: '', prestation_id: prestation_3.id },
             }
@@ -42,11 +42,11 @@ describe DossiersController do
           prestation_choice_2 = projet.prestation_choices.where(prestation_id: prestation_2.id).first
           prestation_choice_3 = projet.prestation_choices.where(prestation_id: prestation_3.id).first
 
-          expect(prestation_choice_1.wished).to       eq true
+          expect(prestation_choice_1.desired).to      eq true
           expect(prestation_choice_1.recommended).to  eq false
           expect(prestation_choice_1.selected).to     eq false
 
-          expect(prestation_choice_2.wished).to       eq false
+          expect(prestation_choice_2.desired).to      eq false
           expect(prestation_choice_2.recommended).to  eq true
           expect(prestation_choice_2.selected).to     eq true
 
@@ -55,12 +55,12 @@ describe DossiersController do
       end
 
       context "si une prestation était sélectionnée" do
-        let(:prestation_choice_1) { create :prestation_choice, :wished, projet: projet, prestation: prestation_1 }
+        let(:prestation_choice_1) { create :prestation_choice, :desired, projet: projet, prestation: prestation_1 }
         let(:prestation_choice_2) { create :prestation_choice, :recommended, :selected, projet: projet, prestation: prestation_2 }
         let(:projet_params) do
           {
             prestation_choices_attributes: {
-              '1' => { id: prestation_choice_1.id, prestation_id: prestation_1.id, wished: false },
+              '1' => { id: prestation_choice_1.id, prestation_id: prestation_1.id, desired: false },
               '2' => { id: prestation_choice_2.id, prestation_id: prestation_2.id, recommended: true, selected: false },
             }
           }
@@ -76,7 +76,7 @@ describe DossiersController do
 
           expect(prestation_choice_1).to eq nil
 
-          expect(prestation_choice_2.wished).to       eq false
+          expect(prestation_choice_2.desired).to      eq false
           expect(prestation_choice_2.recommended).to  eq true
           expect(prestation_choice_2.selected).to     eq false
 

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -60,8 +60,9 @@ describe DossiersController do
         let(:projet_params) do
           {
             prestation_choices_attributes: {
-              '1' => { id: prestation_choice_1.id, prestation_id: prestation_1.id, desired: false },
-              '2' => { id: prestation_choice_2.id, prestation_id: prestation_2.id, recommended: true, selected: false },
+              '1' => { id: prestation_choice_1.id, prestation_id: prestation_1.id },
+              '2' => { id: prestation_choice_2.id, prestation_id: prestation_2.id, recommended: true },
+              '3' => { id: '',                     prestation_id: prestation_3.id },
             }
           }
         end

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -23,7 +23,7 @@ describe DossiersController do
 
       before(:each) { authenticate_as_agent projet.agent_operateur }
 
-      context "si aucune prestation n'était sélectionnée" do
+      context "si aucune prestation n'était retenue" do
         let(:projet_params) do
           {
             prestation_choices_attributes: {
@@ -54,7 +54,7 @@ describe DossiersController do
         end
       end
 
-      context "si une prestation était sélectionnée" do
+      context "si une prestation était retenue" do
         let(:prestation_choice_1) { create :prestation_choice, :desired, projet: projet, prestation: prestation_1 }
         let(:prestation_choice_2) { create :prestation_choice, :recommended, :selected, projet: projet, prestation: prestation_2 }
         let(:projet_params) do

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -15,10 +15,80 @@ describe DossiersController do
   end
 
   context "en tant qu'opérateur connecté" do
-    let(:projet)  { create :projet, :proposition_enregistree }
-    before(:each) { authenticate_as_agent projet.agent_operateur }
+    describe "#proposition" do
+      let!(:prestation_1) { create :prestation, libelle: 'Remplacement d’une baignoire par une douche' }
+      let!(:prestation_2) { create :prestation, libelle: 'Lavabo adapté' }
+      let!(:prestation_3) { create :prestation, libelle: 'Géothermie' }
+      let(:projet)        { create :projet, :en_cours, :with_assigned_operateur }
+
+      before(:each) { authenticate_as_agent projet.agent_operateur }
+
+      context "si aucune prestation n'était sélectionnée" do
+        let(:projet_params) do
+          {
+            prestation_choices_attributes: {
+              '1' => { id: '', prestation_id: prestation_1.id, wished: true },
+              '2' => { id: '', prestation_id: prestation_2.id, recommended: true, selected: true },
+              '3' => { id: '', prestation_id: prestation_3.id },
+            }
+          }
+        end
+
+        it "je définis des prestations souhaitées/préconisées/retenues" do
+          put :proposition, dossier_id: projet.id, projet: projet_params
+          projet.reload
+
+          prestation_choice_1 = projet.prestation_choices.where(prestation_id: prestation_1.id).first
+          prestation_choice_2 = projet.prestation_choices.where(prestation_id: prestation_2.id).first
+          prestation_choice_3 = projet.prestation_choices.where(prestation_id: prestation_3.id).first
+
+          expect(prestation_choice_1.wished).to       eq true
+          expect(prestation_choice_1.recommended).to  eq false
+          expect(prestation_choice_1.selected).to     eq false
+
+          expect(prestation_choice_2.wished).to       eq false
+          expect(prestation_choice_2.recommended).to  eq true
+          expect(prestation_choice_2.selected).to     eq true
+
+          expect(prestation_choice_3).to eq nil
+        end
+      end
+
+      context "si une prestation était sélectionnée" do
+        let(:prestation_choice_1) { create :prestation_choice, :wished, projet: projet, prestation: prestation_1 }
+        let(:prestation_choice_2) { create :prestation_choice, :recommended, :selected, projet: projet, prestation: prestation_2 }
+        let(:projet_params) do
+          {
+            prestation_choices_attributes: {
+              '1' => { id: prestation_choice_1.id, prestation_id: prestation_1.id, wished: false },
+              '2' => { id: prestation_choice_2.id, prestation_id: prestation_2.id, recommended: true, selected: false },
+            }
+          }
+        end
+
+        it "je peux modifier ses attributs (souhaitée/préconisée/retenue) et/ou la supprimer" do
+          put :proposition, dossier_id: projet.id, projet: projet_params
+          projet.reload
+
+          prestation_choice_1 = projet.prestation_choices.where(prestation_id: prestation_1.id).first
+          prestation_choice_2 = projet.prestation_choices.where(prestation_id: prestation_2.id).first
+          prestation_choice_3 = projet.prestation_choices.where(prestation_id: prestation_3.id).first
+
+          expect(prestation_choice_1).to eq nil
+
+          expect(prestation_choice_2.wished).to       eq false
+          expect(prestation_choice_2.recommended).to  eq true
+          expect(prestation_choice_2.selected).to     eq false
+
+          expect(prestation_choice_3).to eq nil
+        end
+      end
+    end
 
     describe "#proposer" do
+      let(:projet)  { create :projet, :proposition_enregistree }
+      before(:each) { authenticate_as_agent projet.agent_operateur }
+
       context "si un attribut requis n'est pas renseigné" do
         before { projet.update_attribute(:date_de_visite, nil) }
 

--- a/spec/factories/prestation_choices.rb
+++ b/spec/factories/prestation_choices.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :prestation_choice do
+    association :projet
+    association :prestation
+
+    trait(:desired)     { desired      true }
+    trait(:recommended) { recommended true }
+    trait(:selected)    { selected    true }
+  end
+end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -98,13 +98,10 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_prestations do
-      transient do
-        prestations_count 1
-      end
-
-      after(:build) do |projet, evaluator|
-        projet.prestations = Prestation.first(evaluator.prestations_count)
+    trait :with_selected_prestation do
+      after(:build) do |projet|
+        prestation = create(:prestation)
+        projet.prestation_choices << create(:prestation_choice, :selected, projet: projet, prestation: prestation)
       end
     end
 
@@ -144,7 +141,7 @@ FactoryGirl.define do
       with_demandeur
       with_demande
       with_assigned_operateur
-      with_prestations
+      with_selected_prestation
     end
 
     trait :proposition_proposee do
@@ -152,14 +149,14 @@ FactoryGirl.define do
       with_demandeur
       with_demande
       with_assigned_operateur
-      with_prestations
+      with_selected_prestation
     end
 
     trait :transmis_pour_instruction do
       with_demandeur
       with_demande
       with_assigned_operateur
-      with_prestations
+      with_selected_prestation
       with_invited_instructeur
 
       after(:build) do |projet|
@@ -173,7 +170,7 @@ FactoryGirl.define do
       with_demandeur
       with_demande
       with_assigned_operateur
-      with_prestations
+      with_selected_prestation
       with_committed_instructeur
       with_invited_pris
 

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -96,9 +96,18 @@ feature "Remplir la proposition de travaux" do
       expect(page).to have_content(I18n.t('helpers.label.diagnostic.remarques_diagnostic') + ' : Le diagnostic est complet.')
 
       # Section "Description des travaux proposés"
-      expect(page).to have_content('Remplacement d’une baignoire par une douche')
-      expect(page).to have_content('Lavabo adapté')
-      expect(page).not_to have_content('Géothermie')
+      expect(page).to     have_content prestation_1.libelle
+      expect(page).to     have_selector "#prestation_#{prestation_1.id}_wished"
+      expect(page).not_to have_selector "#prestation_#{prestation_1.id}_recommended"
+      expect(page).not_to have_selector "#prestation_#{prestation_1.id}_selected"
+      expect(page).to     have_content prestation_2.libelle
+      expect(page).not_to have_selector "#prestation_#{prestation_2.id}_wished"
+      expect(page).not_to have_selector "#prestation_#{prestation_2.id}_recommended"
+      expect(page).to     have_selector "#prestation_#{prestation_2.id}_selected"
+      expect(page).not_to have_content prestation_3.libelle
+      expect(page).not_to have_selector "#prestation_#{prestation_3.id}_wished"
+      expect(page).not_to have_selector "#prestation_#{prestation_3.id}_recommended"
+      expect(page).not_to have_selector "#prestation_#{prestation_3.id}_selected"
       expect(page).to have_content(I18n.t('helpers.label.proposition.gain_energetique'))
       expect(page).to have_css('.gain_energetique', text: 31)
       expect(page).to have_content(I18n.t('helpers.label.proposition.etiquette_apres_travaux'))
@@ -197,12 +206,15 @@ feature "Remplir la proposition de travaux" do
 
         fill_in 'projet_surface_habitable', with: '42'
         uncheck "prestation_#{prestation.id}_selected"
+        check   "prestation_#{prestation.id}_wished"
         fill_in aide.libelle, with: ''
 
         click_on 'Enregistrer cette proposition'
         expect(page.current_path).to eq(dossier_path(projet))
         expect(page).to have_content('42')
-        expect(page).not_to have_content(prestation.libelle)
+        expect(page).to have_content(prestation.libelle)
+        expect(page).to     have_selector "#prestation_#{prestation.id}_wished"
+        expect(page).not_to have_selector "#prestation_#{prestation.id}_selected"
         expect(page).not_to have_content(aide.libelle)
       end
 
@@ -214,9 +226,9 @@ feature "Remplir la proposition de travaux" do
 
         scenario "j'ai toujours accès à cette prestation" do
           visit dossier_proposition_path(projet)
-          expect(page).not_to have_content('Ancienne prestation non utilisée')
-          expect(page).to have_content('Ancienne prestation utilisée')
-          expect(find_field('Ancienne prestation utilisée')).to be_checked
+          expect(page).not_to have_content old_unused_prestation.libelle
+          expect(page).to     have_content old_used_prestation.libelle
+          expect(find_field("prestation_#{old_used_prestation.id}_selected")).to be_checked
         end
       end
 

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -213,7 +213,6 @@ feature "Remplir la proposition de travaux" do
         before { projet.prestation_choices << create(:prestation_choice, :selected, projet: projet, prestation: old_used_prestation) }
 
         scenario "j'ai toujours accès à cette prestation" do
-          skip "TODO projet_concern.rb:20"
           visit dossier_proposition_path(projet)
           expect(page).not_to have_content('Ancienne prestation non utilisée')
           expect(page).to have_content('Ancienne prestation utilisée')

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -187,8 +187,6 @@ feature "Remplir la proposition de travaux" do
       let(:projet)     { create :projet, :proposition_enregistree }
       let(:prestation) { projet.prestations.first }
 
-      before { prestation.choice_for_projet(projet).update(selected: true) }
-
       scenario "je peux modifier la proposition" do
         visit dossier_path(projet)
         within 'article.projet-ope' do
@@ -210,9 +208,9 @@ feature "Remplir la proposition de travaux" do
 
       context "avec une prestation dépréciée" do
         let!(:old_unused_prestation)  { create :prestation, libelle: 'Ancienne prestation non utilisée', active: false }
-        let!(:old_used_prestation)    { create :prestation, libelle: 'Ancienne prestation utilisée', active: false }
+        let!(:old_used_prestation)    { create :prestation, libelle: 'Ancienne prestation utilisée',     active: false }
 
-        before { projet.prestations << old_used_prestation }
+        before { projet.prestation_choices << create(:prestation_choice, :selected, projet: projet, prestation: old_used_prestation) }
 
         scenario "j'ai toujours accès à cette prestation" do
           skip "TODO projet_concern.rb:20"
@@ -225,7 +223,7 @@ feature "Remplir la proposition de travaux" do
 
       context "avec une aide dépréciée" do
         let!(:old_unused_aide)  { create :aide, libelle: 'Ancienne aide non utilisée', active: false }
-        let!(:old_used_aide)    { create :aide, libelle: 'Ancienne aide utilisée', active: false }
+        let!(:old_used_aide)    { create :aide, libelle: 'Ancienne aide utilisée',     active: false }
 
         before do
           projet.aides << old_used_aide

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -97,15 +97,15 @@ feature "Remplir la proposition de travaux" do
 
       # Section "Description des travaux proposés"
       expect(page).to     have_content prestation_1.libelle
-      expect(page).to     have_selector "#prestation_#{prestation_1.id}_wished"
+      expect(page).to     have_selector "#prestation_#{prestation_1.id}_desired"
       expect(page).not_to have_selector "#prestation_#{prestation_1.id}_recommended"
       expect(page).not_to have_selector "#prestation_#{prestation_1.id}_selected"
       expect(page).to     have_content prestation_2.libelle
-      expect(page).not_to have_selector "#prestation_#{prestation_2.id}_wished"
+      expect(page).not_to have_selector "#prestation_#{prestation_2.id}_desired"
       expect(page).not_to have_selector "#prestation_#{prestation_2.id}_recommended"
       expect(page).to     have_selector "#prestation_#{prestation_2.id}_selected"
       expect(page).not_to have_content prestation_3.libelle
-      expect(page).not_to have_selector "#prestation_#{prestation_3.id}_wished"
+      expect(page).not_to have_selector "#prestation_#{prestation_3.id}_desired"
       expect(page).not_to have_selector "#prestation_#{prestation_3.id}_recommended"
       expect(page).not_to have_selector "#prestation_#{prestation_3.id}_selected"
       expect(page).to have_content(I18n.t('helpers.label.proposition.gain_energetique'))
@@ -206,14 +206,14 @@ feature "Remplir la proposition de travaux" do
 
         fill_in 'projet_surface_habitable', with: '42'
         uncheck "prestation_#{prestation.id}_selected"
-        check   "prestation_#{prestation.id}_wished"
+        check   "prestation_#{prestation.id}_desired"
         fill_in aide.libelle, with: ''
 
         click_on 'Enregistrer cette proposition'
         expect(page.current_path).to eq(dossier_path(projet))
         expect(page).to have_content('42')
         expect(page).to have_content(prestation.libelle)
-        expect(page).to     have_selector "#prestation_#{prestation.id}_wished"
+        expect(page).to     have_selector "#prestation_#{prestation.id}_desired"
         expect(page).not_to have_selector "#prestation_#{prestation.id}_selected"
         expect(page).not_to have_content(aide.libelle)
       end

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -51,8 +51,8 @@ feature "Remplir la proposition de travaux" do
       fill_in 'projet_remarques_diagnostic', with: 'Le diagnostic est complet.'
 
       # Section "Description des travaux proposés"
-      check 'Remplacement d’une baignoire par une douche'
-      check 'Lavabo adapté'
+      check "prestation_#{prestation_1.id}_desired"
+      check "prestation_#{prestation_2.id}_selected"
       fill_in I18n.t('helpers.label.proposition.gain_energetique'), with: '31'
       fill_in I18n.t('helpers.label.proposition.etiquette_apres_travaux'), with: 'A'
       fill_in 'projet_consommation_apres_travaux', with: '222'
@@ -187,16 +187,18 @@ feature "Remplir la proposition de travaux" do
       let(:projet)     { create :projet, :proposition_enregistree }
       let(:prestation) { projet.prestations.first }
 
+      before { prestation.choice_for_projet(projet).update(selected: true) }
+
       scenario "je peux modifier la proposition" do
         visit dossier_path(projet)
         within 'article.projet-ope' do
           click_link I18n.t('projets.visualisation.lien_edition')
         end
         expect(page.current_path).to eq(dossier_proposition_path(projet))
-        expect(find_field(prestation.libelle)).to be_checked
+        expect(find_field("prestation_#{prestation.id}_selected")).to be_checked
 
         fill_in 'projet_surface_habitable', with: '42'
-        uncheck prestation.libelle
+        uncheck "prestation_#{prestation.id}_selected"
         fill_in aide.libelle, with: ''
 
         click_on 'Enregistrer cette proposition'
@@ -213,6 +215,7 @@ feature "Remplir la proposition de travaux" do
         before { projet.prestations << old_used_prestation }
 
         scenario "j'ai toujours accès à cette prestation" do
+          skip "TODO projet_concern.rb:20"
           visit dossier_proposition_path(projet)
           expect(page).not_to have_content('Ancienne prestation non utilisée')
           expect(page).to have_content('Ancienne prestation utilisée')

--- a/spec/lib/tasks/deployment/migrate_prestation_choices_spec.rb
+++ b/spec/lib/tasks/deployment/migrate_prestation_choices_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+require 'support/after_party_helper'
+
+describe '20170504092142_migrate_prestation_choices' do
+  include_context 'after_party'
+
+  let!(:projet)     { create :projet }
+  let!(:prestation) { create :prestation }
+
+  it "charge l'environment Rails" do
+    subject.invoke
+
+    expect(subject.prerequisites).to include 'environment'
+  end
+
+  context "quand la table de jointure est vide" do
+    let!(:prestation_choice) { create :prestation_choice, projet: projet, prestation: prestation }
+
+    it "définie une prestation comme sélectionnée" do
+      subject.invoke
+
+      prestation_choice.reload
+      expect(prestation_choice.desired).to     be false
+      expect(prestation_choice.recommended).to be false
+      expect(prestation_choice.selected).to    be true
+    end
+  end
+
+  context "quand la table de jointure est déjà remplie" do
+    let!(:prestation_choice) { create :prestation_choice, :desired, projet: projet, prestation: prestation }
+
+    it "définie une prestation comme sélectionnée" do
+      subject.invoke
+
+      prestation_choice.reload
+      expect(prestation_choice.desired).to     be true
+      expect(prestation_choice.recommended).to be false
+      expect(prestation_choice.selected).to    be false
+    end
+  end
+
+  context "quand la table de jointure est erronée" do
+    let!(:prestation_choice_without_prestation) { create :prestation_choice, projet: projet, prestation: nil }
+    let!(:prestation_choice_without_projet)     { create :prestation_choice, projet: nil,    prestation: prestation }
+
+    it "ne modifie pas la table de jointure si elle est erronée" do
+      subject.invoke
+
+      prestation_choice_without_prestation.reload
+      expect(prestation_choice_without_prestation.desired).to     be false
+      expect(prestation_choice_without_prestation.recommended).to be false
+      expect(prestation_choice_without_prestation.selected).to    be false
+
+      prestation_choice_without_projet.reload
+      expect(prestation_choice_without_projet.desired).to     be false
+      expect(prestation_choice_without_projet.recommended).to be false
+      expect(prestation_choice_without_projet.selected).to    be false
+    end
+  end
+end

--- a/spec/lib/tasks/deployment/migrate_prestation_choices_spec.rb
+++ b/spec/lib/tasks/deployment/migrate_prestation_choices_spec.rb
@@ -16,7 +16,7 @@ describe '20170504092142_migrate_prestation_choices' do
   context "quand la table de jointure est vide" do
     let!(:prestation_choice) { create :prestation_choice, projet: projet, prestation: prestation }
 
-    it "définie une prestation comme sélectionnée" do
+    it "définie une prestation comme retenue" do
       subject.invoke
 
       prestation_choice.reload
@@ -29,7 +29,7 @@ describe '20170504092142_migrate_prestation_choices' do
   context "quand la table de jointure est déjà remplie" do
     let!(:prestation_choice) { create :prestation_choice, :desired, projet: projet, prestation: prestation }
 
-    it "définie une prestation comme sélectionnée" do
+    it "définie une prestation comme retenue" do
       subject.invoke
 
       prestation_choice.reload

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -24,9 +24,9 @@ describe ProjetMailer, type: :mailer do
   end
 
   describe "mise en relation intervenant" do
-    let!(:prestation)      { create :prestation }
     let(:projet)           { create :projet, :proposition_proposee }
     let(:mise_en_relation) { create :mise_en_relation, projet: projet }
+    let(:prestation)       { projet.prestations.first }
     let(:email)            { ProjetMailer.mise_en_relation_intervenant(mise_en_relation) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([mise_en_relation.intervenant_email]) }

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -24,7 +24,8 @@ describe Projet do
     it { is_expected.to have_many :evenements }
     it { is_expected.to belong_to :operateur }
     it { is_expected.to belong_to :adresse_postale }
-    it { is_expected.to have_and_belong_to_many :prestations }
+    it { is_expected.to have_many(:prestations).through(:prestation_choices)}
+    it { is_expected.to have_many(:aides).through(:projet_aides)}
     it { is_expected.to have_and_belong_to_many :themes }
     it { is_expected.to belong_to :agent_operateur }
     it { is_expected.to belong_to :agent_instructeur }


### PR DESCRIPTION
Permet de définir si une prestation est souhaitée/préconisée/retenue

Tâche after_party : rake after_party:migrate_prestation_choices

![choices](https://cloud.githubusercontent.com/assets/24429245/25703424/d2e3cd00-30d5-11e7-996c-ce204ba22c48.gif)
