### PR TITLE
Pf459 creation page indicateur

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -62,3 +62,9 @@
     border-color: #555;
   }
 }
+
+.align-right {
+  position: absolute;
+  right: 15px;
+  bottom: 5px;
+}

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -80,7 +80,7 @@ class DossiersController < ApplicationController
 
   def indicateurs
     if !current_agent.instructeur?
-      redirect_to dossiers_path()
+      redirect_to dossiers_path(), alert: t('sessions.access_forbidden')
     end
   end
 

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -83,6 +83,12 @@ class DossiersController < ApplicationController
       redirect_to dossiers_path, alert: t('sessions.access_forbidden')
     end
     @all_projets = Projet.all
+    @all_prospect = Projet.where(statut: 0)
+    @all_en_cours = Projet.where(statut: 1)
+    @all_proposition_enregistree = Projet.where(statut: 2)
+    @all_proposition_proposee = Projet.where(statut: 3)
+    @all_transmis_pour_instruction = Projet.where(statut: 5)
+    @all_en_cours_d_instruction = Projet.where(statut: 6)
   end
 
 private

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -3,7 +3,8 @@ class DossiersController < ApplicationController
 
   before_action :authenticate_agent!
   before_action :projet_or_dossier
-  before_action :assert_projet_courant, except: [:index]
+  before_action :assert_projet_courant, except: [:index, :indicateurs]
+  #skip_before_action :assert_projet_courant, only: [:indicateurs]
 
   def index
     @dossiers = Projet.for_agent(current_agent)
@@ -76,6 +77,10 @@ class DossiersController < ApplicationController
 
   def show
     render_show
+  end
+
+  def indicateurs
+
   end
 
 private

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -4,7 +4,6 @@ class DossiersController < ApplicationController
   before_action :authenticate_agent!
   before_action :projet_or_dossier
   before_action :assert_projet_courant, except: [:index, :indicateurs]
-  #skip_before_action :assert_projet_courant, only: [:indicateurs]
 
   def index
     @dossiers = Projet.for_agent(current_agent)
@@ -80,7 +79,9 @@ class DossiersController < ApplicationController
   end
 
   def indicateurs
-
+    if !current_agent.instructeur?
+      redirect_to dossiers_path()
+    end
   end
 
 private

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -79,9 +79,10 @@ class DossiersController < ApplicationController
   end
 
   def indicateurs
-    if !current_agent.instructeur?
-      redirect_to dossiers_path(), alert: t('sessions.access_forbidden')
+    unless current_agent.instructeur?
+      redirect_to dossiers_path, alert: t('sessions.access_forbidden')
     end
+    @all_projets = Projet.all
   end
 
 private

--- a/app/views/dossiers/index.html.slim
+++ b/app/views/dossiers/index.html.slim
@@ -1,8 +1,8 @@
 .main-content-block.dashboard-dossiers
+  - if current_agent.instructeur?
+    = btn name: "Indicateurs", href: indicateurs_dossiers_path, icon: "zoom-in", class: "align-right btn-secondary"
   - if @dossiers.blank?
     p Aucun dossier.
-  - if current_agent.instructeur?
-    = link_to "Indicateurs",   indicateurs_dossiers_path
   - else
     = btn name: "Export CSV", href: dossiers_path(format: :csv), icon: "download", class: "btn-export"
     table.table.table-hovered.table-stripped

--- a/app/views/dossiers/index.html.slim
+++ b/app/views/dossiers/index.html.slim
@@ -1,6 +1,8 @@
 .main-content-block.dashboard-dossiers
   - if @dossiers.blank?
     p Aucun dossier.
+  - if current_agent.instructeur?
+    = link_to "Indicateurs",   indicateurs_dossiers_path
   - else
     = btn name: "Export CSV", href: dossiers_path(format: :csv), icon: "download", class: "btn-export"
     table.table.table-hovered.table-stripped

--- a/app/views/dossiers/indicateurs.html.slim
+++ b/app/views/dossiers/indicateurs.html.slim
@@ -1,0 +1,1 @@
+h1 Hello World

--- a/app/views/dossiers/indicateurs.html.slim
+++ b/app/views/dossiers/indicateurs.html.slim
@@ -3,3 +3,11 @@
   = btn name: "Dossiers", href: dossiers_path, icon: "folder-open", class: "align-right btn-secondary"
 
   p=  "Il y a #{ pluralize( @all_projets.count, 'projet' ) }."
