### PR TITLE
[WIP] corrige le seed des Review Apps

### DIFF
--- a/config/initializers/seeds.rb
+++ b/config/initializers/seeds.rb
@@ -5,7 +5,43 @@
 # But such a hook doesn't exist on Scalingo yet (although it does
 # on Heroku) ; hence this workaround.
 
-if ENV['IS_REVIEW_APP'] == "true" && !ActiveRecord::Migrator.needs_migration?
-  Rails.application.load_tasks
-  Rake::Task['db:seed'].invoke
+module ReviewApp
+  extend self
+
+  def seed_if_needed
+    # DEBUG
+    [:review_app?, :rake_task?, :db_ready?, :db_needs_seeds?].each do |selector|
+      begin
+        puts "#{selector.to_s} " + send(selector).to_s
+      rescue Exception => e
+        puts "#{selector.to_s} <Exception>"
+      end
+    end
+
+    if review_app? && !rake_task? && db_ready? && db_needs_seeds?
+      Rails.application.load_seed
+    end
+  end
+
+private
+
+  def review_app?
+    ENV['IS_REVIEW_APP'] == "true"
+  end
+
+  def rake_task?
+    File.split($0).last == 'rake'
+  end
+
+  def db_ready?
+    ActiveRecord::Migrator.needs_migration?
+  rescue ActiveRecord::NoDatabaseError
+    false
+  end
+
+  def db_needs_seeds?
+    Intervenant.count == 0
+  end
 end
+
+ReviewApp.seed_if_needed


### PR DESCRIPTION
Le seed des review apps semble être pété, parce qu'on charge les tâches Rake directement dans l'appli Rails, ce qui provoque des erreurs de symboles dupliqués à un moment ou à un autre.

À la place on utilise la manière standard de rails d'appliquer les seeds : `Rails.application.load_seed`. Et pouf, ça fonctionne.

En bonus, on n'essaie maintenant de seeder les Review Apps que si la base de données est vide (parce que bon, même si les seeds sont idempotentes, y'a pas de raison d'essayer de seeder une base pleine).