### PR TITLE
BSR ajout d’un bouton de contact sur toutes les pages

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,4 +1,4 @@
 $color-primary: #435C70 !default;
+$color-steel:   #008CBA !default;
 
 $font-color: $color-primary;
-

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -30,6 +30,7 @@
 @import "patterns-icon-list";
 @import "section";
 @import "reliable-person";
+@import "help";
 
 @import "col-menu";
 @import "col-projet";

--- a/app/assets/stylesheets/help.scss
+++ b/app/assets/stylesheets/help.scss
@@ -7,25 +7,26 @@
 .help__button {
   display: inline-block;
   color: white;
-  background-color: #E00648;
+  background-color: $color-steel;
   width: 66px;
   height: 66px;
-  line-height: 66px;
-  border-radius: 33px;
   margin-left: 15px;
   margin-bottom: 15px;
-  box-shadow: 0px 2px 3px #62042ECC;
+  border-radius: 33px;
+  box-shadow: 0px 2px 4px -1px darken($color-steel, 30);
+  line-height: 66px;
   text-align: center;
   font-size: 30px;
   font-weight: bold;
+  text-shadow: 0px -1px 0 rgba(0, 0, 0, 0.2);
 
   transition: transform 0.1s, box-shadow 0.1s;
 
   &:hover, &:active {
     transform: scale(1.15);
-    box-shadow: 0px 2px 5px #62042ECC;
+    box-shadow: 0px 2px 6px -1px darken($color-steel, 30);
   }
   &:focus {
-    background-color: #B00648;
+    background-color: darken($color-steel, 10);
   }
 }

--- a/app/assets/stylesheets/help.scss
+++ b/app/assets/stylesheets/help.scss
@@ -1,7 +1,7 @@
 .help__container {
   position: fixed;
   bottom: 0;
-  right: 0;
+  left: 0;
 }
 
 .help__button {
@@ -12,7 +12,7 @@
   height: 66px;
   line-height: 66px;
   border-radius: 33px;
-  margin-right: 15px;
+  margin-left: 15px;
   margin-bottom: 15px;
   box-shadow: 0px 2px 3px #62042ECC;
   text-align: center;

--- a/app/assets/stylesheets/help.scss
+++ b/app/assets/stylesheets/help.scss
@@ -1,0 +1,31 @@
+.help__container {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+}
+
+.help__button {
+  display: inline-block;
+  color: white;
+  background-color: #E00648;
+  width: 66px;
+  height: 66px;
+  line-height: 66px;
+  border-radius: 33px;
+  margin-right: 15px;
+  margin-bottom: 15px;
+  box-shadow: 0px 2px 3px #62042ECC;
+  text-align: center;
+  font-size: 30px;
+  font-weight: bold;
+
+  transition: transform 0.1s, box-shadow 0.1s;
+
+  &:hover, &:active {
+    transform: scale(1.15);
+    box-shadow: 0px 2px 5px #62042ECC;
+  }
+  &:focus {
+    background-color: #B00648;
+  }
+}

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -117,7 +117,7 @@ fieldset {
   height: 30px;
   text-align: center;
   text-transform: uppercase;
-  background-color: #008cba;
+  background-color: $color-steel;
   color: white;
   padding: 5px;
   font-size: 15px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,11 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  def initialize
+    super
+    @display_help = true
+  end
+
   def after_sign_in_path_for(resource)
     if projet_id = session[:projet_id_from_opal]
       projet_or_dossier_path(Projet.find_by_id(projet_id))

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -8,7 +8,7 @@ class ContactsController < ApplicationController
   def new
     @contact = Contact.new
     @contact.subject = "J’ai une question…" if @contact.subject.blank?
-    @page_heading = "Demande de contact"
+    render_new
   end
 
   def create
@@ -18,7 +18,14 @@ class ContactsController < ApplicationController
       ContactMailer.contact(@contact).deliver_later!
       return redirect_to(new_contact_path), notice: "Votre message a bien été envoyé"
     end
+    render_new
+  end
+
+private
+
+  def render_new
     @page_heading = "Demande de contact"
+    @display_help = false
     render :new
   end
 end

--- a/app/views/contacts/new.html.slim
+++ b/app/views/contacts/new.html.slim
@@ -1,3 +1,4 @@
+h3 Un problème, une question ? Contactez nous !
 = simple_form_for @contact, html: { class: "form form-with-alerts form-contact" } do |f|
   = render "shared/errors", resource: @contact
   = f.input :name, wrapper_html: { class: "size-m" }, required: true
@@ -5,5 +6,4 @@
   = f.input :phone, wrapper_html: { class: "size-m" }
   = f.input :subject, required: true
   = f.input :description, input_html: { cols: 40, rows: 6 }
-  = btn name: t("helpers.submit.defaults.send"), class: "btn-large", icon: "ok"
-
+  = btn name: t("helpers.submit.defaults.send"), class: "btn-large", icon: "send"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -31,3 +31,5 @@ html lang="fr"
           /= link_to t("menu.contact"), new_contact_path
     = yield :popins
 
+    - if @display_help
+      = render 'shared/help'

--- a/app/views/shared/_help.html.slim
+++ b/app/views/shared/_help.html.slim
@@ -1,2 +1,2 @@
 div.help__container
-  = link_to t("help.button.label"), new_contact_path, class: "help__button", title: t("help.button.tooltip")
+  = link_to t("help.button.label"), new_contact_path, class: "help__button", title: t("help.button.tooltip"), target: :_blank

--- a/app/views/shared/_help.html.slim
+++ b/app/views/shared/_help.html.slim
@@ -1,0 +1,2 @@
+div.help__container
+  = link_to t("help.button.label"), new_contact_path, class: "help__button", title: t("help.button.tooltip")

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -396,10 +396,18 @@ fr:
       explication_html: "<b>Choisir un intervenant vous engage</b><p>L’opérateur est chargé de vous conseiller tout au long de la démarche. Il vous accompagne danss l’élaboration de votre projet de travaux et la constitution de votre dossier de demande de subvention.</p><p>Lorsqu’une subvention vous est accordée, l’opérateur vous accompagne jusqu’au paiement de la subvention.</p><p>Cette prestation payante peut être totalement ou opartiellement couverte par le complément de subvention qui complète la subvention pour travaux"
       action: "Je choisis cet opérateur"
 
+  # --------------------------- Admin --------------------------------
+
   admin:
     intervenants:
       importer_fichier: "Importer le fichier"
       import_reussi: "Les intervenants ont été importés."
+
+  # ---------------------------- Aide --------------------------------
+  help:
+    button:
+      label: "?"
+      tooltip: "Un problème, une question ? Demandez de l’aide !"
 
   # ---------------------- Active Record -----------------------------
   activerecord:


### PR DESCRIPTION
Le bouton de contact redirige vers la page du formulaire de contact.
Une amélioration future pourra être d’afficher le formulaire de
contact directement sur la page.

Détail : la page de contact elle-même n’affiche pas le bouton – vu que
cela redirigerait vers la même page. C’est contrôlé par une variable
d’instance `@display_help` sur les contrôleurs.

![bouton-aide](https://cloud.githubusercontent.com/assets/179923/26356777/73eee30a-3fcd-11e7-9e44-48211365d8a9.gif)