+
+  ul
+   li= "Il y a #{ pluralize( @all_proposition_enregistree.count, 'projet' )} 'Proposition Enregistrée'."
+   li= "Il y a #{ pluralize( @all_en_cours.count, 'projet' )} 'En Cours'."
+   li= "Il y a #{ pluralize( @all_prospect.count, 'projet' )} 'Prospect'."
+   li= "Il y a #{ pluralize( @all_proposition_proposee.count, 'projet' )} 'Proposition Proposée'."
+   li= "Il y a #{ pluralize( @all_transmis_pour_instruction.count, 'projet' )} 'Transmis pour Instruction'."
+   li= "Il y a #{ pluralize( @all_en_cours_d_instruction.count, 'projet' )} 'En Cours d'Instruction."

--- a/app/views/dossiers/indicateurs.html.slim
+++ b/app/views/dossiers/indicateurs.html.slim
@@ -1,3 +1,5 @@
 .main-content-block
   h1 Indicateurs
   = btn name: "Dossiers", href: dossiers_path, icon: "folder-open", class: "align-right btn-secondary"
+
+  p=  "Il y a #{ pluralize( @all_projets.count, 'projet' ) }."

--- a/app/views/dossiers/indicateurs.html.slim
+++ b/app/views/dossiers/indicateurs.html.slim
@@ -1,1 +1,2 @@
 h1 Hello World
+= link_to "Dossiers",   dossiers_path

--- a/app/views/dossiers/indicateurs.html.slim
+++ b/app/views/dossiers/indicateurs.html.slim
@@ -1,2 +1,3 @@
-h1 Hello World
-= link_to "Dossiers",   dossiers_path
+.main-content-block
+  h1 Indicateurs
+  = btn name: "Dossiers", href: dossiers_path, icon: "folder-open", class: "align-right btn-secondary"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
     get  '/', to: 'projets#show', as: 'projet'
     post '/plan_financements', to: 'plans_financements#create', as: 'projet_plan_financements'
   end
+
   scope(path_names: { new: 'nouveau', edit: 'edition' }) do
     resources :dossiers, only: [], concerns: :projectable do
       post :dossiers_opal, controller: 'dossiers_opal', action: 'create'
@@ -34,6 +35,7 @@ Rails.application.routes.draw do
       get  :proposer
       get  :proposition
       put  :proposition
+      get  :indicateurs, on: :collection
     end
     resources :dossiers, only: [:show, :edit, :update, :index], param: :dossier_id
 
@@ -45,7 +47,10 @@ Rails.application.routes.draw do
       get      :transmission,         action: :new,    controller: 'transmission'
       post     :transmission,         action: :create, controller: 'transmission'
     end
+
     resources :projets, only: [:show, :edit, :update], param: :projet_id
+
+
 
     get   '/projets/:projet_id/invitations/intervenant/:intervenant_id', to: 'invitations#new', as: 'new_invitation'
     post  '/projets/:projet_id/invitations/intervenant/:intervenant_id', to: 'invitations#create', as: 'invitations'

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -121,6 +121,18 @@ describe DossiersController do
     end
   end
 
+  context "si je suis utilisateur connecté non affecté à un projet" do
+    let(:operateur)       { create :operateur }
+    let(:agent_operateur) { create :agent, :operateur, intervenant: operateur }
+    before { authenticate_as_agent agent_operateur }
+
+    context "quand j'essaie d'accéder aux indicateurs" do
+      subject { get :indicateurs }
+      it { is_expected.to redirect_to(dossiers_path()) }
+    end
+  end
+
+
   context "en tant qu'opérateur connecté affecté à un projet" do
     let(:projet)  { create :projet, :proposition_enregistree }
     before(:each) { authenticate_as_agent projet.agent_operateur }

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -130,8 +130,6 @@ describe DossiersController do
     context "quand j'essaie d'accéder aux indicateurs" do
       subject { get :indicateurs }
       it { is_expected.to redirect_to(dossiers_path()) }
-      # SOUCIS FLASH ALERT
-      # it { expect(flash[:alert]).to eq(I18n.t('sessions.access_forbidden')) }
     end
   end
 
@@ -139,9 +137,16 @@ describe DossiersController do
     let(:projet)  { create :projet, :proposition_enregistree }
     before(:each) { authenticate_as_agent projet.agent_operateur }
 
