### PR TITLE
PF457 ETQ Opérateur, je vois les dossiers surlesquels je suis recommandé

### DIFF
--- a/app/controllers/choix_operateur_controller.rb
+++ b/app/controllers/choix_operateur_controller.rb
@@ -9,7 +9,7 @@ class ChoixOperateurController < ApplicationController
   def new
     @suggested_operateurs = @projet_courant.pris_suggested_operateurs.shuffle
     @other_operateurs = @projet_courant.intervenants_disponibles(role: :operateur).shuffle - @suggested_operateurs
-    @operateur = @projet_courant.invited_operateur
+    @operateur = @projet_courant.contacted_operateur
 
     if @operateur.present?
       @action_label = I18n.t('choix_operateur.actions.changer')
@@ -22,7 +22,7 @@ class ChoixOperateurController < ApplicationController
     begin
       @projet_courant.update_attribute(:disponibilite, params[:projet][:disponibilite])
       operateur = Intervenant.find_by_id(params[:operateur_id])
-      unless @projet_courant.invited_operateur == operateur
+      unless @projet_courant.contacted_operateur == operateur
         @projet_courant.contact_operateur!(operateur)
         flash[:notice_titre] = t('invitations.messages.succes_titre')
         flash[:notice] = t('invitations.messages.succes', intervenant: operateur.raison_sociale)

--- a/app/controllers/choix_operateur_controller.rb
+++ b/app/controllers/choix_operateur_controller.rb
@@ -7,7 +7,7 @@ class ChoixOperateurController < ApplicationController
   before_action :init_view
 
   def new
-    @suggested_operateurs = @projet_courant.suggested_operateurs.shuffle
+    @suggested_operateurs = @projet_courant.pris_suggested_operateurs.shuffle
     @other_operateurs = @projet_courant.intervenants_disponibles(role: :operateur).shuffle - @suggested_operateurs
     @operateur = @projet_courant.invited_operateur
 
@@ -23,7 +23,7 @@ class ChoixOperateurController < ApplicationController
       @projet_courant.update_attribute(:disponibilite, params[:projet][:disponibilite])
       operateur = Intervenant.find_by_id(params[:operateur_id])
       unless @projet_courant.invited_operateur == operateur
-        @projet_courant.invite_intervenant!(operateur)
+        @projet_courant.contact_operateur!(operateur)
         flash[:notice_titre] = t('invitations.messages.succes_titre')
         flash[:notice] = t('invitations.messages.succes', intervenant: operateur.raison_sociale)
       end

--- a/app/controllers/demandes_controller.rb
+++ b/app/controllers/demandes_controller.rb
@@ -63,7 +63,7 @@ private
   end
 
   def needs_next_step?
-    @projet_courant.invited_operateur.blank? && @projet_courant.invited_pris.blank?
+    @projet_courant.contacted_operateur.blank? && @projet_courant.invited_pris.blank?
   end
 
   def redirect_to_next_step

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -62,14 +62,14 @@ class DossiersController < ApplicationController
     if request.post?
       if @projet_courant.suggest_operateurs!(suggested_operateurs_params[:suggested_operateur_ids])
         message = I18n.t('recommander_operateurs.succes',
-                          count:     @projet_courant.suggested_operateurs.count,
+                          count:     @projet_courant.pris_suggested_operateurs.count,
                           demandeur: @projet_courant.demandeur.fullname)
         redirect_to(dossier_path(@projet_courant), notice: message)
       end
     end
 
     @available_operateurs = @projet_courant.intervenants_disponibles(role: :operateur).to_a
-    if @projet_courant.suggested_operateurs.blank? && !request.post?
+    if @projet_courant.pris_suggested_operateurs.blank? && !request.post?
       @available_operateurs.shuffle!
     end
   end

--- a/app/controllers/mises_en_relation_controller.rb
+++ b/app/controllers/mises_en_relation_controller.rb
@@ -42,6 +42,6 @@ private
   end
 
   def needs_mise_en_relation?
-    @projet_courant.invited_operateur.blank? && @projet_courant.invited_pris.blank?
+    @projet_courant.contacted_operateur.blank? && @projet_courant.invited_pris.blank?
   end
 end

--- a/app/controllers/mises_en_relation_controller.rb
+++ b/app/controllers/mises_en_relation_controller.rb
@@ -20,7 +20,7 @@ class MisesEnRelationController < ApplicationController
       @projet_courant.update_attribute(:disponibilite, params[:projet][:disponibilite])
       intervenant = Intervenant.find_by_id(params[:intervenant])
       unless @projet_courant.intervenants.include? intervenant
-        @projet_courant.invite_intervenant!(intervenant)
+        @projet_courant.invite_pris!(intervenant)
         flash[:notice_titre] = t('invitations.messages.succes_titre')
         flash[:notice] = t('invitations.messages.succes', intervenant: intervenant.raison_sociale)
       end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -125,8 +125,14 @@ class Projet < ActiveRecord::Base
     intervenants.pour_role(:instructeur).first
   end
 
+  def pris_suggested_operateurs
+    pris_suggested_operateur_ids = invitations.where(suggested: true).map(&:intervenant_id)
+    intervenants.pour_role(:operateur).find(pris_suggested_operateur_ids)
+  end
+
   def invited_operateur
