### PR TITLE
BSR valide l’unicité de l’email dès la 1ère page

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -61,7 +61,7 @@ class Projet < ActiveRecord::Base
 
   validates :numero_fiscal, :reference_avis, presence: true
   validates :tel, phone: { :minimum => 10, :maximum => 12 }, allow_blank: true
-  validates :email, email: true, presence: true, on: :update
+  validates :email, email: true, presence: true, uniqueness: { case_sensitive: false }, on: :update
   validates :adresse_postale, presence: true, on: :update
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true
   validates :date_de_visite, :assiette_subventionnable_amount, presence: { message: :blank_feminine }, on: :proposition

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -11,6 +11,7 @@ describe Projet do
     it { is_expected.not_to validate_presence_of(:adresse_postale).on(:create) }
     it { is_expected.to validate_presence_of(:adresse_postale).on(:update) }
     it { is_expected.to validate_presence_of(:email).on(:update) }
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive.on(:update) }
     it { is_expected.not_to validate_presence_of(:tel) }
     it { is_expected.not_to validate_presence_of(:date_de_visite) }
     it { is_expected.to validate_presence_of(:date_de_visite).with_message(:blank_feminine).on(:proposition) }


### PR DESCRIPTION
Aujourd'hui je peux :

- Créer un dossier
- Mettre un email sur la page 1
- Aller jusqu'à la page 4
- Mettre un mot de passe
- Prendre une erreur parce qu'un utilisateur avec cet email existe déjà

Cette PR vérifie l'unicité de l'email dès la page 1, pour éviter qu'on se prenne une erreur plus tard.

<img width="574" alt="capture d ecran 2017-05-31 a 17 48 48" src="https://cloud.githubusercontent.com/assets/179923/26640934/6e7735f0-4629-11e7-9165-534541ad6593.png">
