### PR TITLE
PF365 améliore la gestion de la consommation énergétique

### DIFF
--- a/app/models/occupant.rb
+++ b/app/models/occupant.rb
@@ -8,7 +8,7 @@ class Occupant < ActiveRecord::Base
 
   validates :nom, :prenom, presence: true
   validates :date_de_naissance, birthday: true, presence: true
-  validates :civilite, presence: true, on: :update, if: :require_civilite?
+  validates :civilite, presence: { message: :blank_feminine }, on: :update, if: :require_civilite?
 
   strip_fields :nom, :prenom
 

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -54,6 +54,7 @@ class Projet < ActiveRecord::Base
   validates :adresse_postale, presence: true, on: :update
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true
   validates :date_de_visite, :assiette_subventionnable_amount, :travaux_ht_amount, :travaux_ttc_amount, presence: true, on: :proposition
+  validates :consommation_avant_travaux, :consommation_apres_travaux, numericality: { greater_than_or_equal_to: 0, message: :greater_than_or_equal_to_feminine }, allow_nil: true
   validate  :validate_frozen_attributes
   validate  :validate_theme_count, on: :proposition
 

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -53,7 +53,8 @@ class Projet < ActiveRecord::Base
   validates :tel, phone: { :minimum => 10, :maximum => 12 }, allow_blank: true
   validates :adresse_postale, presence: true, on: :update
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true
-  validates :date_de_visite, :assiette_subventionnable_amount, :travaux_ht_amount, :travaux_ttc_amount, presence: true, on: :proposition
+  validates :date_de_visite, :assiette_subventionnable_amount, presence: { message: :blank_feminine }, on: :proposition
+  validates :travaux_ht_amount, :travaux_ttc_amount, presence: true, on: :proposition
   validates :consommation_avant_travaux, :consommation_apres_travaux, numericality: { greater_than_or_equal_to: 0, message: :greater_than_or_equal_to_feminine }, allow_nil: true
   validate  :validate_frozen_attributes
   validate  :validate_theme_count, on: :proposition

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -406,6 +406,8 @@ fr:
         note_degradation: "La note de dégradation"
         note_insalubrite: "La note d’insalubrité"
         date_de_visite: "La date de visite du logement"
+        consommation_avant_travaux: "Consommation énergétique avant travaux"
+        consommation_apres_travaux: "Consommation énergétique après travaux"
       occupant:
         civilite: "La civilité"
         nom: "Nom"
@@ -413,21 +415,19 @@ fr:
         date_de_naissance: "Date de naissance"
     errors:
       messages:
-        greater_than_or_equal_to_feminine: "La %{attribute} doit être supérieure ou égale à %{count}"
-        greater_than_or_equal_to_masculine: "Le %{attribute} doit être supérieur ou égal à %{count}"
+        blank_feminine: "doit être renseignée"
+        blank_masculine: "doit être renseigné"
+        greater_than_or_equal_to_feminine: "doit être supérieure ou égale à %{count}"
+        greater_than_or_equal_to_masculine: "doit être supérieur ou égal à %{count}"
       models:
         projet:
           frozen: "Le projet est figé : %{attribute} ne peut pas être modifié"
           attributes:
-            date_de_visite:
-              blank: "doit être renseignée."
             note_degradation:
               inclusion: "doit être comprise entre zéro et un."
             note_insalubrite:
               inclusion: "doit être comprise entre zéro et un."
         occupant:
           attributes:
-            civilite:
-              blank: "doit être renseignée."
             date_de_naissance:
               not_in_past: "invalide : merci d’indiquer une date dans le passé."

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -412,6 +412,9 @@ fr:
         prenom: "Prénom"
         date_de_naissance: "Date de naissance"
     errors:
+      messages:
+        greater_than_or_equal_to_feminine: "La %{attribute} doit être supérieure ou égale à %{count}"
+        greater_than_or_equal_to_masculine: "Le %{attribute} doit être supérieur ou égal à %{count}"
       models:
         projet:
           frozen: "Le projet est figé : %{attribute} ne peut pas être modifié"

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -25,7 +25,7 @@ describe DossiersController do
         it "je ne peux pas proposer au demandeur" do
           get :proposer, dossier_id: projet.id
           expect(assigns(:projet_courant).statut.to_sym).to eq :proposition_enregistree
-          expect(assigns(:projet_courant).errors).to be_added :date_de_visite, :blank
+          expect(assigns(:projet_courant).errors).to be_added :date_de_visite, :blank_feminine
           expect(response).to render_template(:show)
         end
       end

--- a/spec/models/occupant_spec.rb
+++ b/spec/models/occupant_spec.rb
@@ -21,12 +21,12 @@ describe Occupant do
     context "pour un occupant existant" do
       context "qui n'est pas le demandeur" do
         subject { create(:occupant) }
-        it { is_expected.not_to validate_presence_of(:civilite) }
+        it { is_expected.not_to validate_presence_of(:civilite).with_message(:blank_feminine) }
       end
 
       context "qui est le demandeur" do
         subject { create(:projet, :with_demandeur).demandeur }
-        it { is_expected.to validate_presence_of(:civilite) }
+        it { is_expected.to validate_presence_of(:civilite).with_message(:blank_feminine) }
       end
     end
   end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -13,8 +13,8 @@ describe Projet do
     it { is_expected.not_to validate_presence_of(:email) }
     it { is_expected.not_to validate_presence_of(:tel) }
     it { is_expected.not_to validate_presence_of(:date_de_visite) }
-    it { is_expected.to validate_presence_of(:date_de_visite).on(:proposition) }
-    it { is_expected.to validate_presence_of(:assiette_subventionnable_amount).on(:proposition) }
+    it { is_expected.to validate_presence_of(:date_de_visite).with_message(:blank_feminine).on(:proposition) }
+    it { is_expected.to validate_presence_of(:assiette_subventionnable_amount).with_message(:blank_feminine).on(:proposition) }
     it { is_expected.to validate_presence_of(:travaux_ht_amount).on(:proposition) }
     it { is_expected.to validate_presence_of(:travaux_ttc_amount).on(:proposition) }
     it { is_expected.to validate_inclusion_of(:note_degradation).in_range(0..1) }


### PR DESCRIPTION
Suite à la validation :

- Le label des champs est changé de  "consommation avant travaux" à "consommation énergétique avant travaux" ;
- Ajout d'une validation pour empêcher de saisir des chiffres négatifs.

<img width="1201" alt="capture d ecran 2017-05-04 a 15 25 18" src="https://cloud.githubusercontent.com/assets/179923/25705576/0d128a40-30de-11e7-9184-693729aace25.png">

### Note technique

J'ai rajouté des clefs de localisation, pour pouvoir générer les messages d'erreurs en fonction du genre de manière générique. Par exemple "Le montant doit être rempli" et "L'année doit être remplie".

Ça a l'air assez efficace ; mais je sens que j'ai besoin d'un peu de recul avant de tout migrer à ce système :)