-    intervenants.pour_role(:operateur).first
+    contacted_operateur_ids = invitations.where(contacted: true).map(&:intervenant_id)
+    intervenants.pour_role(:operateur).find(contacted_operateur_ids).first
   end
 
   def invited_pris
@@ -224,8 +230,18 @@ class Projet < ActiveRecord::Base
   end
 
   def suggest_operateurs!(operateur_ids)
-    self.suggested_operateur_ids = operateur_ids
-    if validate_suggested_operateurs && save
+    if operateur_ids.blank?
+      errors[:base] << I18n.t('recommander_operateurs.errors.blank')
+      return false
+    end
+
+    invitations.each { |i| i.update(suggested: false) }
+
+    operateur_ids.each do |operateur_id|
+      self.invitations.find_or_create_by(intervenant_id: operateur_id).update(suggested: true)
+    end
+
+    if save
       ProjetMailer.recommandation_operateurs(self).deliver_later!
       true
     else
@@ -233,32 +249,44 @@ class Projet < ActiveRecord::Base
     end
   end
 
-  def invite_intervenant!(intervenant)
-    return if intervenants.include? intervenant
+  def contact_operateur!(operateur_to_contact)
+    previous_operateur = invited_operateur
+    return if previous_operateur == operateur_to_contact
 
-    if intervenant.operateur? && operateur.present?
+    if operateur.present?
       raise "Cannot invite an operator: the projet is already committed with an operator (#{operateur.raison_sociale})"
     end
 
-    previous_operateur = invited_operateur
-    previous_pris = invited_pris
+    invitation = Invitation.find_or_create_by!(projet: self, intervenant: operateur_to_contact)
+    invitation.update(contacted: true)
+    notify_intervenant_of(invitation)
 
-    invitation = Invitation.new(projet: self, intervenant: intervenant)
-    invitation.save!
-    ProjetMailer.invitation_intervenant(invitation).deliver_later!
-    ProjetMailer.notification_invitation_intervenant(invitation).deliver_later!
-    EvenementEnregistreurJob.perform_later(label: 'invitation_intervenant', projet: self, producteur: invitation)
-
-    if intervenant.operateur? && previous_operateur
+    if previous_operateur
       previous_invitation = invitations.where(intervenant: previous_operateur).first
       ProjetMailer.resiliation_operateur(previous_invitation).deliver_later!
-      previous_invitation.destroy!
+      if previous_invitation.suggested
+        previous_invitation.update(contacted: false)
+      else
+        previous_invitation.destroy!
+      end
     end
+  end
 
-    if intervenant.pris? && previous_pris
-      previous_invitation = invitations.where(intervenant: previous_pris).first
-      previous_invitation.destroy!
-    end
+  def invite_pris!(pris)
+    previous_pris = invited_pris
+    return if previous_pris == pris
+
+    invitation = Invitation.new(projet: self, intervenant: pris)
+    invitation.save!
+    notify_intervenant_of(invitation)
+
+    invitations.where(intervenant: previous_pris).first.try(:destroy!)
+  end
+
+  def notify_intervenant_of(invitation)
+    ProjetMailer.invitation_intervenant(invitation).deliver_later! if invitation.intervenant.email.present?
+    ProjetMailer.notification_invitation_intervenant(invitation).deliver_later! if invitation.projet.email.present?
+    EvenementEnregistreurJob.perform_later(label: 'invitation_intervenant', projet: self, producteur: invitation)
   end
 
   def commit_with_operateur!(committed_operateur)
@@ -371,13 +399,5 @@ class Projet < ActiveRecord::Base
       end
     end
     utf8.encode(csv_ouput_encoding, invalid: :replace, undef: :replace, replace: "")
-  end
-
-  def validate_suggested_operateurs
-    if suggested_operateurs.blank?
-      errors[:base] << I18n.t('recommander_operateurs.errors.blank')
-      return false
-    end
-    valid?
   end
 end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -130,7 +130,7 @@ class Projet < ActiveRecord::Base
     intervenants.pour_role(:operateur).find(pris_suggested_operateur_ids)
   end
 
-  def invited_operateur
+  def contacted_operateur
     contacted_operateur_ids = invitations.where(contacted: true).map(&:intervenant_id)
     intervenants.pour_role(:operateur).find(contacted_operateur_ids).first
   end
@@ -144,11 +144,11 @@ class Projet < ActiveRecord::Base
   end
 
   def can_switch_operateur?
-    statut.to_sym == :prospect && invited_operateur.present?
+    statut.to_sym == :prospect && contacted_operateur.present?
   end
 
   def can_validate_operateur?
-    invited_operateur.present? && operateur.blank?
+    contacted_operateur.present? && operateur.blank?
   end
 
   FROZEN_STATUTS = [:transmis_pour_instruction, :en_cours_d_instruction]
@@ -250,7 +250,7 @@ class Projet < ActiveRecord::Base
   end
 
   def contact_operateur!(operateur_to_contact)
-    previous_operateur = invited_operateur
+    previous_operateur = contacted_operateur
     return if previous_operateur == operateur_to_contact
 
     if operateur.present?
@@ -386,7 +386,7 @@ class Projet < ActiveRecord::Base
           projet.adresse.try(:ville),
           projet.invited_instructeur.try(:raison_sociale),
           projet.themes.map(&:libelle).join(", "),
