### PR TITLE
Déploie la branche `staging` sur Scalingo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,8 +15,9 @@ database:
 deployment:
   staging:
     branch: staging
-    heroku:
-      appname: aideanah-staging
+    commands:
+      - git fetch --unshallow
+      - git push -f git@scalingo.com:anah-staging.git $CIRCLE_SHA1:master
   demo:
     branch: master
     commands:


### PR DESCRIPTION
Finalement on sera quand même mieux avec tout sous le même prestataire de service (plutôt que de mixer Heroku et Scalingo).