### PR TITLE
PF483 N'assigne pas de date de naissance par défaut aux occupants

### DIFF
--- a/app/controllers/occupants_controller.rb
+++ b/app/controllers/occupants_controller.rb
@@ -10,7 +10,7 @@ class OccupantsController < ApplicationController
 
     if request.post?
       if occupant_params?
-        if @occupant.save
+        if @occupant.save(context: :user_action)
           # Clear form fields
           @occupant = @projet_courant.avis_impositions.first.occupants.build
         end

--- a/app/models/occupant.rb
+++ b/app/models/occupant.rb
@@ -7,7 +7,7 @@ class Occupant < ActiveRecord::Base
   delegate :projet, to: :avis_imposition
 
   validates :nom, :prenom, presence: true
-  validates :date_de_naissance, birthday: true, presence: true
+  validates :date_de_naissance, birthday: true, presence: true, on: :user_action
   validates :civilite, presence: { message: :blank_feminine }, on: :update, if: :require_civilite?
 
   strip_fields :nom, :prenom

--- a/app/services/projet_initializer.rb
+++ b/app/services/projet_initializer.rb
@@ -55,7 +55,7 @@ class ProjetInitializer
       avis_imposition.occupants.build(
         nom:    "#{declarant_count + index + 1}",
         prenom: "Occupant ",
-        date_de_naissance: "1970-01-01", # TODO: obligatoire :(
+        date_de_naissance: nil,
         declarant: false,
         demandeur: false
       )

--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -25,7 +25,11 @@
             td
               span.firstname= occupant.prenom
               span.lastname<= occupant.nom
-            td= occupant.date_de_naissance.year
+            td
+              - if occupant.date_de_naissance
+                = occupant.date_de_naissance.year
+              - else
+                | -
             td
               - if occupant.can_be_deleted?
                 = link_to projet_or_dossier_occupant_path(projet: @projet_courant, id: occupant.id),

--- a/spec/controllers/occupants_controller_spec.rb
+++ b/spec/controllers/occupants_controller_spec.rb
@@ -65,7 +65,7 @@ describe OccupantsController do
 
           it "affiche les erreurs de validation" do
             occupant = assigns(:occupant)
-            expect(occupant.errors).to be_present
+            expect(occupant.errors).to be_added :date_de_naissance, :blank
             expect(response.body).to include occupant.errors.full_messages.first
           end
         end

--- a/spec/models/occupant_spec.rb
+++ b/spec/models/occupant_spec.rb
@@ -11,22 +11,32 @@ describe Occupant do
     it { is_expected.to be_valid }
     it { is_expected.to validate_presence_of(:nom) }
     it { is_expected.to validate_presence_of(:prenom) }
-    it { is_expected.to validate_presence_of(:date_de_naissance) }
 
-    context "pour un nouvel occupant" do
-      subject { build(:occupant) }
-      it { is_expected.not_to validate_presence_of(:civilite) }
+    describe "date_de_naissance" do
+      context "pour une opération effectuée manuellement par un utilisateur" do
+        it { is_expected.to validate_presence_of(:date_de_naissance).on(:user_action) }
+      end
+      context "pour une opération effectuée automatiquement" do
+        it { is_expected.not_to validate_presence_of(:date_de_naissance) }
+      end
     end
 
-    context "pour un occupant existant" do
-      context "qui n'est pas le demandeur" do
-        subject { create(:occupant) }
-        it { is_expected.not_to validate_presence_of(:civilite).with_message(:blank_feminine) }
+    describe "civilite" do
+      context "pour un nouvel occupant" do
+        subject { build(:occupant) }
+        it { is_expected.not_to validate_presence_of(:civilite) }
       end
 
-      context "qui est le demandeur" do
-        subject { create(:projet, :with_demandeur).demandeur }
-        it { is_expected.to validate_presence_of(:civilite).with_message(:blank_feminine) }
+      context "pour un occupant existant" do
+        context "qui n'est pas le demandeur" do
+          subject { create(:occupant) }
+          it { is_expected.not_to validate_presence_of(:civilite).with_message(:blank_feminine) }
+        end
+
+        context "qui est le demandeur" do
+          subject { create(:projet, :with_demandeur).demandeur }
+          it { is_expected.to validate_presence_of(:civilite).with_message(:blank_feminine) }
+        end
       end
     end
   end

