### PR TITLE
PF520 les instructeurs voient les dossiers sur lesquels ils sont affectés

### DIFF
--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -86,7 +86,7 @@ class Projet < ActiveRecord::Base
   scope :with_demandeur, -> { joins(:occupants).where('occupants.demandeur = true').distinct  }
   scope :for_agent, ->(agent) {
     if agent.instructeur?
-      with_demandeur
+      joins(:intervenants).where('intervenants.id = ?', agent.intervenant_id).group('projets.id').with_demandeur
     elsif agent.siege?
       all
     else

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -159,21 +159,25 @@ describe Projet do
     let!(:invitation2)      { create :invitation, intervenant: operateur1, projet: projet2 }
     let!(:invitation3)      { create :invitation, intervenant: operateur2, projet: projet3 }
 
-    before { projet4.suggest_operateurs! [operateur4.id] }
+    before do
+      projet3.invite_instructeur! instructeur
+      projet4.invite_instructeur! instructeur
+      projet4.suggest_operateurs! [operateur4.id]
+    end
 
     describe "un opérateur voit les projets sur lesquels il est affecté ou recommandé" do
-      it { expect(Projet.for_agent(agent_operateur1).length).to eq(2) }
-      it { expect(Projet.for_agent(agent_operateur2).length).to eq(1) }
-      it { expect(Projet.for_agent(agent_operateur3).length).to eq(0) }
-      it { expect(Projet.for_agent(agent_operateur4).length).to eq(1) }
+      it { expect(Projet.for_agent(agent_operateur1).length).to eq 2 }
+      it { expect(Projet.for_agent(agent_operateur2).length).to eq 1 }
+      it { expect(Projet.for_agent(agent_operateur3).length).to eq 0 }
+      it { expect(Projet.for_agent(agent_operateur4).length).to eq 1 }
     end
 
     it "un instructeur voit tous les projets avec un demandeur" do
-      expect(Projet.for_agent(agent_instructeur)).to include(projet1)
-      expect(Projet.for_agent(agent_instructeur)).to include(projet2)
-      expect(Projet.for_agent(agent_instructeur)).to include(projet3)
-      expect(Projet.for_agent(agent_instructeur)).to include(projet4)
-      expect(Projet.for_agent(agent_instructeur)).not_to include(projet5)
+      expect(Projet.for_agent(agent_instructeur)).not_to include projet1
+      expect(Projet.for_agent(agent_instructeur)).not_to include projet2
+      expect(Projet.for_agent(agent_instructeur)).to     include projet3
+      expect(Projet.for_agent(agent_instructeur)).to     include projet4
+      expect(Projet.for_agent(agent_instructeur)).not_to include projet5
     end
   end
 


### PR DESCRIPTION
**Avant** : les instructeurs avaient sur leur export CSV tous les projets (nationalement) avec des demandeurs

**Après** : les instructeurs ont sur leur export CSV tous leurs projets avec des demandeurs