-          projet.invited_operateur.try(:raison_sociale),
+          projet.contacted_operateur.try(:raison_sociale),
           projet.date_de_visite.present? ? format_date(projet.date_de_visite) : "",
           I18n.t(projet.status_for_operateur, scope: "projets.statut"),
         ]

--- a/app/views/dossiers/_projet_envisage.html.slim
+++ b/app/views/dossiers/_projet_envisage.html.slim
@@ -11,7 +11,7 @@ article.block.projet
       = affiche_demande_souhaitee(@projet_courant.demande)
       hr/
       h4 Organisme choisi pour accompagner le projet :
-      - operateur = @projet_courant.invited_operateur
+      - operateur = @projet_courant.contacted_operateur
       - if operateur.present?
         .description-operateur
           strong= operateur.raison_sociale

--- a/app/views/dossiers/_projet_envisage.html.slim
+++ b/app/views/dossiers/_projet_envisage.html.slim
@@ -11,7 +11,7 @@ article.block.projet
       = affiche_demande_souhaitee(@projet_courant.demande)
       hr/
       h4 Organisme choisi pour accompagner le projet :
-      - operateur = @projet_courant.intervenants.pour_role(:operateur).first
+      - operateur = @projet_courant.invited_operateur
       - if operateur.present?
         .description-operateur
           strong= operateur.raison_sociale
@@ -25,10 +25,11 @@ article.block.projet
       - else
         p
           = t('projets.envisage.operateur.aucun')
-        - if @projet_courant.suggested_operateurs.present?
+        - suggested_operateurs = @projet_courant.pris_suggested_operateurs
+        - if suggested_operateurs.present?
           h4 = t('projets.envisage.operateurs_recommandes')
           ul
-          - @projet_courant.suggested_operateurs.each do |operateur|
+          - suggested_operateurs.each do |operateur|
             li = operateur.raison_sociale
           = btn name: t('recommander_operateurs.modifier'), href: dossier_recommander_operateurs_path(@projet_courant)
         - else

--- a/app/views/dossiers/index.html.slim
+++ b/app/views/dossiers/index.html.slim
@@ -56,7 +56,7 @@
                 - if projet.themes.present?
                   = projet.themes.map(&:libelle).join(', ')
             td= link_to edit_url do
-              = projet.invited_operateur.raison_sociale rescue ' '
+              = projet.contacted_operateur.raison_sociale rescue ' '
               - if projet.agent_operateur && (current_agent.instructeur? || current_agent.operateur?)
                 br/
                 span.firstname= projet.agent_operateur.prenom

--- a/app/views/dossiers/recommander_operateurs.html.slim
+++ b/app/views/dossiers/recommander_operateurs.html.slim
@@ -9,7 +9,7 @@
           label
             = check_box_tag "projet[suggested_operateur_ids][]",
                             operateur.id,
-                            @projet_courant.suggested_operateur_ids.include?(operateur.id),
+                            @projet_courant.pris_suggested_operateurs.include?(operateur),
                             { id: "operateur_#{operateur.id}" }
             = operateur.raison_sociale
     = btn name: t('recommander_operateurs.valider')

--- a/app/views/projets/_projet_envisage.html.slim
+++ b/app/views/projets/_projet_envisage.html.slim
@@ -12,7 +12,7 @@ article.block.projet
       = affiche_demande_souhaitee(@projet_courant.demande)
       hr/
       h4 Organisme qui vous accompagne pour la suite de votre projet :
-      - operateur = @projet_courant.invited_operateur
+      - operateur = @projet_courant.contacted_operateur
       - if operateur.present?
         .description-operateur
           strong= operateur.raison_sociale
@@ -25,7 +25,7 @@ article.block.projet
           |. Vous serez informé par email pour chaque réponse de sa part.
         .button-group
           - if @projet_courant.can_validate_operateur?
-            = btn name: t('projets.visualisation.s_engager_avec_operateur'), href: projet_engagement_operateur_path(@projet_courant, operateur_id: @projet_courant.invited_operateur)
+            = btn name: t('projets.visualisation.s_engager_avec_operateur'), href: projet_engagement_operateur_path(@projet_courant, operateur_id: @projet_courant.contacted_operateur)
           - if @projet_courant.can_switch_operateur?
             = btn name: t('projets.visualisation.changer_intervenant'), href: projet_choix_operateur_path(@projet_courant)
       - elsif @projet_courant.pris_suggested_operateurs.present?

--- a/app/views/projets/_projet_envisage.html.slim
+++ b/app/views/projets/_projet_envisage.html.slim
@@ -12,7 +12,7 @@ article.block.projet
       = affiche_demande_souhaitee(@projet_courant.demande)
       hr/
       h4 Organisme qui vous accompagne pour la suite de votre projet :
-      - operateur = @projet_courant.intervenants.pour_role(:operateur).first
+      - operateur = @projet_courant.invited_operateur
       - if operateur.present?
         .description-operateur
           strong= operateur.raison_sociale
@@ -28,7 +28,7 @@ article.block.projet
             = btn name: t('projets.visualisation.s_engager_avec_operateur'), href: projet_engagement_operateur_path(@projet_courant, operateur_id: @projet_courant.invited_operateur)
           - if @projet_courant.can_switch_operateur?
             = btn name: t('projets.visualisation.changer_intervenant'), href: projet_choix_operateur_path(@projet_courant)
