### PR TITLE
PF416 pré-remplit le nom du demandeur lors d’un déclarant unique

### DIFF
--- a/app/views/demandeurs/show.html.slim
+++ b/app/views/demandeurs/show.html.slim
@@ -6,7 +6,7 @@
       .js-demandeur-civility
         = f.fields_for @demandeur do |ff|
           = ff.input :civility, as: :radio_buttons, collection: Occupant::CIVILITIES, required: true
-      = f.input :demandeur, collection: @declarants, selected: @projet_courant.demandeur.try(:id), wrapper_html: { class: "size-m" }, required: true, prompt: @declarants_prompt
+      = f.input :demandeur, collection: @declarants, selected: @projet_courant.demandeur.try(:id), wrapper_html: { class: "size-m" }, prompt: @declarants_prompt, required: @declarants_prompt.present?
       = f.input :adresse_postale, as: :string, input_html: { value: @projet_courant.adresse_postale.try(:description) }
       = f.input :adresse_a_renover, as: :string, input_html: { value: @projet_courant.adresse_a_renover.try(:description)}
       = f.input :tel, wrapper_html: { class: "size-s" }


### PR DESCRIPTION
Lorsqu’il y a plusieurs déclarants, on force l’utilisateur à choisir
explicitement le demandeur.

En revanche, lorsqu’il n’y a qu’un seul déclarant, on doit pré-remplir
le nom du demandeur. Le passage à simple_form a cassé ce comportement.

Cette PR rétablit la pré-présélection du demandeur lorsqu’il n’y a qu’un
seul déclarant.

![demandeur](https://cloud.githubusercontent.com/assets/179923/26361830/77b5cf4e-3fdc-11e7-81a3-509137c5dcf3.gif)