--- a/spec/services/projet_initializer_spec.rb
+++ b/spec/services/projet_initializer_spec.rb
@@ -111,16 +111,19 @@ describe ProjetInitializer do
         occupants = avis_imposition.occupants
         expect(occupants[1].prenom).to eq "Occupant "
         expect(occupants[1].nom).to eq "2"
+        expect(occupants[1].date_de_naissance).to be_nil
         expect(occupants[1]).not_to be_declarant
         expect(occupants[1]).not_to be_demandeur
 
         expect(occupants[2].prenom).to eq "Occupant "
         expect(occupants[2].nom).to eq "3"
+        expect(occupants[2].date_de_naissance).to be_nil
         expect(occupants[2]).not_to be_declarant
         expect(occupants[2]).not_to be_demandeur
 
         expect(occupants[3].prenom).to eq "Occupant "
         expect(occupants[3].nom).to eq "4"
+        expect(occupants[3].date_de_naissance).to be_nil
         expect(occupants[3]).not_to be_declarant
         expect(occupants[3]).not_to be_demandeur
       end

--- a/spec/services/projet_initializer_spec.rb
+++ b/spec/services/projet_initializer_spec.rb
@@ -79,21 +79,50 @@ describe ProjetInitializer do
     let(:projet) { create :projet }
 
     context "lorsque les identifiants sont valides" do
-      it "crée un avis d’imposition avec les informations du contribuable" do
-        expect(projet.avis_impositions.length).to eq(0)
+      before { projet_initializer.initialize_avis_imposition(projet, '15', '1515') }
+      let(:avis_imposition) { projet.avis_impositions.first }
 
-        projet_initializer.initialize_avis_imposition(projet, '15', '1515')
+      it "crée un avis d’imposition" do
         expect(projet.avis_impositions.length).to eq(1)
+      end
 
-        avis_imposition = projet.avis_impositions.first
+      it "remplit l'avis d'imposition avec les informations générales" do
         expect(avis_imposition.numero_fiscal).to eq('15')
         expect(avis_imposition.reference_avis).to eq('1515')
+        expect(avis_imposition.annee).to eq 2015
         expect(avis_imposition.nombre_personnes_charge).to eq(3)
+      end
+
+      it "remplit l'avis d'imposition avec les informations des déclarants" do
+        expect(avis_imposition.declarant_1).to eq "Jean Martin"
+        expect(avis_imposition.declarant_2).to be nil
+
+        declarant = avis_imposition.occupants.first
+        expect(declarant.prenom).to eq "Jean"
+        expect(declarant.nom).to eq "Martin"
+        expect(declarant.date_de_naissance).to eq DateTime.new(1980, 04, 19)
+        expect(declarant).to be_declarant
+        expect(declarant).not_to be_demandeur
+      end
+
+      it "ajoute des occupants à partir du nombre de personnes à charge" do
         expect(avis_imposition.occupants.length).to eq(4)
 
-        occupant = avis_imposition.occupants.first
-        expect(occupant).to be_declarant
-        expect(occupant.nom).to eq('Martin')
+        occupants = avis_imposition.occupants
+        expect(occupants[1].prenom).to eq "Occupant "
+        expect(occupants[1].nom).to eq "2"
+        expect(occupants[1]).not_to be_declarant
+        expect(occupants[1]).not_to be_demandeur
+
+        expect(occupants[2].prenom).to eq "Occupant "
+        expect(occupants[2].nom).to eq "3"
+        expect(occupants[2]).not_to be_declarant
+        expect(occupants[2]).not_to be_demandeur
+
+        expect(occupants[3].prenom).to eq "Occupant "
+        expect(occupants[3].nom).to eq "4"
+        expect(occupants[3]).not_to be_declarant
+        expect(occupants[3]).not_to be_demandeur
       end
     end
 


### PR DESCRIPTION
Avant une date de naissance au "1er janvier 1970" était automatiquement assignée aux occupants créés automatiquement à partir d'un avis d'imposition.

Avec cette PR :

- Les occupants créés automatiquement n'ont pas de date de naissance par défaut assignée automatiquement ;
- Les occupants créés manuellement par un utilisateur demandent eux une date de naissance (vu que c'est une demande métier).

<img width="941" alt="capture d ecran 2017-05-09 a 11 56 39" src="https://cloud.githubusercontent.com/assets/179923/25845548/9b28e922-34ae-11e7-8743-5d53970c15f2.png">

