### PR TITLE
Ajout d'une route pour déclencher une exception

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,6 +56,10 @@ class ApplicationController < ActionController::Base
     true
   end
 
+  def debug_exception
+    raise "Exception de test"
+  end
+
   # Routing ------------------------
 
   # Demandeurs access their projects through '/projets/' URLs;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,8 @@ Rails.application.routes.draw do
   get  '/patterns',                  to: 'patterns#index'
   get  '/patterns/forms',            to: 'patterns#forms'
 
+  get  '/debug_exception',           to: 'application#debug_exception'
+
   resources :contacts, only: [:index, :new, :create]
 
   require "sidekiq/web"


### PR DESCRIPTION
Pour déclencher une exception: accéder à la route `/debug_exception`

![error](https://cloud.githubusercontent.com/assets/24429245/26108355/88cbcc42-3a4c-11e7-9a7d-ea2fa142270f.gif)
