### PR TITLE
BSR supprime les utilisateurs lors du reset de base

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -5,6 +5,7 @@ class ToolsController < ApplicationController
       Demande.destroy_all
       Occupant.destroy_all
       Projet.destroy_all
+      User.destroy_all
       reset_session
       redirect_to root_path, notice: t('reinitialisation.succes')
     else


### PR DESCRIPTION
Ça permet de créer à nouveau des utilisateurs avec les me^mes adresses emails qu'avant le reset.

@qcattez tu peux 👓  ?