### PR TITLE
FIX utilise toujours EMAIL_CONTACT comme émetteur

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -319,7 +319,7 @@ GEM
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.1)
     slim (3.0.7)
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)

--- a/app/mailers/projet_mailer.rb
+++ b/app/mailers/projet_mailer.rb
@@ -34,8 +34,8 @@ class ProjetMailer < ActionMailer::Base
   def resiliation_operateur(invitation)
     @invitation = invitation
     mail(
-    to: invitation.intervenant.email,
-    subject: t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur: @invitation.demandeur.fullname)
+      to: invitation.intervenant.email,
+      subject: t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur: @invitation.demandeur.fullname)
     )
   end
 
@@ -43,25 +43,25 @@ class ProjetMailer < ActionMailer::Base
     @projet = projet
     @invitation = @projet.invitations.find_by_intervenant_id(projet.operateur_id)
     mail(
-    to: @projet.operateur.email,
-    subject: t('mailers.projet_mailer.notification_engagement_operateur.sujet', intervenant: @projet.operateur.raison_sociale, demandeur: @projet.demandeur.fullname)
+      to: @projet.operateur.email,
+      subject: t('mailers.projet_mailer.notification_engagement_operateur.sujet', intervenant: @projet.operateur.raison_sociale, demandeur: @projet.demandeur.fullname)
     )
   end
 
   def notification_validation_dossier(projet)
     @projet = projet
     mail(
-    to: @projet.email,
-    cc: @projet.personne.try(:email),
-    subject: t('mailers.projet_mailer.notification_validation_dossier.sujet', intervenant: @projet.operateur.raison_sociale, demandeur: @projet.demandeur.fullname)
+      to: @projet.email,
+      cc: @projet.personne.try(:email),
+      subject: t('mailers.projet_mailer.notification_validation_dossier.sujet', intervenant: @projet.operateur.raison_sociale, demandeur: @projet.demandeur.fullname)
     )
   end
 
   def mise_en_relation_intervenant(invitation)
     @invitation = invitation
     mail(
-    to: invitation.intervenant.email,
-    subject: t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: @invitation.intermediaire.raison_sociale)
+      to: invitation.intervenant.email,
+      subject: t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: @invitation.intermediaire.raison_sociale)
     )
   end
 
@@ -71,7 +71,7 @@ class ProjetMailer < ActionMailer::Base
     @instructeur = projet.invited_instructeur
     @date_depot = projet.date_depot
     mail(
-      from: projet.invited_instructeur.email,
+      reply_to: projet.invited_instructeur.email,
       to: projet.email,
       cc: projet.personne.try(:email),
       subject: t('mailers.projet_mailer.accuse_reception.sujet')

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -4,6 +4,7 @@ describe ProjetMailer, type: :mailer do
   describe "notifie le demandeur que le PRIS lui recommande des opérateurs" do
     let(:projet) { create :projet, :prospect, :with_suggested_operateurs, :with_invited_pris, :with_trusted_person }
     let(:email)  { ProjetMailer.recommandation_operateurs(projet) }
+
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
@@ -15,6 +16,7 @@ describe ProjetMailer, type: :mailer do
   describe "notifie l'opérateur de l'invitation du demandeur" do
     let(:invitation) { create :invitation }
     let(:email)      { ProjetMailer.invitation_intervenant(invitation) }
+
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([invitation.intervenant.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur: invitation.demandeur.fullname)) }
@@ -28,6 +30,7 @@ describe ProjetMailer, type: :mailer do
     let(:projet)     { create :projet, :prospect, :with_contacted_operateur, :with_invited_pris, :with_trusted_person }
     let(:invitation) { projet.invitations.where(intervenant: projet.contacted_operateur).first }
     let(:email)      { ProjetMailer.notification_invitation_intervenant(invitation) }
+
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
@@ -39,6 +42,7 @@ describe ProjetMailer, type: :mailer do
   describe "notifie l'opérateur que le demandeur a choisi un autre opérateur" do
     let(:invitation) { create :invitation }
     let(:email)      { ProjetMailer.resiliation_operateur(invitation) }