-    context "quand j'essaie d'accéder aux indicateurs" do
-      subject { get :indicateurs }
-      it { is_expected.to redirect_to(dossiers_path()) }
+    describe "#indicateurs" do
+      context "quand j'essaie d'accéder aux indicateurs" do
+
+        it "je retourne à la page Dossiers et j'ai un message d'erreur" do
+          get :indicateurs
+          expect(flash[:alert]).to eq I18n.t('sessions.access_forbidden')
+          expect(response).to redirect_to dossiers_path()
+        end
+
+      end
     end
 
     describe "#proposer" do

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -21,10 +21,10 @@ describe DossiersController do
 
   context "en tant qu'opérateur connecté" do
     describe "#proposition" do
-      let!(:prestation_1) { create :prestation, libelle: 'Remplacement d’une baignoire par une douche' }
-      let!(:prestation_2) { create :prestation, libelle: 'Lavabo adapté' }
-      let!(:prestation_3) { create :prestation, libelle: 'Géothermie' }
-      let!(:aide_1)       { create :aide, libelle: 'Aide 1' }
+      let!(:prestation_1) { create :prestation }
+      let!(:prestation_2) { create :prestation }
+      let!(:prestation_3) { create :prestation }
+      let!(:aide_1)       { create :aide }
       let(:projet)        { create :projet, :en_cours, :with_assigned_operateur }
 
       before(:each) { authenticate_as_agent projet.agent_operateur }
@@ -121,33 +121,9 @@ describe DossiersController do
     end
   end
 
-  context "si je suis utilisateur connecté non affecté à un projet" do
-    let(:operateur)       { create :operateur }
-    let(:agent_operateur) { create :agent, :operateur, intervenant: operateur }
-    before { authenticate_as_agent agent_operateur }
-
-
-    context "quand j'essaie d'accéder aux indicateurs" do
-      subject { get :indicateurs }
-      it { is_expected.to redirect_to(dossiers_path()) }
-    end
-  end
-
   context "en tant qu'opérateur connecté affecté à un projet" do
     let(:projet)  { create :projet, :proposition_enregistree }
     before(:each) { authenticate_as_agent projet.agent_operateur }
-
-    describe "#indicateurs" do
-      context "quand j'essaie d'accéder aux indicateurs" do
-
-        it "je retourne à la page Dossiers et j'ai un message d'erreur" do
-          get :indicateurs
-          expect(flash[:alert]).to eq I18n.t('sessions.access_forbidden')
-          expect(response).to redirect_to dossiers_path()
-        end
-
-      end
-    end
 
     describe "#proposer" do
       let(:projet)  { create :projet, :proposition_enregistree }

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -119,6 +119,38 @@ describe DossiersController do
         expect(response).to render_template(:indicateurs)
       end
     end
+
+    describe "#indicateurs" do
+      before do
+        create :projet, :proposition_enregistree
+        create :projet, :en_cours
+        create :projet, :en_cours
+      end
+
+      it "je peux voir la liste des projets" do
+        get :indicateurs
+
+        expect(assigns(:all_projets).count).to eq 3
+        expect(assigns(:all_prospect).count).to eq 0
+        expect(assigns(:all_en_cours).count).to eq 2
+        expect(assigns(:all_proposition_enregistree).count).to eq 1
+        expect(assigns(:all_proposition_proposee).count).to eq 0
+        expect(assigns(:all_transmis_pour_instruction).count).to eq 0
+        expect(assigns(:all_en_cours_d_instruction).count).to eq 0
+      end
+    end
+  end
+
+  context "si je suis utilisateur connecté non affecté à un projet" do
+    let(:operateur)       { create :operateur }
+    let(:agent_operateur) { create :agent, :operateur, intervenant: operateur }
+    before { authenticate_as_agent agent_operateur }
+
+
+    context "quand j'essaie d'accéder aux indicateurs" do
+      subject { get :indicateurs }
+      it { is_expected.to redirect_to(dossiers_path()) }
+    end
   end
 
   context "en tant qu'opérateur connecté affecté à un projet" do

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -8,6 +8,11 @@ describe DossiersController do
       it { is_expected.to redirect_to(new_agent_session_path) }
     end
 
+    context "quand j'essaie d'accéder aux indicateurs" do
+      subject { get :indicateurs }
+      it { is_expected.to redirect_to(new_agent_session_path) }
+    end
+
     context "quand j'essaie d'accéder au dossier" do
       subject { get :show, dossier_id: 42 }
       it { is_expected.to redirect_to(new_agent_session_path) }
@@ -101,6 +106,24 @@ describe DossiersController do
         expect(projet.projet_aides.count).to eq 1
       end
     end
