### PR TITLE
PF615 Corrige une erreur lors du calcul automatique d'aides/financements

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -132,7 +132,7 @@ $(document).ready(function() {
   }
 
   function parseAmountAndSum(accumulator, element) {
-    var field_value = parseFloat(element.value.replace(',', '.'));
+    var field_value = parseFloat(element.value.replace(',', '.').replace(' ', ''));
     field_value = isNaN(field_value) ? 0 : field_value;
     return accumulator + field_value;
   }

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -168,7 +168,8 @@ private
         projet_aide_to_modify = ProjetAide.where(aide_id: projet_aide[:aide_id], projet_id: @projet_courant.id).first
         projet_aide[:id] = projet_aide_to_modify.try(:id)
 
-        projet_aide[:_destroy] = true if projet_aide[:localized_amount].blank?
+        amount = projet_aide[:localized_amount]
+        projet_aide[:_destroy] = true if amount.blank? || BigDecimal(amount) == 0
       end
     end
   end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -145,7 +145,7 @@ class Projet < ActiveRecord::Base
   end
 
   def has_fundings?
-    FUNDING_FIELDS.any? { |field| send(field).present? }
+    FUNDING_FIELDS.any? { |field| send(field).present? } || aides.present?
   end
 
   def pris_suggested_operateurs

--- a/lib/tasks/deployment/20170614115138_clean_projet_aides_amounts.rake
+++ b/lib/tasks/deployment/20170614115138_clean_projet_aides_amounts.rake
@@ -1,0 +1,12 @@
+namespace :after_party do
+  desc 'Deployment task: clean_projet_aides_amounts'
+  task clean_projet_aides_amounts: :environment do
+    puts "Running deploy task 'clean_projet_aides_amounts'" unless Rake.application.options.quiet
+
+    ProjetAide.find_each do |projet_aide|
+      projet_aide.destroy! if projet_aide.amount == 0
+    end
+
+    AfterParty::TaskRecord.create version: '20170614115138'
+  end  # task :clean_projet_aides_amounts
+end  # namespace :after_party

--- a/spec/lib/tasks/deployment/clean_projet_aides_amounts_spec.rb
+++ b/spec/lib/tasks/deployment/clean_projet_aides_amounts_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+require 'support/after_party_helper'
+
+describe '20170614115138_clean_projet_aides_amounts' do
+  include_context 'after_party'
+
+  let!(:valid_projet_aides)     { create :projet_aide, amount: BigDecimal("1.2") }
+  let!(:invalid_projet_aides_1) { create :projet_aide, amount: BigDecimal("0") }
+  let!(:invalid_projet_aides_2) { create :projet_aide, amount: BigDecimal("A") }
+
+  before { subject.invoke }
+
+  it "charge l'environment Rails" do
+    expect(subject.prerequisites).to include 'environment'
+  end
+
+  it "supprime les aides dont le montant est nul" do
+    expect(ProjetAide.find_by_id(valid_projet_aides.id)).to     be_present
+    expect(ProjetAide.find_by_id(invalid_projet_aides_1.id)).to be_nil
+    expect(ProjetAide.find_by_id(invalid_projet_aides_2.id)).to be_nil
+  end
+end

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -317,12 +317,15 @@ describe Projet do
   end
 
   describe "#has_fundings?" do
+    let(:aide)                    { create :aide }
     let(:projet_without_fundings) { create :projet }
     let(:projet_with_fundings)    { create :projet, travaux_ht_amount: 1 }
+    let(:projet_with_helps)       { create :projet, aides: [aide] }
 
     it "retourne vrai si un élément de financement est renseigné" do
       expect(projet_without_fundings.has_fundings?).to be_falsy
-      expect(projet_with_fundings.has_fundings?).to be_truthy
+      expect(projet_with_fundings.has_fundings?).to    be_truthy
+      expect(projet_with_helps.has_fundings?).to       be_truthy
     end
   end
 


### PR DESCRIPTION
**Avant : ne gérait pas l'espace entre les nombres et affichait donc une erreur :**

<img width="738" alt="capture d ecran 2017-06-14 a 14 24 58" src="https://user-images.githubusercontent.com/24429245/27131983-574bc3ac-510d-11e7-9b4c-412740c66f97.png">

**Après : espaces pris en comptes :**

<img width="741" alt="capture d ecran 2017-06-14 a 14 24 18" src="https://user-images.githubusercontent.com/24429245/27132001-682f7024-510d-11e7-8a58-aecf3c9262c6.png">
