### PR TITLE
PF603 sépare l'éligibilité de la mise en relation

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,8 +1,14 @@
-$color-primary: #435C70 !default;
-$color-steel:   #008CBA !default;
-$color-red:     #D9184E !default;
-$color-light-grey: #EEF1F7 !default;
-$color-black:   #111 !default;
+$color-primary:       #435C70 !default;
+$color-steel:         #008CBA !default;
+$color-red:           #D9184E !default;
+$color-light-grey:    #EEF1F7 !default;
+$color-black:         #111    !default;
+$color-light-green:   #B6E89F !default;
+$color-dark-green:    #1C5D1D !default;
+$color-light-yellow:  #EAE5A3 !default;
+$color-brown:         #764C11 !default;
+$color-light-red:     #E89D9A !default;
+$color-dark-red:      #851B0D !default;
 
 $font-color: $color-primary;
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -21,6 +21,7 @@
 @import "alert";
 @import "buttons";
 @import "dashboards";
+@import "eligibility";
 @import "forms";
 @import "glyphicons";
 @import "imposition";

--- a/app/assets/stylesheets/eligibility.scss
+++ b/app/assets/stylesheets/eligibility.scss
@@ -1,0 +1,84 @@
+@import "variables";
+
+.eligibility__heading {
+  background-color: $color-light-grey;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+  font-size: 18px;
+  font-weight: bold;
+  color: $font-color;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
+  padding: 15px 30px;
+}
+.eligibility__content {
+  @media screen and (min-width: 600px) {
+    padding: 0.75em;
+  }
+  @media screen and (min-width: 920px) {
+    padding: 1.25em;
+  }
+}
+
+.eligibility__positive {
+  @media screen and (min-width: 600px) {
+    margin: 0.75em;
+  }
+  @media screen and (min-width: 920px) {
+    margin: 1.25em;
+  }
+  display: flex;
+  align-items: center;
+  border-radius: 0.5em;
+  padding: 1em;
+  color: $color-black;
+  background-color: $color-light-green;
+}
+.eligibility__negative {
+  @media screen and (min-width: 600px) {
+    margin: 0.75em;
+  }
+  @media screen and (min-width: 920px) {
+    margin: 1.25em;
+  }
+  display: flex;
+  align-items: center;
+  border-radius: 0.5em;
+  padding: 1em;
+  color: $color-black;
+  background-color: $color-light-red;
+}
+.eligibility__conditions {
+  @media screen and (min-width: 600px) {
+    margin: 0.75em;
+  }
+  @media screen and (min-width: 920px) {
+    margin: 1.25em;
+  }
+  display: flex;
+  align-items: center;
+  border-radius: 0.5em;
+  padding: 1em;
+  color: $color-black;
+  background-color: $color-light-yellow;
+}
+
+.eligibility__icon-positive {
+  color: $color-dark-green;
+  margin: 1em;
+}
+.eligibility__icon-negative {
+  color: $color-dark-red;
+  margin: 1em;
+}
+.eligibility__icon-conditions {
+  color: $color-brown;
+  margin: 1em;
+}
+
+.eligibility__answer {
+  color: $color-black;
+  margin: 1em;
+}
+.eligibility__link {
+  color: $color-brown;
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/inscription.scss
+++ b/app/assets/stylesheets/inscription.scss
@@ -239,7 +239,3 @@
     }
   }
 }
-
-.assignement-pris {
-  margin-top: 1em;
-}

--- a/app/controllers/demandes_controller.rb
+++ b/app/controllers/demandes_controller.rb
@@ -68,9 +68,9 @@ private
 
   def redirect_to_next_step
     if needs_next_step?
-      redirect_to new_user_registration_path
+      redirect_to projet_eligibility_path @projet_courant
     else
-      redirect_to projet_or_dossier_path(@projet_courant)
+      redirect_to projet_or_dossier_path @projet_courant
     end
   end
 end