+  end
+
+  context "en tant qu'instructeur connecté non affecté à un projet" do
+    let(:instructeur)       { create :instructeur }
+    let(:agent_instructeur) { create :agent, :instructeur, intervenant: instructeur }
+    before { authenticate_as_agent agent_instructeur }
+
+    describe "#indicateurs" do
+      it "je peux accéder aux indicateurs" do
+        get :indicateurs
+        expect(response).to render_template(:indicateurs)
+      end
+    end
+  end
+
+  context "en tant qu'opérateur connecté affecté à un projet" do
+    let(:projet)  { create :projet, :proposition_enregistree }
+    before(:each) { authenticate_as_agent projet.agent_operateur }
 
     describe "#proposer" do
       let(:projet)  { create :projet, :proposition_enregistree }

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -126,16 +126,23 @@ describe DossiersController do
     let(:agent_operateur) { create :agent, :operateur, intervenant: operateur }
     before { authenticate_as_agent agent_operateur }
 
+
     context "quand j'essaie d'accéder aux indicateurs" do
       subject { get :indicateurs }
       it { is_expected.to redirect_to(dossiers_path()) }
+      # SOUCIS FLASH ALERT
+      # it { expect(flash[:alert]).to eq(I18n.t('sessions.access_forbidden')) }
     end
   end
-
 
   context "en tant qu'opérateur connecté affecté à un projet" do
     let(:projet)  { create :projet, :proposition_enregistree }
     before(:each) { authenticate_as_agent projet.agent_operateur }
+
+    context "quand j'essaie d'accéder aux indicateurs" do
+      subject { get :indicateurs }
+      it { is_expected.to redirect_to(dossiers_path()) }
+    end
 
     describe "#proposer" do
       let(:projet)  { create :projet, :proposition_enregistree }

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -8,19 +8,19 @@ FactoryGirl.define do
     trait :instructeur do
       nom 'Instructeur'
       prenom 'Agent'
-      username 'agent_instructeur'
+      sequence(:username) {|n| "agent_instructeur#{n}" }
     end
 
     trait :operateur do
       nom 'Operateur'
       prenom 'Agent'
-      username 'agent_operateur'
+      sequence(:username) {|n| "agent_operateur#{n}" }
     end
 
     trait :pris do
       nom 'PRIS'
       prenom 'Agent'
-      username 'agent_pris'
+      sequence(:username) {|n| "agent_pris#{n}" }
     end
   end
 end

--- a/spec/factories/aide.rb
+++ b/spec/factories/aide.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :aide do
-    libelle "Subvention truc"
+    sequence(:libelle) {|n| "Subvention #{n}" }
   end
 
   factory :projet_aide do

--- a/spec/factories/prestations.rb
+++ b/spec/factories/prestations.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
   factory :prestation do
-    libelle 'Chaudiere'
+    sequence(:libelle) {|n| "Prestation #{n}" }
   end
 end

--- a/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
+++ b/spec/features/3_proposition_travaux/remplir_proposition_travaux_spec.rb
@@ -8,11 +8,11 @@ feature "Remplir la proposition de travaux" do
   let(:operateur)         { projet.operateur }
   let(:agent_operateur)   { create :agent, intervenant: operateur }
   let(:theme)             { create :theme }
-  let!(:prestation_1)     { create :prestation, libelle: 'Remplacement d’une baignoire par une douche' }
-  let!(:prestation_2)     { create :prestation, libelle: 'Lavabo adapté' }
-  let!(:prestation_3)     { create :prestation, libelle: 'Géothermie' }
-  let!(:aide_1)           { create :aide, libelle: 'Aide 1' }
-  let!(:aide_2)           { create :aide, libelle: 'Aide 2' }
+  let!(:prestation_1)     { create :prestation }
+  let!(:prestation_2)     { create :prestation }
+  let!(:prestation_3)     { create :prestation }
+  let!(:aide_1)           { create :aide }
+  let!(:aide_2)           { create :aide }
 
   context "en tant qu'opérateur" do
     before { login_as agent_operateur, scope: :agent }
@@ -226,8 +226,8 @@ feature "Remplir la proposition de travaux" do
       end
 
       context "avec une prestation dépréciée" do