+
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([invitation.intervenant.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur: invitation.demandeur.fullname)) }
@@ -50,42 +54,47 @@ describe ProjetMailer, type: :mailer do
     let(:projet)      { create :projet, :prospect, operateur: operateur }
     let!(:invitation) { create :invitation, projet: projet, intervenant: operateur }
     let(:email)       { ProjetMailer.notification_engagement_operateur(projet) }
+
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([projet.operateur.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_engagement_operateur.sujet', intervenant: operateur.raison_sociale, demandeur: projet.demandeur.fullname)) }
     it { expect(email.body.encoded).to match(invitation.demandeur.fullname) }
     it { expect(email.body.encoded).to include(dossier_url(projet)) }
-   end
+  end
 
-   describe "notifie le demandeur qu'il doit valider la proposition faite par l'opérateur" do
-     let(:projet)     { create :projet, :proposition_proposee, :with_trusted_person }
-     let(:prestation) { projet.prestations.first }
-     let(:email)      { ProjetMailer.notification_validation_dossier(projet) }
-     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
-     it { expect(email.to).to eq([projet.email]) }
-     it { expect(email.cc).to eq([projet.personne.email]) }
-     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_validation_dossier.sujet')) }
-     it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
-     it { expect(email.body.encoded).to match(projet.operateur.raison_sociale) }
-     it { expect(email.body).to include("a complété votre dossier") }
-   end
+  describe "notifie le demandeur qu'il doit valider la proposition faite par l'opérateur" do
+    let(:projet)     { create :projet, :proposition_proposee, :with_trusted_person }
+    let(:prestation) { projet.prestations.first }
+    let(:email)      { ProjetMailer.notification_validation_dossier(projet) }
 
-   describe "notifie l'instructeur qu'un opérateur lui a transmis un dossier" do
-     let(:projet)           { create :projet, :transmis_pour_instruction }
-     let(:mise_en_relation) { create :mise_en_relation, projet: projet }
-     let(:prestation)       { projet.prestations.first }
-     let(:email)            { ProjetMailer.mise_en_relation_intervenant(mise_en_relation) }
-     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
-     it { expect(email.to).to eq([mise_en_relation.intervenant.email]) }
-     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: mise_en_relation.intermediaire.raison_sociale)) }
-     it { expect(email.body.encoded).to match(mise_en_relation.description_adresse) }
-     it { expect(email.body).to include(prestation.libelle) }
-   end
+    it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
+    it { expect(email.to).to eq([projet.email]) }
+    it { expect(email.cc).to eq([projet.personne.email]) }
+    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_validation_dossier.sujet')) }
+    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
+    it { expect(email.body.encoded).to match(projet.operateur.raison_sociale) }
+    it { expect(email.body).to include("a complété votre dossier") }
+  end
+
+  describe "notifie l'instructeur qu'un opérateur lui a transmis un dossier" do
+    let(:projet)           { create :projet, :transmis_pour_instruction }
+    let(:mise_en_relation) { create :mise_en_relation, projet: projet }
+    let(:prestation)       { projet.prestations.first }
+    let(:email)            { ProjetMailer.mise_en_relation_intervenant(mise_en_relation) }
+
+    it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
+    it { expect(email.to).to eq([mise_en_relation.intervenant.email]) }
+    it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: mise_en_relation.intermediaire.raison_sociale)) }
+    it { expect(email.body.encoded).to match(mise_en_relation.description_adresse) }
+    it { expect(email.body).to include(prestation.libelle) }
+  end
 
   describe "notifie le demandeur que sa demande a été transmise au service instructeur" do
     let(:projet) { create :projet, :transmis_pour_instruction, :with_trusted_person }
     subject(:email) { ProjetMailer.accuse_reception(projet) }
-    it { expect(email.from).to eq([projet.invited_instructeur.email]) }
+
+    it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
+    it { expect(email.reply_to).to eq([projet.invited_instructeur.email]) }
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.accuse_reception.sujet')) }
@@ -94,5 +103,6 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.body).to include(projet.invited_instructeur.raison_sociale) }
     it { expect(email.body).to include(projet.invited_instructeur.description_adresse) }
     it { expect(email.body).to include(projet.invited_instructeur.email) }
-   end
+  end
 end
+


### PR DESCRIPTION
Mailjet demande la validation systématique de l’adresse e-mail lorsqu’elle est utilisée comme expéditeur. La pratique recommandée est de jouer sur le header "reply-to".