--- a/app/controllers/eligibilities_controller.rb
+++ b/app/controllers/eligibilities_controller.rb
@@ -1,0 +1,9 @@
+class EligibilitiesController < ApplicationController
+  layout 'inscription'
+
+  before_action :assert_projet_courant
+
+  def show
+    @eligible = @projet_courant.preeligibilite(@projet_courant.annee_fiscale_reference) != :plafond_depasse
+  end
+end

--- a/app/controllers/mises_en_relation_controller.rb
+++ b/app/controllers/mises_en_relation_controller.rb
@@ -5,7 +5,7 @@ class MisesEnRelationController < ApplicationController
 
   def show
     @demande = @projet_courant.demande
-    @non_eligible = @projet_courant.preeligibilite(@projet_courant.annee_fiscale_reference) == :plafond_depasse
+    @not_eligible = @projet_courant.preeligibilite(@projet_courant.annee_fiscale_reference) == :plafond_depasse
     fetch_intervenants_and_operations
     if @pris.blank?
       Rails.logger.error "Il n’y a pas de PRIS disponible pour le département #{@projet_courant.departement} (projet_id: #{@projet_courant.id})"
@@ -17,7 +17,7 @@ class MisesEnRelationController < ApplicationController
 
   def update
     begin
-      @projet_courant.update_attribute(:disponibilite, params[:projet][:disponibilite])
+      @projet_courant.update_attribute(:disponibilite, params[:projet][:disponibilite]) if params[:projet].present?
       fetch_intervenants_and_operations
       unless @projet_courant.intervenants.include?(@pris) || (@operations.count == 1 && @operateurs.count == 1)
         @projet_courant.invite_pris!(@pris)

--- a/app/views/eligibilities/show.html.slim
+++ b/app/views/eligibilities/show.html.slim
@@ -1,0 +1,17 @@
+.eligibility
+  h2.eligibility__heading = t('demarrage_projet.eligibility.section_eligibility')
+  .eligibility__content
+    - if @eligible
+      .eligibility__positive
+        i.glyphicon.glyphicon-ok.eligibility__icon-positive
+        p.eligibility__answer = t('demarrage_projet.eligibility.eligible')
+    - else
+      .eligibility__negative
+        i.glyphicon.glyphicon-remove.eligibility__icon-negative
+        p.eligibility__answer = t('demarrage_projet.eligibility.not_eligible')
+
+    .eligibility__conditions
+      i.glyphicon.glyphicon-list-alt.eligibility__icon-conditions
+      p.eligibility__answer = t('demarrage_projet.eligibility.informations', conditions: link_to("les conditions générales à remplir", "http://www.anah.fr/proprietaires/proprietaires-occupants/les-conditions-generales-a-remplir/", target: :_blank, class: "eligibility__link")).html_safe
+
+= btn name: "Suivant", href: new_user_registration_path, class: "btn-large btn-centered", icon: "arrow-right"

--- a/app/views/mises_en_relation/show.html.slim
+++ b/app/views/mises_en_relation/show.html.slim
@@ -1,24 +1,16 @@
 = simple_form_for @projet_courant, url: {controller: 'mises_en_relation', action: 'update'}, method: 'patch', html: { class:'ui form'}  do |f|
-    <div>
-      /! Eligibilite
-      section.eligibilite
-        h2 = t('demarrage_projet.mise_en_relation.section_eligibilite')
-        p.chapo
-          - if @non_eligible
-            = t('demarrage_projet.mise_en_relation.votre_projet_est_non_eligible')
-          - else
-            = t('demarrage_projet.mise_en_relation.votre_projet_est_eligible')
-      /! Auto-assignation d'un PRIS
-      section.assignement-pris
-        h2 = t('demarrage_projet.mise_en_relation.assignement_pris_titre')
-        p.chapo
-          - if @non_eligible
-            = t('demarrage_projet.mise_en_relation.non_eligible_recontacter',  { pris: @pris.raison_sociale})
-          - elsif @operations.count == 1 && @operateurs.count == 1
-            = t('demarrage_projet.mise_en_relation.to_operator')
-          - else
-            = t('demarrage_projet.mise_en_relation.un_pris_va_vous_contacter', { pris: @pris.raison_sociale})
-            p.chapo Il pourra vous recommander un opérateur chargé de vous accompagner tout au long de votre démarche.
+  section
+    h2 = t('demarrage_projet.mise_en_relation.assignement_pris_titre')
+    p.chapo
+      - if @not_eligible
+        = t('demarrage_projet.mise_en_relation.non_eligible_recontacter',  { pris: @pris.raison_sociale})
         = render 'mises_en_relation/disponibilite_form', simple_form_builder: f