-        let!(:old_unused_prestation)  { create :prestation, libelle: 'Ancienne prestation non utilisée', active: false }
-        let!(:old_used_prestation)    { create :prestation, libelle: 'Ancienne prestation utilisée',     active: false }
+        let!(:old_unused_prestation)  { create :prestation, active: false }
+        let!(:old_used_prestation)    { create :prestation, active: false }
 
         before { projet.prestation_choices << create(:prestation_choice, :selected, projet: projet, prestation: old_used_prestation) }
 
@@ -240,8 +240,8 @@ feature "Remplir la proposition de travaux" do
       end
 
       context "avec une aide dépréciée" do
-        let!(:old_unused_aide)  { create :aide, libelle: 'Ancienne aide non utilisée', active: false }
-        let!(:old_used_aide)    { create :aide, libelle: 'Ancienne aide utilisée',     active: false }
+        let!(:old_unused_aide)  { create :aide, active: false }
+        let!(:old_used_aide)    { create :aide, active: false }
 
         before do
           projet.aides << old_used_aide
@@ -250,9 +250,9 @@ feature "Remplir la proposition de travaux" do
 
         scenario "j'ai toujours accès à cette aide" do
           visit dossier_proposition_path(projet)
-          expect(page).not_to have_content('Ancienne aide non utilisée')
-          expect(page).to have_content('Ancienne aide utilisée')
-          expect(find_field('Ancienne aide utilisée').value).to eq '1 111,10 '
+          expect(page).not_to have_content old_unused_aide.libelle
+          expect(page).to have_content old_used_aide.libelle
+          expect(find_field(old_used_aide.libelle).value).to eq '1 111,10 '
         end
       end
     end

--- a/spec/features/indicateurs_spec.rb
+++ b/spec/features/indicateurs_spec.rb
@@ -12,18 +12,19 @@ feature "Je peux naviguer entre mes pages Dossiers et Indicateurs" do
   context "en tant qu'instructeur" do
     let(:current_agent) { agent_instructeur }
 
-    scenario "j'ai accès à mes indicateurs depuis la page Dossiers" do
+    scenario "j'ai accès à ma page indicateurs depuis la page Dossiers" do
       visit dossiers_path
       click_on 'Indicateurs'
       expect(page).to have_current_path(indicateurs_dossiers_path)
     end
-    scenario "j'ai accès à mes Dossiers depuis la page Indicateurs" do
+
+    scenario "j'ai accès à ma page Dossiers depuis la page Indicateurs" do
       visit indicateurs_dossiers_path
       click_on 'Dossiers'
       expect(page).to have_current_path(dossiers_path)
     end
-
   end
+
 end
 
 
@@ -43,4 +44,33 @@ feature "Je n'ai pas accès aux indicateurs" do
       expect(page).to have_current_path(dossiers_path())
     end
   end
+
+end
+
+feature "Affichage de la page Indicateurs" do
+  let(:instructeur) { create :instructeur }
+  let(:agent_instructeur) { create :agent, :instructeur, intervenant: instructeur }
+
+  before do
+    login_as current_agent, scope: :agent
+  end
+
+  let!(:projet1)  { create :projet, :proposition_enregistree }
+  let!(:projet2)  { create :projet, :en_cours }
+  let!(:projet3)  { create :projet, :prospect }
+  let!(:projet4)  { create :projet, :proposition_proposee }
+  let!(:projet5)  { create :projet, :transmis_pour_instruction }
+  let!(:projet6)  { create :projet, :en_cours_d_instruction }
+  let!(:projet7)  { create :projet, :en_cours }
+
+
+  context "si je suis instructeur" do
+    let(:current_agent) { agent_instructeur }
+    scenario "la page affiche le nombre total de projets" do
+
+      visit indicateurs_dossiers_path
+      expect(page).to have_content("Il y a 7 projets.")
+    end
+  end
+
 end

--- a/spec/features/indicateurs_spec.rb
+++ b/spec/features/indicateurs_spec.rb
@@ -18,3 +18,21 @@ feature "J'ai accès à mes indicateurs" do
     end
   end
 end
+
+feature "Je n'ai pas accès aux indicateurs" do
+  let(:operateur) { create :operateur }
+  let(:agent_operateur) { create :agent, :operateur, intervenant: operateur }
+
+  before do
+    login_as current_agent, scope: :agent
+  end
+
+  context "si je ne suis pas instructeur" do
+    let(:current_agent) { agent_operateur }
+
+    scenario "je n'ai pas accès aux mes indicateurs" do
+      visit indicateurs_dossiers_path
+      expect(page).to have_current_path(dossiers_path())
+    end
+  end
+end