-      - elsif @projet_courant.suggested_operateurs.present?
+      - elsif @projet_courant.pris_suggested_operateurs.present?
         p= t('projets.visualisation.le_pris_a_recommande_des_operateurs')
         - unless current_agent
           .button-group

--- a/db/migrate/20170511143826_add_suggested_and_contacted_to_invitations.rb
+++ b/db/migrate/20170511143826_add_suggested_and_contacted_to_invitations.rb
@@ -1,0 +1,6 @@
+class AddSuggestedAndContactedToInvitations < ActiveRecord::Migration
+  def change
+    add_column :invitations, :suggested, :boolean, null: false, default: false
+    add_column :invitations, :contacted, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170510152048) do
+ActiveRecord::Schema.define(version: 20170511143826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,8 @@ ActiveRecord::Schema.define(version: 20170510152048) do
     t.integer  "intermediaire_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "suggested",        default: false, null: false
+    t.boolean  "contacted",        default: false, null: false
   end
 
   add_index "invitations", ["intermediaire_id"], name: "index_invitations_on_intermediaire_id", using: :btree

--- a/lib/tasks/deployment/20170511152048_migrate_uncommited_operateurs.rake
+++ b/lib/tasks/deployment/20170511152048_migrate_uncommited_operateurs.rake
@@ -1,0 +1,20 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_uncommited_operateurs'
+  task migrate_uncommited_operateurs: :environment do
+    puts "Running deploy task 'migrate_uncommited_operateurs'" unless Rake.application.options.quiet
+
+    Invitation.where(suggested: false).each do |invitation|
+      invitation.update(contacted: true) if invitation.intervenant.roles.include? 'operateur'
+    end
+
+    Projet.all.each do |projet|
+      projet.suggested_operateur_ids.each do |operateur_id|
+        projet.invitations.find_or_create_by(intervenant_id: operateur_id).update(suggested: true)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20170511152048'
+  end
+end

--- a/spec/controllers/choix_operateur_controller_spec.rb
+++ b/spec/controllers/choix_operateur_controller_spec.rb
@@ -24,7 +24,7 @@ describe ChoixOperateurController do
         operateur_id: operateur.id,
         projet: { disponibilite: 'Plutôt le midi' }
       projet.reload
-      expect(projet.invited_operateur).to eq operateur
+      expect(projet.contacted_operateur).to eq operateur
       expect(projet.disponibilite).to eq 'Plutôt le midi'
       expect(response).to redirect_to projet_path(projet)
     end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -51,7 +51,8 @@ FactoryGirl.define do
         operateurA = create(:operateur, departements: [projet.departement])
         operateurB = create(:operateur, departements: [projet.departement])
         operateurC = create(:operateur, departements: [projet.departement])
-        projet.suggested_operateurs = [operateurA, operateurC]
+        projet.invitations << create(:invitation, projet: projet, intervenant: operateurA, suggested: true)
+        projet.invitations << create(:invitation, projet: projet, intervenant: operateurC, suggested: true)
         # B is available but not suggested
       end
     end
@@ -59,7 +60,7 @@ FactoryGirl.define do
     trait :with_invited_operateur do
       after(:build) do |projet|
         operateur = create(:operateur, departements: [projet.departement])
-        projet.invitations << create(:invitation, projet: projet, intervenant: operateur)
+        projet.invitations << create(:invitation, projet: projet, intervenant: operateur, contacted: true)
       end
     end
 

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -57,7 +57,7 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_invited_operateur do
+    trait :with_contacted_operateur do
       after(:build) do |projet|
         operateur = create(:operateur, departements: [projet.departement])
         projet.invitations << create(:invitation, projet: projet, intervenant: operateur, contacted: true)
@@ -65,9 +65,9 @@ FactoryGirl.define do
     end
 
     trait :with_committed_operateur do
-      with_invited_operateur
+      with_contacted_operateur
       after(:build) do |projet|
-        projet.operateur = projet.invited_operateur
+        projet.operateur = projet.contacted_operateur
       end
     end
 

--- a/spec/features/2_choix_operateur/choix_operateur_spec.rb
+++ b/spec/features/2_choix_operateur/choix_operateur_spec.rb
@@ -31,9 +31,10 @@ feature "Choisir un opérateur:" do
     end
 
     context "lorsque le PRIS m'a recommandé des opérateurs" do
-      let(:projet)              { create(:projet, :prospect, :with_invited_pris, :with_suggested_operateurs) }
-      let(:suggested_operateur) { projet.suggested_operateurs.first }
-      let(:other_operateur)     { (projet.intervenants_disponibles(role: :operateur) - projet.suggested_operateurs).first }
+      let(:projet)               { create(:projet, :prospect, :with_invited_pris, :with_suggested_operateurs) }
+      let(:suggested_operateur1) { projet.pris_suggested_operateurs.first }
+      let(:suggested_operateur2) { projet.pris_suggested_operateurs.last }
+      let(:other_operateur)      { (projet.intervenants_disponibles(role: :operateur) - projet.suggested_operateurs).first }
 
       scenario "je peux choisir un opérateur parmi ceux recommandés" do
         signin(projet.numero_fiscal, projet.reference_avis)
@@ -41,17 +42,18 @@ feature "Choisir un opérateur:" do
         click_link I18n.t('projets.visualisation.choisir_operateur_recommande')
 
         expect(page).to have_current_path projet_choix_operateur_path(projet)
-        expect(page).to have_content(suggested_operateur.raison_sociale)
+        expect(page).to have_content(suggested_operateur1.raison_sociale)
+        expect(page).to have_content(suggested_operateur2.raison_sociale)
         expect(page).to have_content(other_operateur.raison_sociale)
         expect(page).not_to have_selector("input[checked]")
 
-        choose suggested_operateur.raison_sociale
+        choose suggested_operateur1.raison_sociale
         fill_in I18n.t('helpers.label.projet.disponibilite'), with: "Plutôt le matin"
         check I18n.t('agrements.autorisation_acces_donnees_intervenants')
         click_button I18n.t('choix_operateur.actions.contacter')
 
         expect(page).to have_content(I18n.t('invitations.messages.succes_titre'))
-        expect(page).to have_content(suggested_operateur.raison_sociale)
+        expect(page).to have_content(suggested_operateur1.raison_sociale)
         expect(page).to have_content('Plutôt le matin')
       end
     end

--- a/spec/features/2_choix_operateur/choix_operateur_spec.rb
+++ b/spec/features/2_choix_operateur/choix_operateur_spec.rb
@@ -59,16 +59,16 @@ feature "Choisir un opérateur:" do
     end
 
     context "avant de m'être engagé avec un opérateur" do
-      let(:projet) { create(:projet, :prospect, :with_intervenants_disponibles, :with_invited_operateur) }
+      let(:projet) { create(:projet, :prospect, :with_intervenants_disponibles, :with_contacted_operateur) }
 
       scenario "je peux choisir un autre opérateur" do
         signin(projet.numero_fiscal, projet.reference_avis)
         click_link I18n.t('projets.visualisation.changer_intervenant')
 
         expect(page).to have_selector('.choose-operator.choose-operator-intervenant')
-        expect(page).to have_selector("#operateur_id_#{projet.invited_operateur.id}[checked]")
+        expect(page).to have_selector("#operateur_id_#{projet.contacted_operateur.id}[checked]")
 
-        previous_operateur = projet.invited_operateur
+        previous_operateur = projet.contacted_operateur
         new_operateur = projet.intervenants_disponibles(role: :operateur).first
 
         choose new_operateur.raison_sociale

--- a/spec/features/2_choix_operateur/dossier_spec.rb
+++ b/spec/features/2_choix_operateur/dossier_spec.rb
@@ -4,8 +4,8 @@ require 'support/api_particulier_helper'
 require 'support/api_ban_helper'
 
 feature "Accéder au informations du dossier :" do
-  let(:projet)      { create(:projet, :prospect, :with_invited_operateur, :with_invited_instructeur, :with_invited_pris) }
-  let(:operateur)   { projet.invited_operateur }
+  let(:projet)      { create(:projet, :prospect, :with_contacted_operateur, :with_invited_instructeur, :with_invited_pris) }
+  let(:operateur)   { projet.contacted_operateur }
   let(:instructeur) { projet.invited_instructeur }
   let(:pris)        { projet.invited_pris }
 

--- a/spec/features/2_choix_operateur/engagement_operateur_spec.rb
+++ b/spec/features/2_choix_operateur/engagement_operateur_spec.rb
@@ -3,8 +3,8 @@ require 'support/mpal_features_helper'
 require 'support/api_particulier_helper'
 
 feature "S'engager avec un opérateur :" do
-  let(:projet)    { create(:projet, :prospect, :with_invited_operateur) }
-  let(:operateur) { projet.invited_operateur }
+  let(:projet)    { create(:projet, :prospect, :with_contacted_operateur) }
+  let(:operateur) { projet.contacted_operateur }
 
   scenario "en tant que demandeur, je peux m'engager avec un opérateur" do
     signin(projet.numero_fiscal, projet.reference_avis)

--- a/spec/features/2_choix_operateur/recommander_operateurs_spec.rb
+++ b/spec/features/2_choix_operateur/recommander_operateurs_spec.rb
@@ -47,20 +47,23 @@ feature "Recommander un opérateur:" do
                             :with_intervenants_disponibles,
                             :with_invited_pris,
                             :with_suggested_operateurs) }
