### PR TITLE
PF365 corrige l’enregistrement de consommation énergétiques décimales

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -58,7 +58,7 @@ class Projet < ActiveRecord::Base
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true
   validates :date_de_visite, :assiette_subventionnable_amount, presence: { message: :blank_feminine }, on: :proposition
   validates :travaux_ht_amount, :travaux_ttc_amount, presence: true, on: :proposition
-  validates :consommation_avant_travaux, :consommation_apres_travaux, numericality: { greater_than_or_equal_to: 0, message: :greater_than_or_equal_to_feminine }, allow_nil: true
+  validates :consommation_avant_travaux, :consommation_apres_travaux, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validate  :validate_frozen_attributes
   validate  :validate_theme_count, on: :proposition
 

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -417,8 +417,6 @@ fr:
       messages:
         blank_feminine: "doit être renseignée"
         blank_masculine: "doit être renseigné"
-        greater_than_or_equal_to_feminine: "doit être supérieure ou égale à %{count}"
-        greater_than_or_equal_to_masculine: "doit être supérieur ou égal à %{count}"
       models:
         projet:
           frozen: "Le projet est figé : %{attribute} ne peut pas être modifié"
@@ -427,6 +425,10 @@ fr:
               inclusion: "doit être comprise entre zéro et un."
             note_insalubrite:
               inclusion: "doit être comprise entre zéro et un."
+            consommation_avant_travaux:
+              greater_than_or_equal_to: "doit être supérieure ou égale à %{count}"
+            consommation_apres_travaux:
+              greater_than_or_equal_to: "doit être supérieure ou égale à %{count}"
         occupant:
           attributes:
             date_de_naissance:

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -19,6 +19,8 @@ describe Projet do
     it { is_expected.to validate_presence_of(:travaux_ttc_amount).on(:proposition) }
     it { is_expected.to validate_inclusion_of(:note_degradation).in_range(0..1) }
     it { is_expected.to validate_inclusion_of(:note_insalubrite).in_range(0..1) }
+    it { is_expected.to validate_numericality_of(:consommation_avant_travaux).is_greater_than_or_equal_to(0).allow_nil }
+    it { is_expected.to validate_numericality_of(:consommation_apres_travaux).is_greater_than_or_equal_to(0).allow_nil }
     it { is_expected.to have_one :demande }
     it { is_expected.to have_many :intervenants }
     it { is_expected.to have_many :evenements }


### PR DESCRIPTION
Cette PR corrige une exception lorsque on essaie d'entrer une consommation énergétique de `0,5`.

@qcattez je peux te laisser relire et merger ?