### PR TITLE
PF483 corrige l'affichage de la date de naissance des occupants 🚑

### DIFF
--- a/app/views/projets/_foyer.html.slim
+++ b/app/views/projets/_foyer.html.slim
@@ -39,5 +39,8 @@ article.block.occupants
             td
               span.firstname= occupant.prenom
               span.lastname<= occupant.nom
-            td= occupant.date_de_naissance.year
-
+            td
+              - if occupant.date_de_naissance
+                = occupant.date_de_naissance.year
+              - else
+                | -

--- a/spec/factories/occupants.rb
+++ b/spec/factories/occupants.rb
@@ -2,17 +2,18 @@ FactoryGirl.define do
   factory :occupant do
     sequence(:nom) {|n| "Martin#{n}" }
     prenom 'Jean'
-    date_de_naissance '20/06/1977'
     civilite 'mr'
     avis_imposition
   end
 
   factory :demandeur, parent: :occupant do
     demandeur true
+    date_de_naissance '20/06/1977'
   end
 
   factory :declarant, parent: :occupant do
     demandeur true
     declarant true
+    date_de_naissance '20/06/1977'
   end
 end


### PR DESCRIPTION
- Correction des factories pour ne pas avoir de date de naissance sur certains occupants (=> les tests pètent) ;
- Correction du template foireux pour corriger les tests :)