### PR TITLE
Corrige l'affichage des dossiers des instructeurs

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -71,11 +71,15 @@ class Projet < ActiveRecord::Base
 
   before_save :clean_numero_fiscal, :clean_reference_avis
 
-  scope :for_agent, ->(agent) {
-    next where(nil) if agent.instructeur?
-    joins(:intervenants).where('intervenants.id = ?', agent.intervenant_id).group('projets.id')
-  }
   scope :ordered, -> { order("projets.id desc") }
+  scope :with_demandeur, -> { joins(:occupants).where('occupants.demandeur = true').distinct  }
+  scope :for_agent, ->(agent) {
+    if agent.instructeur?
+      with_demandeur
+    else
+      joins(:intervenants).where('intervenants.id = ?', agent.intervenant_id).group('projets.id')
+    end
+  }
 
   def self.find_by_locator(locator)
     is_numero_plateforme = locator.try(:include?, '_')

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -129,25 +129,29 @@ describe Projet do
   end
 
   describe '#for_agent' do
-    context "en tant qu'operateur" do
-      let(:instructeur) {       create :instructeur }
-      let(:operateur1) {        create :operateur }
-      let(:operateur2) {        create :operateur }
-      let(:operateur3) {        create :operateur }
-      let(:agent_instructeur) { create :agent, intervenant: instructeur }
-      let(:agent_operateur1) {  create :agent, intervenant: operateur1 }
-      let(:agent_operateur2) {  create :agent, intervenant: operateur2 }
-      let(:agent_operateur3) {  create :agent, intervenant: operateur3 }
-      let(:projet1) {           create :projet }
-      let(:projet2) {           create :projet }
-      let(:projet3) {           create :projet }
-      let!(:invitation1) {       create :invitation, intervenant: operateur1, projet: projet1 }
-      let!(:invitation2) {       create :invitation, intervenant: operateur1, projet: projet2 }
-      let!(:invitation3) {       create :invitation, intervenant: operateur2, projet: projet3 }
-      it { expect(Projet.for_agent(agent_operateur1).length).to eq(2) }
-      it { expect(Projet.for_agent(agent_operateur2).length).to eq(1) }
-      it { expect(Projet.for_agent(agent_operateur3).length).to eq(0) }
-      it { expect(Projet.for_agent(agent_instructeur).length).to eq(3) }
+    let(:instructeur) {       create :instructeur }
+    let(:operateur1) {        create :operateur }
+    let(:operateur2) {        create :operateur }
+    let(:operateur3) {        create :operateur }
+    let(:agent_instructeur) { create :agent, intervenant: instructeur }
+    let(:agent_operateur1) {  create :agent, intervenant: operateur1 }
+    let(:agent_operateur2) {  create :agent, intervenant: operateur2 }
+    let(:agent_operateur3) {  create :agent, intervenant: operateur3 }
+    let(:projet1) {           create :projet }
+    let(:projet2) {           create :projet }
+    let(:projet3) {           create :projet }
+    let!(:invitation1) {      create :invitation, intervenant: operateur1, projet: projet1 }
+    let!(:invitation2) {      create :invitation, intervenant: operateur1, projet: projet2 }
+    let!(:invitation3) {      create :invitation, intervenant: operateur2, projet: projet3 }
+
+    it "un opérateur voit les projets sur lesquels il est affecté" do
+      expect(Projet.for_agent(agent_operateur1).length).to eq(2)
+      expect(Projet.for_agent(agent_operateur2).length).to eq(1)
+      expect(Projet.for_agent(agent_operateur3).length).to eq(0)
+    end
+
+    it "un instructeur voit tous les projets" do
+      expect(Projet.for_agent(agent_instructeur).length).to eq(3)
     end
   end
 

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -128,6 +128,15 @@ describe Projet do
     end
   end
 
+  describe "#with_demandeur" do
+    let!(:projet1) { create :projet, :with_demandeur }
+    let!(:projet2) { create :projet, :with_demandeur }
+    let!(:projet3) { create :projet }
+
+    it { expect(Projet.with_demandeur).to include(projet1, projet2) }
+    it { expect(Projet.with_demandeur).not_to include(projet3) }
+  end
+
   describe '#for_agent' do
     let(:instructeur) {       create :instructeur }
     let(:operateur1) {        create :operateur }
@@ -137,21 +146,25 @@ describe Projet do
     let(:agent_operateur1) {  create :agent, intervenant: operateur1 }
     let(:agent_operateur2) {  create :agent, intervenant: operateur2 }
     let(:agent_operateur3) {  create :agent, intervenant: operateur3 }
-    let(:projet1) {           create :projet }
-    let(:projet2) {           create :projet }
-    let(:projet3) {           create :projet }
+    let(:projet1) {           create :projet, :with_demandeur }
+    let(:projet2) {           create :projet, :with_demandeur }
+    let(:projet3) {           create :projet, :with_demandeur }
+    let(:projet4) {           create :projet }
     let!(:invitation1) {      create :invitation, intervenant: operateur1, projet: projet1 }
     let!(:invitation2) {      create :invitation, intervenant: operateur1, projet: projet2 }
     let!(:invitation3) {      create :invitation, intervenant: operateur2, projet: projet3 }
 
-    it "un opérateur voit les projets sur lesquels il est affecté" do
-      expect(Projet.for_agent(agent_operateur1).length).to eq(2)
-      expect(Projet.for_agent(agent_operateur2).length).to eq(1)
-      expect(Projet.for_agent(agent_operateur3).length).to eq(0)
+    describe "un opérateur voit les projets sur lesquels il est affecté" do
+      it { expect(Projet.for_agent(agent_operateur1).length).to eq(2) }
+      it { expect(Projet.for_agent(agent_operateur2).length).to eq(1) }
+      it { expect(Projet.for_agent(agent_operateur3).length).to eq(0) }
     end
 
-    it "un instructeur voit tous les projets" do
-      expect(Projet.for_agent(agent_instructeur).length).to eq(3)
+    it "un instructeur voit tous les projets avec un demandeur" do
+      expect(Projet.for_agent(agent_instructeur)).to include(projet1)
+      expect(Projet.for_agent(agent_instructeur)).to include(projet2)
+      expect(Projet.for_agent(agent_instructeur)).to include(projet3)
+      expect(Projet.for_agent(agent_instructeur)).not_to include(projet4)
     end
   end
 


### PR DESCRIPTION
Aujourd'hui les instructeurs voient absolument tous les projets, sans limitation.

Cela inclut potentiellement les projets pour lesquels le demandeur n'a pas encore été assigné – ce qui fait planter la page d'affichage des tableaux de bord.

Cette PR rajoute un scope `with_demandeur`, qui permet d'exclure les projets sans demandeurs du tableau de bord des instructeurs.