-      let(:suggested_operateur) { projet.suggested_operateurs.first }
+      let(:suggested_operateur1) { projet.pris_suggested_operateurs.first }
+      let(:suggested_operateur2) { projet.pris_suggested_operateurs.last }
 
       scenario "je peux modifier les opérateurs recommandés" do
         visit dossier_path(projet)
         click_link I18n.t('recommander_operateurs.modifier')
 
         expect(page).to have_current_path dossier_recommander_operateurs_path(projet)
-        expect(find("#operateur_#{suggested_operateur.id}")).to be_checked
-        uncheck suggested_operateur.raison_sociale
+        expect(find("#operateur_#{suggested_operateur1.id}")).to be_checked
+        expect(find("#operateur_#{suggested_operateur2.id}")).to be_checked
+        uncheck suggested_operateur1.raison_sociale
         click_button I18n.t('recommander_operateurs.valider')
 
         expect(page).to have_current_path dossier_path(projet)
         expect(page).to have_content "L’opérateur sélectionné a été recommandé"
-        expect(page).not_to have_content suggested_operateur.raison_sociale
+        expect(page).not_to have_content suggested_operateur1.raison_sociale
+        expect(page).to     have_content suggested_operateur2.raison_sociale
       end
     end
   end

--- a/spec/lib/tasks/deployment/migrate_uncommited_operateurs_spec.rb
+++ b/spec/lib/tasks/deployment/migrate_uncommited_operateurs_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require 'support/after_party_helper'
+
+describe '20170511152048_migrate_uncommited_operateurs' do
+  include_context 'after_party'
+
+  let(:projet)              { create :projet }
+  let(:suggested_operateur) { create :operateur }
+  let(:contacted_operateur) { create :operateur }
+  let(:pris)                { create :pris }
+  let!(:contact_invitation) { create :invitation, projet: projet, intervenant: contacted_operateur }
+  let!(:invitation_pris)    { create :invitation, projet: projet, intervenant: pris }
+
+  before do
+    projet.suggested_operateurs << suggested_operateur
+    subject.invoke
+  end
+
+  shared_examples "met à jour les invitations d'opérateurs" do
+    specify do
+      suggestion_invitation = Invitation.find_by(intervenant_id: suggested_operateur.id)
+      contact_invitation.reload
+      invitation_pris.reload
+
+      expect(suggestion_invitation.suggested).to eq true
+      expect(suggestion_invitation.contacted).to eq false
+
+      expect(contact_invitation.suggested).to eq false
+      expect(contact_invitation.contacted).to eq true
+
+      expect(invitation_pris.suggested).to eq false
+      expect(invitation_pris.contacted).to eq false
+    end
+  end
+
+  it "charge l'environment Rails" do
+    expect(subject.prerequisites).to include 'environment'
+  end
+
+  it_behaves_like "met à jour les invitations d'opérateurs"
+
+  context "si appelé plusieurs fois" do
+    before { subject.invoke }
+    it_behaves_like "met à jour les invitations d'opérateurs"
+  end
+end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -138,33 +138,40 @@ describe Projet do
   end
 
   describe '#for_agent' do
