### PR TITLE
Ajoute la personne de confiance dans les mails

### DIFF
--- a/app/mailers/projet_mailer.rb
+++ b/app/mailers/projet_mailer.rb
@@ -9,6 +9,7 @@ class ProjetMailer < ActionMailer::Base
     @pris = projet.invited_pris
     mail(
       to: projet.email,
+      cc: projet.personne.try(:email),
       subject: t('mailers.projet_mailer.recommandation_operateurs.sujet')
     )
   end
@@ -25,6 +26,7 @@ class ProjetMailer < ActionMailer::Base
     @invitation = invitation
     mail(
       to: invitation.projet.email,
+      cc: invitation.projet.personne.try(:email),
       subject: t('mailers.projet_mailer.notification_invitation_intervenant.sujet', intervenant: @invitation.intervenant.raison_sociale)
     )
   end
@@ -50,6 +52,7 @@ class ProjetMailer < ActionMailer::Base
     @projet = projet
     mail(
     to: @projet.email,
+    cc: @projet.personne.try(:email),
     subject: t('mailers.projet_mailer.notification_validation_dossier.sujet', intervenant: @projet.operateur.raison_sociale, demandeur: @projet.demandeur.fullname)
     )
   end
@@ -70,6 +73,7 @@ class ProjetMailer < ActionMailer::Base
     mail(
       from: projet.invited_instructeur.email,
       to: projet.email,
+      cc: projet.personne.try(:email),
       subject: t('mailers.projet_mailer.accuse_reception.sujet')
     )
   end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -6,6 +6,12 @@ FactoryGirl.define do
     association :adresse_postale,   factory: [ :adresse, :rue_de_rome ]
     association :adresse_a_renover, factory: [ :adresse, :rue_de_la_mare ]
 
+    trait :with_trusted_person do
+      after(:build) do |projet|
+        projet.personne = create :personne
+      end
+    end
+
     trait :with_avis_imposition do
       transient do
         declarants_count 1

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 describe ProjetMailer, type: :mailer do
   describe "notifie le demandeur que le PRIS lui recommande des opérateurs" do
-    let(:projet) { create :projet, :prospect, :with_suggested_operateurs, :with_invited_pris }
-    let(:email) { ProjetMailer.recommandation_operateurs(projet) }
+    let(:projet) { create :projet, :prospect, :with_suggested_operateurs, :with_invited_pris, :with_trusted_person }
+    let(:email)  { ProjetMailer.recommandation_operateurs(projet) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([projet.email]) }
+    it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.recommandation_operateurs.sujet')) }
     it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
     it { expect(email.body.encoded).to match(projet_choix_operateur_url(projet)) }
@@ -13,7 +14,7 @@ describe ProjetMailer, type: :mailer do
 
   describe "notifie l'opérateur de l'invitation du demandeur" do
     let(:invitation) { create :invitation }
-    let(:email) { ProjetMailer.invitation_intervenant(invitation) }
+    let(:email)      { ProjetMailer.invitation_intervenant(invitation) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([invitation.intervenant.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur: invitation.demandeur.fullname)) }
@@ -24,10 +25,12 @@ describe ProjetMailer, type: :mailer do
   end
 
   describe "notifie le demandeur qu'il a bien invité un opérateur " do
-    let(:invitation) { create :invitation }
-    let(:email) { ProjetMailer.notification_invitation_intervenant(invitation) }
+    let(:projet)     { create :projet, :prospect, :with_contacted_operateur, :with_invited_pris, :with_trusted_person }
+    let(:invitation) { projet.invitations.where(intervenant: projet.contacted_operateur).first }
+    let(:email)      { ProjetMailer.notification_invitation_intervenant(invitation) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
-    it { expect(email.to).to eq([invitation.projet.email]) }
+    it { expect(email.to).to eq([projet.email]) }
+    it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_invitation_intervenant.sujet', intervenant: invitation.intervenant.raison_sociale)) }
     it { expect(email.body.encoded).to match(invitation.intervenant.raison_sociale) }
     it { expect(email.body.encoded).to include("Un email vient d’être envoyé à ") }
@@ -35,7 +38,7 @@ describe ProjetMailer, type: :mailer do
 
   describe "notifie l'opérateur que le demandeur a choisi un autre opérateur" do
     let(:invitation) { create :invitation }
-    let(:email) { ProjetMailer.resiliation_operateur(invitation) }
+    let(:email)      { ProjetMailer.resiliation_operateur(invitation) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([invitation.intervenant.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur: invitation.demandeur.fullname)) }
@@ -43,10 +46,10 @@ describe ProjetMailer, type: :mailer do
   end
 
   describe "notifie l'intervenant qu'il a été choisi par le demandeur" do
-    let(:operateur) { create :operateur }
-    let(:projet) { create :projet, :prospect, operateur: operateur }
+    let(:operateur)   { create :operateur }
+    let(:projet)      { create :projet, :prospect, operateur: operateur }
     let!(:invitation) { create :invitation, projet: projet, intervenant: operateur }
-    let(:email) { ProjetMailer.notification_engagement_operateur(projet) }
+    let(:email)       { ProjetMailer.notification_engagement_operateur(projet) }
     it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
     it { expect(email.to).to eq([projet.operateur.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_engagement_operateur.sujet', intervenant: operateur.raison_sociale, demandeur: projet.demandeur.fullname)) }
@@ -55,11 +58,12 @@ describe ProjetMailer, type: :mailer do
    end
 
    describe "notifie le demandeur qu'il doit valider la proposition faite par l'opérateur" do
-     let(:projet)           { create :projet, :proposition_proposee }
-     let(:prestation)       { projet.prestations.first }
-     let(:email)            { ProjetMailer.notification_validation_dossier(projet) }
+     let(:projet)     { create :projet, :proposition_proposee, :with_trusted_person }
+     let(:prestation) { projet.prestations.first }
+     let(:email)      { ProjetMailer.notification_validation_dossier(projet) }
      it { expect(email.from).to eq([ENV['NO_REPLY_FROM']]) }
      it { expect(email.to).to eq([projet.email]) }
+     it { expect(email.cc).to eq([projet.personne.email]) }
      it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_validation_dossier.sujet')) }
      it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
      it { expect(email.body.encoded).to match(projet.operateur.raison_sociale) }
@@ -79,10 +83,11 @@ describe ProjetMailer, type: :mailer do
    end
 
   describe "notifie le demandeur que sa demande a été transmise au service instructeur" do
-    let(:projet) { create :projet, :transmis_pour_instruction }
+    let(:projet) { create :projet, :transmis_pour_instruction, :with_trusted_person }
     subject(:email) { ProjetMailer.accuse_reception(projet) }
     it { expect(email.from).to eq([projet.invited_instructeur.email]) }
     it { expect(email.to).to eq([projet.email]) }
+    it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.accuse_reception.sujet')) }
     it { expect(email.body).to include(projet.demandeur.fullname) }
     it { expect(email.body).to include(projet.plateforme_id) }


### PR DESCRIPTION
Quand l'adresse email de la personne de confiance est renseigné, cette personne reçoit aussi les emails envoyés par l'appli

<img width="515" alt="capture d ecran 2017-05-22 a 17 43 28" src="https://cloud.githubusercontent.com/assets/24429245/26316941/3200c93e-3f16-11e7-93df-bbe1cf3d9e11.png">
