### PR TITLE
PF571 fix les pages d’erreur

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module Mpal
     config.active_job.queue_adapter = ENV['SIDEKIQ_DISABLED'] == 'true' ? :inline : :sidekiq
 
     config.autoload_paths += %W(#{config.root}/lib)
+
+    # Serve error pages from the Rails app itself
+    config.exceptions_app = self.routes
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,8 +90,8 @@ Rails.application.routes.draw do
 
   resources :contacts, only: [:index, :new, :create]
 
-  get "/404", to: "errors#not_found"
-  get "/500", to: "errors#internal_server_error"
+  match "/404", via: :all, to: "errors#not_found"
+  match "/500", via: :all, to: "errors#internal_server_error"
 
   require "sidekiq/web"
   Sidekiq::Web.use Rack::Auth::Basic do |username, password|


### PR DESCRIPTION
Les pages d’erreur n’étaient pas activées, il manquait un élément dans la config.