-    let(:instructeur) {       create :instructeur }
-    let(:operateur1) {        create :operateur }
-    let(:operateur2) {        create :operateur }
-    let(:operateur3) {        create :operateur }
+    let(:instructeur)       { create :instructeur }
+    let(:operateur1)        { create :operateur }
+    let(:operateur2)        { create :operateur }
+    let(:operateur3)        { create :operateur }
+    let(:operateur4)        { create :operateur }
     let(:agent_instructeur) { create :agent, intervenant: instructeur }
-    let(:agent_operateur1) {  create :agent, intervenant: operateur1 }
-    let(:agent_operateur2) {  create :agent, intervenant: operateur2 }
-    let(:agent_operateur3) {  create :agent, intervenant: operateur3 }
-    let(:projet1) {           create :projet, :with_demandeur }
-    let(:projet2) {           create :projet, :with_demandeur }
-    let(:projet3) {           create :projet, :with_demandeur }
-    let(:projet4) {           create :projet }
-    let!(:invitation1) {      create :invitation, intervenant: operateur1, projet: projet1 }
-    let!(:invitation2) {      create :invitation, intervenant: operateur1, projet: projet2 }
-    let!(:invitation3) {      create :invitation, intervenant: operateur2, projet: projet3 }
+    let(:agent_operateur1)  { create :agent, intervenant: operateur1 }
+    let(:agent_operateur2)  { create :agent, intervenant: operateur2 }
+    let(:agent_operateur3)  { create :agent, intervenant: operateur3 }
+    let(:agent_operateur4)  { create :agent, intervenant: operateur4 }
+    let(:projet1)           { create :projet, :with_demandeur }
+    let(:projet2)           { create :projet, :with_demandeur }
+    let(:projet3)           { create :projet, :with_demandeur }
+    let(:projet4)           { create :projet, :with_demandeur }
+    let(:projet5)           { create :projet }
+    let!(:invitation1)      { create :invitation, intervenant: operateur1, projet: projet1 }
+    let!(:invitation2)      { create :invitation, intervenant: operateur1, projet: projet2 }
+    let!(:invitation3)      { create :invitation, intervenant: operateur2, projet: projet3 }
 
-    describe "un opérateur voit les projets sur lesquels il est affecté" do
+    before { projet4.suggest_operateurs! [operateur4.id] }
+
+    describe "un opérateur voit les projets sur lesquels il est affecté ou recommandé" do
       it { expect(Projet.for_agent(agent_operateur1).length).to eq(2) }
       it { expect(Projet.for_agent(agent_operateur2).length).to eq(1) }
       it { expect(Projet.for_agent(agent_operateur3).length).to eq(0) }
+      it { expect(Projet.for_agent(agent_operateur4).length).to eq(1) }
     end
 
     it "un instructeur voit tous les projets avec un demandeur" do
       expect(Projet.for_agent(agent_instructeur)).to include(projet1)
       expect(Projet.for_agent(agent_instructeur)).to include(projet2)
       expect(Projet.for_agent(agent_instructeur)).to include(projet3)
