### PR TITLE
PF620 FIX : préserve la demande lors de la proposition opérateur

### DIFF
--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -46,7 +46,7 @@ class DossiersController < ApplicationController
     end
 
     if request.put?
-      if @projet_courant.save_proposition!(projet_params)
+      if @projet_courant.save_proposition!(projet_params) && @projet_courant.demande.update(annee_construction: demande_params[:annee_construction])
         return redirect_to projet_or_dossier_path(@projet_courant), notice: t('projets.edition_projet.messages.succes')
       else
         flash.now[:alert] = t('projets.edition_projet.messages.erreur')
@@ -160,11 +160,15 @@ private
                         :suggested_operateur_ids => [],
                         :prestation_choices_attributes => [:prestation_id, :desired, :recommended, :selected],
                         :projet_aides_attributes => [:aide_id, :localized_amount],
-                        :demande_attributes => [:annee_construction],
                 )
     clean_projet_aides(attributs)
     clean_prestation_choices(attributs)
     attributs
+  end
+
+  def demande_params
+    attributs = params.require(:projet).permit(:demande_attributes => [:annee_construction])[:demande_attributes]
+    attributs ? attributs : {}
   end
 
   def clean_projet_aides(attributs)

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -159,9 +159,6 @@ describe DossiersController do
 
       it "sauvegarder l'année de construction si elle est modifiée" do
         projet_params = {
-          prestation_choices_attributes: {
-            '1' => { id: '', prestation_id: prestation_1.id, recommended: true },
-          },
           demande_attributes: {
             annee_construction: "1980"
           }
@@ -169,8 +166,19 @@ describe DossiersController do
         put :proposition, dossier_id: projet.id, projet: projet_params
         projet.reload
 
-        expect(projet.prestation_choices.count).to eq 1
         expect(projet.demande.annee_construction).to eq 1980
+      end
+
+      it "n'écrase pas la demande si l'année de construction n'est pas renseignée" do
+        projet_params = {
+          demande_attributes: {
+            annee_construction: nil
+          }
+        }
+        put :proposition, dossier_id: projet.id, projet: projet_params
+        projet.reload
+
+        expect(projet.demande.complete?).to be_truthy
       end
 
       it "je ne peux pas créer de doublon" do


### PR DESCRIPTION
La demande (du demandeur) était réinitialisée lorsque l'année de construction de la proposition opérateur était à vide.