-      = btn name: @action_label, class: 'btn-large btn-centered js-engagement', icon: 'ok'
-    </div><!-- Workaround for allowing slim to honor the scope of the submit tag -->
+        = btn name: @action_label, class: 'btn-large btn-centered js-engagement', icon: 'ok'
+      - elsif @operations.count == 1 && @operateurs.count == 1
+        = t('demarrage_projet.mise_en_relation.to_operator')
+        = btn name: @action_label, class: 'btn-large btn-centered', icon: 'ok'
+      - else
+        = t('demarrage_projet.mise_en_relation.information_pris', { pris: @pris.raison_sociale})
+        p.chapo Il pourra vous recommander un opérateur chargé de vous accompagner tout au long de votre démarche.
+        = render 'mises_en_relation/disponibilite_form', simple_form_builder: f
+        = btn name: @action_label, class: 'btn-large btn-centered js-engagement', icon: 'ok'

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -146,15 +146,20 @@ fr:
       ptz: "PTZ"
       annee_construction: "Année de construction"
       precisions: "Précisions"
+    # ----------------------- Eligibilité ---------------------
+    eligibility:
+      section_eligibility: "Éligibilité"
+      eligible: "D’après les informations fiscales que vous nous avez transmises, les conditions de ressources des occupants du logement sont remplies."
+      not_eligible: "D’après les éléments renseignés, vous n’êtes à priori pas éligible, pour s’en assurer un complément d'étude de votre situation peut être réalisé."
+      section_conditions: "Conditions de financement"
+      informations: "Pour découvrir les conditions s’appliquant à votre projet, vous pouvez consultez %{conditions}"
+
     # ----------------------- Mise en relation ---------------------
     mise_en_relation:
-      votre_projet_est_eligible: "D’après les informations fiscales que vous nous avez transmises, les conditions de ressources des occupants du logement sont remplies."
-      votre_projet_est_non_eligible: "D’après les éléments renseignés, vous n’êtes à priori pas éligible, pour s’en assurer un complément d'étude de votre situation va être prochainement réalisé. Un interlocuteur va prendre contact avec vous."
       titre: "Choisissez votre opérateur"
-      section_eligibilite: "Accompagnement"
       assignement_pris_titre: "Un contact pour vous aider"
       non_eligible_recontacter: "Si vous n’êtes pas recontacté dans un délai d’une semaine merci de bien vouloir contacter le Point Rénovation Info Service de votre département, « %{pris} », ou l’opérateur de l’opération programmée"
-      un_pris_va_vous_contacter: "Le Point Rénovation Info Service de votre département, « %{pris} », va vous contacter prochainement."
+      information_pris: "Le Point Rénovation Info Service de votre département est « %{pris} »."
       to_operator: "Un contact va vous être proposé pour vous aider à compléter votre dossier. Dès que vous l’aurez sélectionné, il lui sera alors possible d’entrer en relation avec vous."
       disponibilite_placeholder: "Par exemple : Le matin, entre 8h et 11h"
       error: "Une erreur s’est produite lors de l’enregistrement de l’intervenant."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     resource  :demandeur,         only: [:show, :update]
     resource  :demande,           only: [:show, :update]
     resource  :mise_en_relation,  only: [:show, :update]
+    resource  :eligibility,       only: :show
     get       :calcul_revenu_fiscal_reference
     get       :preeligibilite
   end

--- a/spec/controllers/demandes_controller_spec.rb
+++ b/spec/controllers/demandes_controller_spec.rb
@@ -29,7 +29,7 @@ describe DemandesController do
         }
         projet.demande.reload
         expect(projet.demande.changement_chauffage).to be true