-      expect(Projet.for_agent(agent_instructeur)).not_to include(projet4)
+      expect(Projet.for_agent(agent_instructeur)).to include(projet4)
+      expect(Projet.for_agent(agent_instructeur)).not_to include(projet5)
     end
   end
 
@@ -283,8 +290,29 @@ describe Projet do
     end
   end
 
+  describe "#pris_suggested_operateurs" do
+    let(:projet)     { create :projet }
+    let(:operateur1) { create :operateur }
+    let(:operateur2) { create :operateur }
+    let(:operateur3) { create :operateur }
+    let(:operateur4) { create :operateur }
+
+    before do
+      create :invitation, projet_id: projet.id, intervenant_id: operateur1.id, suggested: true
+      create :invitation, projet_id: projet.id, intervenant_id: operateur2.id, suggested: true
+      create :invitation, projet_id: projet.id, intervenant_id: operateur3.id, contacted: true
+    end
+
+    it "retourne les opérateurs recommandés par le PRIS" do
+      suggested_operateurs = projet.pris_suggested_operateurs
+
+      expect(suggested_operateurs).to     include(operateur1, operateur2)
+      expect(suggested_operateurs).not_to include(operateur3, operateur4)
+    end
+  end
+
   describe "#suggest_operateurs!" do
-    let(:projet)     { create :projet, :with_suggested_operateurs }
+    let(:projet)     { create :projet }
     let(:operateurA) { create :operateur }
     let(:operateurB) { create :operateur }
 
@@ -292,7 +320,7 @@ describe Projet do
       expect(ProjetMailer).to receive(:recommandation_operateurs).and_call_original
       result = projet.suggest_operateurs!([operateurA.id, operateurB.id])
       expect(result).to be true
-      expect(projet.suggested_operateurs.count).to eq 2
+      expect(projet.pris_suggested_operateurs.count).to eq 2
       expect(projet.errors).to be_empty
     end
 
@@ -303,90 +331,119 @@ describe Projet do
     end
   end
 
-  describe "#invite_intervenant!" do
-    context "sans intervenant invité au préalable" do
+  describe "#contact_operateur!" do
+    context "sans opérateur invité au préalable" do
       let(:projet)    { create :projet }
       let(:operateur) { create :operateur }
 
-      it "sélectionne et notifie l'intervenant" do
+      it "sélectionne et notifie l'opérateur" do
         expect(ProjetMailer).to receive(:invitation_intervenant).and_call_original
-        projet.invite_intervenant!(operateur)
+        projet.contact_operateur!(operateur)
         expect(projet.invitations.count).to eq(1)
         expect(projet.invited_operateur).to eq(operateur)
       end
     end
 
-    context "avec un PRIS invité auparavant" do
-      let(:projet)        { create :projet, :prospect, :with_invited_pris }
-      let(:new_operateur) { create :operateur }
+    context "avec des opérateurs recommandés par un PRIS" do
+      let(:projet)    { create :projet, :prospect, :with_suggested_operateurs }
+      let(:operateur) { projet.invitations.last.intervenant }
 
-      it "sélectionne le nouvel intervenant" do
-        projet.invite_intervenant!(new_operateur)
-        expect(projet.invitations.count).to eq(2)
-        expect(projet.invited_pris).not_to be_nil
-        expect(projet.invited_operateur).to eq(new_operateur)
+      context "dont un opérateur contacté" do
+        before { projet.invitations.first.update(contacted: true) }
+
+        it "ne supprime pas la suggestion sur contact d'un autre opérateur" do
+          projet.contact_operateur!(operateur)
+          expect(projet.invitations.count).to eq 2
+          expect(projet.invitations.first.suggested).to eq true
+          expect(projet.invitations.first.contacted).to eq false
+        end
       end
     end
 
     context "avec un opérateur invité auparavant" do
-      context "et un nouveau PRIS" do
-        let(:projet)    { create :projet, :prospect, :with_invited_operateur }
-        let(:operateur) { projet.invited_operateur }
-        let(:pris)      { create :pris }
-
-        it "rajoute l’opérateur et conserve la relation avec le PRIS" do
-          projet.invite_intervenant!(pris)
-          expect(projet.invitations.count).to eq(2)
-          expect(projet.invited_operateur).to eq(operateur)
-          expect(projet.invited_pris).to eq(pris)
-        end
-      end
+      let(:projet) { create :projet, :prospect, :with_invited_operateur }
 
       context "et un nouvel opérateur différent du précédent" do
-        let(:projet)             { create :projet, :prospect, :with_invited_operateur }
-        let(:previous_operateur) { projet.invited_operateur }
-        let(:new_operateur)      { create :operateur }
+        let(:new_operateur) { create :operateur }
 
         it "sélectionne le nouvel opérateur, et notifie l'ancien opérateur" do
           expect(ProjetMailer).to receive(:invitation_intervenant).and_call_original
           expect(ProjetMailer).to receive(:resiliation_operateur).and_call_original
-          projet.invite_intervenant!(new_operateur)
+          projet.contact_operateur!(new_operateur)
           expect(projet.invitations.count).to eq(1)
           expect(projet.invited_operateur).to eq(new_operateur)
         end
       end
 
       context "et un nouvel opérateur identique au précédent" do
-        let(:projet)    { create :projet, :prospect, :with_invited_operateur }
         let(:operateur) { projet.invited_operateur }
 
         it "ne change rien" do
