### PR TITLE
PF365 supprime le titre « Détail des travaux proposés »

### DIFF
--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -87,7 +87,7 @@ table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
         td.recap-projet-image-cell= image_tag "check.svg", alt: "Préconisé", id: "prestation_#{prestation.id}_recommended" if prestation_choice.recommended
         td.recap-projet-image-cell= image_tag "check.svg", alt: "Retenu",    id: "prestation_#{prestation.id}_selected"    if prestation_choice.selected
 
-h4 Détails travaux
+h4 Consommation énergétique
 table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
   tbody
     tr
@@ -109,6 +109,12 @@ table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
         th scope="row"= t('helpers.label.proposition.gain_energetique')
         td class='gain_energetique' = @projet_courant.gain_energetique
 
+h4 Plan de financement prévisionnel
+table.recap-projet-table border="0" cellpadding="0" cellspacing="0"
+  tbody
+    tr
+      th.empty scope="row"  &nbsp;
+      td Proposition
     - if @projet_courant.travaux_ht_amount.present?
       tr
         th scope="row"= t('helpers.label.proposition.travaux_ht_amount')

--- a/app/views/projets/proposition.html.slim
+++ b/app/views/projets/proposition.html.slim
@@ -97,11 +97,9 @@
                     td= check_box_tag "#{field_name}[selected]",    true, prestation.selected,     id: "prestation_#{prestation.id}_selected"
 
           fieldset
-            legend Détails des travaux proposés
+            legend Efficacité énergétique
             table.pp-table border="0" cellpadding="0" cellspacing="0" width="100%"
               tbody
-                tr
-                  th.tab-title colspan="3" scope="row" Efficacité énergétique
                 tr
                   th scope="row"
                     = f.label :consommation_apres_travaux, t('helpers.label.proposition.consommation_apres_travaux')
@@ -119,8 +117,11 @@
                   td
                     = f.text_field :gain_energetique
                     = " %"
-                tr
-                  th.tab-title colspan="3" scope="row" Plan de financement prévisionnel
+
+          fieldset
+            legend Plan de financement prévisionnel
+            table.pp-table border="0" cellpadding="0" cellspacing="0" width="100%"
+              tbody
                 tr
                   th scope="row"
                     = f.label :localized_travaux_ht_amount, t('helpers.label.proposition.travaux_ht_amount')


### PR DESCRIPTION
Comme [demandé par Céline](https://anah-produits.atlassian.net/browse/PF-365?focusedCommentId=13403&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13403) :

- Suppression du titre de section "détail des travaux proposés"
- Ajout d'un titre de section pour "Consommation énergétique"

### Formulaire

<img width="718" alt="capture d ecran 2017-05-17 a 11 13 19" src="https://cloud.githubusercontent.com/assets/179923/26146936/2ee56e62-3af2-11e7-8648-a5dc44e8267f.png">

### Fiche de synthèse

<img width="713" alt="capture d ecran 2017-05-17 a 11 13 01" src="https://cloud.githubusercontent.com/assets/179923/26146945/33c24fb8-3af2-11e7-9304-d1763c75dfba.png">
