### PR TITLE
BSR valide l’unicité de l’email dès la 1ère page

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -62,7 +62,7 @@ class Projet < ActiveRecord::Base
 
   validates :numero_fiscal, :reference_avis, presence: true
   validates :tel, phone: { :minimum => 10, :maximum => 12 }, allow_blank: true
-  validates :email, email: true, presence: true, on: :update
+  validates :email, email: true, presence: true, uniqueness: { case_sensitive: false }, on: :update
   validates :adresse_postale, presence: true, on: :update
   validates :note_degradation, :note_insalubrite, :inclusion => 0..1, allow_nil: true
   validates :date_de_visite, :assiette_subventionnable_amount, presence: { message: :blank_feminine }, on: :proposition

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -162,10 +162,10 @@ describe DossiersController do
         let(:other_department_project) { create :projet, :en_cours }
 
         before do
-          create :projet, :proposition_proposee, agent_instructeur: current_agent
-          create :projet, :proposition_enregistree
-          create :projet, :en_cours_d_instruction
-          create :projet, :transmis_pour_instruction
+          create :projet, :proposition_proposee, agent_instructeur: current_agent, email: "prenom.nom2@site.com"
+          create :projet, :proposition_enregistree,   email: "prenom.nom3@site.com"
+          create :projet, :en_cours_d_instruction,    email: "prenom.nom4@site.com"
+          create :projet, :transmis_pour_instruction, email: "prenom.nom5@site.com"
           other_department_project.adresse.update(departement: "03")
         end
 
@@ -184,8 +184,8 @@ describe DossiersController do
       let(:siege)         { create :siege }
       let(:current_agent) { create :agent, :siege, intervenant: siege }
       let(:projet_01)     { create :projet, :proposition_proposee }
-      let(:projet_34)     { create :projet, :en_cours }
-      let(:projet_56)     { create :projet, :en_cours }
+      let(:projet_34)     { create :projet, :en_cours, email: "prenom.nom2@site.com" }
+      let(:projet_56)     { create :projet, :en_cours, email: "prenom.nom3@site.com" }
 
       before do
         projet_01.adresse.update(departement: "01")

--- a/spec/features/indicateurs_spec.rb
+++ b/spec/features/indicateurs_spec.rb
@@ -53,22 +53,22 @@ feature "Affichage de la page Indicateurs" do
   let(:agent_siege) { create :agent, :siege, intervenant: siege }
 
   let!(:projet1) { create :projet, :en_cours }
-  let!(:projet2) { create :projet, :transmis_pour_instruction }
-  let!(:projet3) { create :projet, :en_cours_d_instruction }
+  let!(:projet2) { create :projet, :transmis_pour_instruction, email: "prenom.nom2@site.com" }
+  let!(:projet3) { create :projet, :en_cours_d_instruction, email: "prenom.nom3@site.com" }
 
   before do
     login_as current_agent, scope: :agent
-    create :projet, :prospect
-    create :projet, :prospect
-    create :projet, :prospect
-    create :projet, :en_cours
-    create :projet, :en_cours
-    create :projet, :en_cours
-    create :projet, :en_cours
-    create :projet, :proposition_enregistree
-    create :projet, :proposition_proposee
-    create :projet, :en_cours_d_instruction
-    create :projet, :en_cours_d_instruction
+    create :projet, :prospect,                email: "prenom.nom4@site.com"
+    create :projet, :prospect,                email: "prenom.nom5@site.com"
+    create :projet, :prospect,                email: "prenom.com6@site.com"
+    create :projet, :en_cours,                email: "prenom.nom7@site.com"
+    create :projet, :en_cours,                email: "prenom.nom8@site.com"
+    create :projet, :en_cours,                email: "prenom.nom9@site.com"
+    create :projet, :en_cours,                email: "prenom.nom10@site.com"
+    create :projet, :proposition_enregistree, email: "prenom.nom11@site.com"
+    create :projet, :proposition_proposee,    email: "prenom.nom12@site.com"
+    create :projet, :en_cours_d_instruction,  email: "prenom.nom13@site.com"
+    create :projet, :en_cours_d_instruction,  email: "prenom.nom14@site.com"
     projet1.adresse.update(departement: "03")
     projet2.adresse.update(departement: "23")
     projet3.adresse.update(departement: "35")

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -14,8 +14,8 @@ end
 
 feature "Réinitialisation de la session :" do
   let(:projet) {          create :projet, :prospect }
-  let(:invitation) {      create :invitation }
   let(:operateur) {       create :operateur, departements: [projet.departement] }
+  let(:invitation) {      create :invitation, projet: projet, intervenant: operateur }
   let(:agent_operateur) { create :agent, intervenant: operateur }
 
   context "en tant que demandeur" do

--- a/spec/jobs/evenement_enregistreur_spec.rb
+++ b/spec/jobs/evenement_enregistreur_spec.rb
@@ -1,20 +1,21 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe EvenementEnregistreurJob do
-let!(:projet) { FactoryGirl.create(:projet) }
-  it 'enregistre un evenement' do
-    expect{ subject.perform(label: 'creation_projet', projet: projet) }.to change{ Evenement.count }.by(1)
+  let(:invitation) { create :invitation }
+  let(:projet) {     invitation.projet }
+
+  it "enregistre un évènement" do
+    expect{ subject.perform(label: "creation_projet", projet: projet) }.to change{ Evenement.count }.by(1)
   end
 
-  it 'enregistre une invitation' do
-    invitation = FactoryGirl.create(:invitation)
-    expect{ subject.perform(label: 'invitation_intervenant', projet: invitation.projet, producteur: invitation) }
+  it "enregistre une invitation" do
+    expect{ subject.perform(label: "invitation_intervenant", projet: projet, producteur: invitation) }
       .to change{ Evenement.count }.by(1)
   end
 
-  it "enregistre la transmission d'un dossier aux services instructeurs" do
-    invitation = FactoryGirl.create(:invitation)
-    expect{ subject.perform(label: 'transmis_instructeur', projet: invitation.projet, producteur: invitation) }
+  it "enregistre la transmission d’un dossier aux services instructeurs" do
+    expect{ subject.perform(label: "transmis_instructeur", projet: projet, producteur: invitation) }
       .to change{ Evenement.count }.by(1)
   end
 end
+

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -11,6 +11,7 @@ describe Projet do
     it { is_expected.not_to validate_presence_of(:adresse_postale).on(:create) }
     it { is_expected.to validate_presence_of(:adresse_postale).on(:update) }
     it { is_expected.to validate_presence_of(:email).on(:update) }
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive.on(:update) }
     it { is_expected.not_to validate_presence_of(:tel) }
     it { is_expected.not_to validate_presence_of(:date_de_visite) }
     it { is_expected.to validate_presence_of(:date_de_visite).with_message(:blank_feminine).on(:proposition) }


### PR DESCRIPTION
Note : reprise de la PR de @kemenaran que je ne pouvais pas modifier (et où les tests étaient rouge).

Aujourd'hui je peux :
- Créer un dossier
- Mettre un email sur la page 1
- Aller jusqu'à la page 4
- Mettre un mot de passe
- Prendre une erreur parce qu'un utilisateur avec cet email existe déjà

Cette PR vérifie l'unicité de l'email dès la page 1, pour éviter qu'on se prenne une erreur plus tard.

<img width="574" alt="pr387" src="https://cloud.githubusercontent.com/assets/2368859/26755205/fcbf0ab6-4888-11e7-8ab0-664120503a14.png">