--- a/spec/features/indicateurs_spec.rb
+++ b/spec/features/indicateurs_spec.rb
@@ -55,21 +55,33 @@ feature "Affichage de la page Indicateurs" do
     login_as current_agent, scope: :agent
   end
 
-  let!(:projet1)  { create :projet, :proposition_enregistree }
-  let!(:projet2)  { create :projet, :en_cours }
-  let!(:projet3)  { create :projet, :prospect }
-  let!(:projet4)  { create :projet, :proposition_proposee }
+  let!(:projet0)  { create :projet, :proposition_enregistree }
+  let!(:projet1)  { create :projet, :en_cours }
+  let!(:projet1b)  { create :projet, :en_cours }
+  let!(:projet1c)  { create :projet, :en_cours }
+  let!(:projet2)  { create :projet, :prospect }
+  let!(:projet3)  { create :projet, :proposition_proposee }
   let!(:projet5)  { create :projet, :transmis_pour_instruction }
   let!(:projet6)  { create :projet, :en_cours_d_instruction }
-  let!(:projet7)  { create :projet, :en_cours }
+  let!(:projet6b)  { create :projet, :en_cours_d_instruction }
 
 
   context "si je suis instructeur" do
     let(:current_agent) { agent_instructeur }
-    scenario "la page affiche le nombre total de projets" do
 
+    scenario "la page affiche le nombre total de projets" do
       visit indicateurs_dossiers_path
-      expect(page).to have_content("Il y a 7 projets.")
+      expect(page).to have_content("Il y a 9 projets.")
+    end
+
+    scenario "la page affiche le nombre total de projets par statut" do
+      visit indicateurs_dossiers_path
+      expect(page).to have_content("Il y a 1 projet 'Proposition Enregistrée'.")
+      expect(page).to have_content("Il y a 3 projets 'En Cours'.")
+      expect(page).to have_content("Il y a 1 projet 'Prospect'.")
+      expect(page).to have_content("Il y a 1 projet 'Proposition Proposée'.")
+      expect(page).to have_content("Il y a 1 projet 'Transmis pour Instruction'.")
+      expect(page).to have_content("Il y a 2 projets 'En Cours d'Instruction.")
     end
   end
 

--- a/spec/features/indicateurs_spec.rb
+++ b/spec/features/indicateurs_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'support/mpal_features_helper'
+
+feature "J'ai accès à mes indicateurs" do
+  let(:instructeur) { create :instructeur }
+  let(:agent_instructeur) { create :agent, :instructeur, intervenant: instructeur }
+
+  before do
+    login_as current_agent, scope: :agent
+  end
+
+  context "en tant qu'instructeur" do
+    let(:current_agent) { agent_instructeur }
+
+    scenario "j'ai accès à mes indicateurs" do
+      visit indicateurs_dossiers_path
+      expect(page).to have_current_path(indicateurs_dossiers_path)
+    end
+  end
+end

--- a/spec/features/indicateurs_spec.rb
+++ b/spec/features/indicateurs_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'support/mpal_features_helper'
 
-feature "J'ai accès à mes indicateurs" do
+feature "Je peux naviguer entre mes pages Dossiers et Indicateurs" do
   let(:instructeur) { create :instructeur }
   let(:agent_instructeur) { create :agent, :instructeur, intervenant: instructeur }
 
@@ -12,12 +12,20 @@ feature "J'ai accès à mes indicateurs" do
   context "en tant qu'instructeur" do
     let(:current_agent) { agent_instructeur }
 
-    scenario "j'ai accès à mes indicateurs" do
-      visit indicateurs_dossiers_path
+    scenario "j'ai accès à mes indicateurs depuis la page Dossiers" do
+      visit dossiers_path
+      click_on 'Indicateurs'
       expect(page).to have_current_path(indicateurs_dossiers_path)
     end
+    scenario "j'ai accès à mes Dossiers depuis la page Indicateurs" do
+      visit indicateurs_dossiers_path
+      click_on 'Dossiers'
+      expect(page).to have_current_path(dossiers_path)
+    end
+
   end
 end
+
 
 feature "Je n'ai pas accès aux indicateurs" do
   let(:operateur) { create :operateur }


### PR DESCRIPTION
Création de la page indicateurs pour les instructeurs.
Affiche le nombre total de projets, et de projets par statut.
Correction de factories pour faciliter la création de plusieurs projets.
![page indicateurs](https://cloud.githubusercontent.com/assets/22198770/25941372/778a2936-3639-11e7-8fcd-dd4b5d62f528.gif)