-          projet.invite_intervenant!(operateur)
-          expect(projet.invitations.count).to eq(1)
-          expect(projet.invited_operateur).to eq(operateur)
+          projet.contact_operateur!(operateur)
+          expect(projet.invitations.count).to eq 1
+          expect(projet.invited_operateur).to eq operateur
         end
       end
     end
 
     context "avec un opérateur engagé auparavant" do
+      let(:projet) { create :projet, :prospect, :with_committed_operateur }
+
       context "et un nouvel opérateur différent de celui déjà engagé" do
-        let(:projet)             { create :projet, :prospect, :with_committed_operateur }
-        let(:new_operateur)      { create :operateur }
+        let(:new_operateur) { create :operateur }
 
         it "ne change rien et lève une exception" do
-          expect { projet.invite_intervenant!(new_operateur) }.to raise_error RuntimeError
-          expect(projet.invitations.count).to eq(1)
-          expect(projet.invited_operateur).to eq(projet.operateur)
+          expect { projet.contact_operateur!(new_operateur) }.to raise_error RuntimeError
+          expect(projet.invitations.count).to eq 1
+          expect(projet.invited_operateur).to eq projet.operateur
         end
       end
 
       context "et un nouvel opérateur identique au précédent" do
-        let(:projet)    { create :projet, :en_cours }
         let(:operateur) { projet.operateur }
 
         it "ne change rien" do
-          projet.invite_intervenant!(operateur)
-          expect(projet.operateur).to eq(operateur)
+          projet.contact_operateur!(operateur)
+          expect(projet.operateur).to eq operateur
+        end
+      end
+    end
+  end
+
+  describe "#invite_pris!" do
+    context "sans PRIS invité au préalable" do
+      let(:projet) { create :projet }
+      let(:pris)   { create :pris }
+
+      it "sélectionne et notifie le PRIS" do
+        expect(ProjetMailer).to receive(:invitation_intervenant).and_call_original
+        projet.invite_pris!(pris)
+        expect(projet.invitations.count).to eq(1)
+        expect(projet.invited_pris).to eq(pris)
+      end
+    end
+
+    context "avec un PRIS invité auparavant" do
+      let(:projet) { create :projet, :prospect, :with_invited_pris }
+
+      context "et un nouveau PRIS différent du précédent" do
+        let(:new_pris) { create :pris }
+
+        it "sélectionne le nouveau PRIS, et notifie l'ancien PRIS" do
+          expect(ProjetMailer).to receive(:invitation_intervenant).and_call_original
+          projet.invite_pris!(new_pris)
+          expect(projet.invitations.count).to eq(1)
+          expect(projet.invited_pris).to eq(new_pris)
+        end
+      end
+
+      context "et un nouveau PRIS identique au précédent" do
+        let(:pris) { projet.invited_pris }
+
+        it "ne change rien" do
+          projet.invite_pris!(pris)
+          expect(projet.invitations.count).to eq 1
+          expect(projet.invited_pris).to eq pris
         end
       end
     end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -340,7 +340,7 @@ describe Projet do
         expect(ProjetMailer).to receive(:invitation_intervenant).and_call_original
         projet.contact_operateur!(operateur)
         expect(projet.invitations.count).to eq(1)
-        expect(projet.invited_operateur).to eq(operateur)
+        expect(projet.contacted_operateur).to eq(operateur)
       end
     end
 
@@ -361,7 +361,7 @@ describe Projet do
     end
 
     context "avec un opérateur invité auparavant" do
-      let(:projet) { create :projet, :prospect, :with_invited_operateur }
+      let(:projet) { create :projet, :prospect, :with_contacted_operateur }
 
       context "et un nouvel opérateur différent du précédent" do
         let(:new_operateur) { create :operateur }
@@ -371,17 +371,17 @@ describe Projet do
           expect(ProjetMailer).to receive(:resiliation_operateur).and_call_original
           projet.contact_operateur!(new_operateur)
           expect(projet.invitations.count).to eq(1)
-          expect(projet.invited_operateur).to eq(new_operateur)
+          expect(projet.contacted_operateur).to eq(new_operateur)
         end
       end
 
       context "et un nouvel opérateur identique au précédent" do
-        let(:operateur) { projet.invited_operateur }
+        let(:operateur) { projet.contacted_operateur }
 
         it "ne change rien" do
           projet.contact_operateur!(operateur)
           expect(projet.invitations.count).to eq 1
-          expect(projet.invited_operateur).to eq operateur
+          expect(projet.contacted_operateur).to eq operateur
         end
       end
     end
@@ -395,7 +395,7 @@ describe Projet do
         it "ne change rien et lève une exception" do
           expect { projet.contact_operateur!(new_operateur) }.to raise_error RuntimeError
           expect(projet.invitations.count).to eq 1
-          expect(projet.invited_operateur).to eq projet.operateur
+          expect(projet.contacted_operateur).to eq projet.operateur
         end
       end
 


### PR DESCRIPTION
Un opérateur voit maintenant la ligne d'un dossier quand cet opérateur a été recommandé sur ce dossier par un PRIS.

Quelques refactos en passant par là :)

![457](https://cloud.githubusercontent.com/assets/24429245/26057994/2b2218e2-397c-11e7-9926-00f5a9160224.gif)


 