-        expect(response).to redirect_to new_user_registration_path
+        expect(response).to redirect_to projet_eligibility_path projet
         expect(flash[:alert]).to be_blank
       end
     end

--- a/spec/controllers/mises_en_relation_controller_spec.rb
+++ b/spec/controllers/mises_en_relation_controller_spec.rb
@@ -84,17 +84,6 @@ describe MisesEnRelationController do
           expect(projet.invited_instructeur).to be_present
         end
       end
-
-      context "quand une erreur se produit lors de l'enregistrement" do
-        it "affiche une erreur" do
-          patch :update, {
-            projet_id: projet.id,
-            projet: nil,
-          }
-          expect(response).to redirect_to projet_mise_en_relation_path(projet)
-          expect(flash[:alert]).to eq I18n.t('demarrage_projet.mise_en_relation.error')
-        end
-      end
     end
   end
 end

--- a/spec/features/1_demarrage/etape4_preciser_le_projet_spec.rb
+++ b/spec/features/1_demarrage/etape4_preciser_le_projet_spec.rb
@@ -34,7 +34,7 @@ feature "Préciser le projet :" do
       fill_in :demande_travaux_autres, with: "Aménager une chambre au RDC"
 
       click_button I18n.t('demarrage_projet.action')
-      expect(page.current_path).to eq(new_user_registration_path)
+      expect(page).to have_current_path projet_eligibility_path projet
 
       projet.reload
       expect(projet.demande.froid).to be_truthy
@@ -59,10 +59,22 @@ feature "Préciser le projet :" do
 
     scenario "je ne peux pas passer à l'étape suivante tant que je n'ai pas rempli au moins un besoin" do
       signin_for_new_projet
-      visit projet_demande_path(projet)
+      visit projet_demande_path projet
       click_button I18n.t('demarrage_projet.action')
-      expect(page.current_path).to eq(projet_demande_path(projet))
-      expect(page).to have_content(I18n.t("demarrage_projet.demande.erreurs.besoin_obligatoire"))
+      expect(page).to have_current_path projet_demande_path projet
+      expect(page).to have_content I18n.t("demarrage_projet.demande.erreurs.besoin_obligatoire")
+    end
+
+    scenario "je suis notifié de mon éligibilité" do
+      signin_for_new_projet
+      visit projet_eligibility_path projet
+      expect(page).to have_content I18n.t('demarrage_projet.eligibility.eligible')
+    end
+
+    scenario "je suis notifié de ma non éligibilité" do
+      signin_for_new_projet_non_eligible
+      visit projet_eligibility_path projet
+      expect(page).to have_content I18n.t('demarrage_projet.eligibility.not_eligible')
     end
   end
 end

--- a/spec/features/1_demarrage/etape6_choisir_un_intervenant_spec.rb
+++ b/spec/features/1_demarrage/etape6_choisir_un_intervenant_spec.rb
@@ -5,64 +5,49 @@ require 'support/api_ban_helper'
 require 'support/rod_helper'
 
 feature "En tant que demandeur" do
+  let(:projet) { create :projet, :prospect }
+  let(:pris)   { Intervenant.pour_role('pris').last }
 
   context "quand je suis en diffu (pris assigné à mon projet)" do
-    let(:pris) { Intervenant.pour_role('pris').last }
+    scenario "je valide ma mise en relation avec le PRIS et renseigne mes disponibilités" do
+      signin(projet.numero_fiscal, projet.reference_avis)
 
-  	context "quand je suis éligible" do
-      let(:projet) { create :projet, :prospect }
+      visit projet_mise_en_relation_path(projet)
+      expect(page).to have_content I18n.t('demarrage_projet.mise_en_relation.assignement_pris_titre')
+      expect(page).to have_content pris.raison_sociale
+      fill_in I18n.t('activerecord.attributes.projet.disponibilite'), with: "Plutôt le matin"
+      check I18n.t('agrements.autorisation_acces_donnees_intervenants')
+      click_button I18n.t('demarrage_projet.action')
 
-      scenario "je valide ma mise en relation avec le PRIS" do
-        signin(projet.numero_fiscal, projet.reference_avis)
-
-        visit projet_mise_en_relation_path(projet)
-        expect(page).to have_content I18n.t('demarrage_projet.mise_en_relation.votre_projet_est_eligible')
-        expect(page).to have_content I18n.t('demarrage_projet.mise_en_relation.assignement_pris_titre')
-        expect(page).to have_content pris.raison_sociale
-        check I18n.t('agrements.autorisation_acces_donnees_intervenants')
-        click_button I18n.t('demarrage_projet.action')
-
-        expect(page.current_path).to eq(projet_path(projet))
-        expect(page).to have_content(I18n.t('invitations.messages.succes_titre'))
-      end
-
-      scenario "je renseigne mes disponibilités" do
-        signin(projet.numero_fiscal, projet.reference_avis)
-
-        visit projet_mise_en_relation_path(projet)
-        fill_in I18n.t('activerecord.attributes.projet.disponibilite'), with: "Plutôt le matin"
-        check I18n.t('agrements.autorisation_acces_donnees_intervenants')
-        click_button I18n.t('demarrage_projet.action')
-
-        expect(page.current_path).to eq(projet_path(projet))
-        expect(page).to have_content("Plutôt le matin")
-      end
+      expect(page).to have_current_path projet_path(projet)
+      expect(page).to have_content "Plutôt le matin"
+      expect(page).to have_content I18n.t('invitations.messages.succes_titre')
     end
   end
 
   context "quand je suis en opération programmée" do
-    let(:projet) { create :projet, :prospect }
+    before { Fakeweb::Rod.register_query_for_success_with_operation }
 
-    it "affiche un bouton pour contacter un opérateur" do
+    scenario "Je suis informé qu'un contact va m'être proposé et je peux le contacter" do
       signin(projet.numero_fiscal, projet.reference_avis)
 
-      visit projet_path(projet)
-      expect(projet.invited_pris).to be_nil
-      expect(page).to have_content(I18n.t('projets.visualisation.choisir_operateur'))
+      visit projet_mise_en_relation_path(projet)
+      expect(page).to have_content I18n.t('demarrage_projet.mise_en_relation.to_operator')
+      click_button I18n.t('demarrage_projet.action')
+
+      expect(page).to have_current_path projet_path(projet)
+      expect(page).to have_content I18n.t('projets.visualisation.choisir_operateur')
     end
   end
 
   context "quand je ne suis pas éligible" do
     let(:projet) { Projet.last }
-    let(:pris) { Intervenant.pour_role('pris').last }
 
-
-    scenario "je suis notifié de ma non éligibilité" do
+    scenario "un contact m'est donné" do
       signin_for_new_projet_non_eligible
       projet.build_demande.update froid: true
-      visit projet_mise_en_relation_path(projet)
-      expect(page).to have_content(I18n.t('demarrage_projet.mise_en_relation.votre_projet_est_non_eligible'))
-      expect(page).to have_content(I18n.t('demarrage_projet.mise_en_relation.non_eligible_recontacter',  { pris: pris.raison_sociale }))
+      visit projet_mise_en_relation_path projet
+      expect(page).to have_content I18n.t('demarrage_projet.mise_en_relation.non_eligible_recontacter', { pris: pris.raison_sociale })
     end
   end
 end


### PR DESCRIPTION
Ajout d'une nouvelle page pour l'Éligibilité avant la création du compte utilisateur : 

Eligible :
<img width="1156" alt="capture d ecran 2017-06-27 a 12 23 39" src="https://user-images.githubusercontent.com/24429245/27583067-79a67de0-5b33-11e7-9ec5-f9bc8b1615c1.png">

Non Eligible :
<img width="1155" alt="capture d ecran 2017-06-27 a 12 22 57" src="https://user-images.githubusercontent.com/24429245/27583053-692700c0-5b33-11e7-9527-cba900bd23e3.png">

Suppression de cette partie sur la page de Mise en Relation : 

<img width="1137" alt="capture d ecran 2017-06-13 a 17 04 07" src="https://user-images.githubusercontent.com/24429245/27089330-5df793ce-505a-11e7-9807-e48ee10cb1d9.png">

