### PR TITLE
PF633 gère la vue de l'operateur

### DIFF
--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -13,9 +13,12 @@ class DossiersController < ApplicationController
 
     if current_agent.siege?
       @dossiers = Projet.all.with_demandeur
+    elsif current_agent.operateur?
+      @invitations = Invitation.visible_for_operateur(current_agent.intervenant)
     else
-      @invitations = Invitation.where(intervenant_id: current_agent.intervenant.id).includes(:projet)
+      @invitations = Invitation.where(intervenant_id: current_agent.intervenant_id).includes(:projet)
     end
+
     respond_to do |format|
       format.html {
         @page_heading = I18n.t('tableau_de_bord.titre_section')

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -18,4 +18,8 @@ class Invitation < ActiveRecord::Base
   delegate :demandeur,           to: :projet
   delegate :description_adresse, to: :projet
 
+  scope :visible_for_operateur, -> (operateur) {
+    where(intervenant_id: operateur.id).includes(:projet).select { |i| (i.projet.operateur == operateur) || i.projet.operateur.blank? }
+  }
+
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -15,9 +15,46 @@ describe Invitation do
   it { is_expected.to delegate_method(:demandeur).to(:projet) }
   it { is_expected.to delegate_method(:description_adresse).to(:projet) }
 
-  describe '#projet_email' do
+  describe "#projet_email" do
     it "devrait retourner l'email du projet" do
       expect(invitation.projet.email).to eq('prenom.nom@site.com')
     end
   end
+
+  describe "#visible_for_operateur" do
+    let(:projet_with_operator)  { create :projet, :proposition_proposee }
+    let(:projet_with_2_invited) { create :projet, :prospect, email: "prenom.nom2@site.com" }
+    let(:projet_with_1_invited) { create :projet, :prospect, email: "prenom.nom3@site.com" }
+    let(:operateur1)            { projet_with_operator.operateur }
+    let(:operateur2)            { create :operateur }
+
+    before do
+      create :invitation, projet: projet_with_1_invited, intervenant: operateur1, suggested: true
+      create :invitation, projet: projet_with_2_invited, intervenant: operateur1, suggested: true
+      create :invitation, projet: projet_with_2_invited, intervenant: operateur2, suggested: true
+      create :invitation, projet: projet_with_operator,  intervenant: operateur2, suggested: true
+    end
+
+    context "if operator is invited" do
+      it "demandeur is visible if no operator is committed" do
+        invitations_for_operateur1 = Invitation.visible_for_operateur(operateur1)
+        invitations_for_operateur2 = Invitation.visible_for_operateur(operateur2)
+
+        expect(invitations_for_operateur1.count).to eq 3
+        expect(invitations_for_operateur1.map(&:projet)).to include(projet_with_operator, projet_with_2_invited, projet_with_1_invited)
+
+        expect(invitations_for_operateur2.count).to eq 1
+        expect(invitations_for_operateur2.first.projet).to eq projet_with_2_invited
+      end
+    end
+  end
+end
+
+describe "#with_demandeur" do
+  let!(:projet1) { create :projet, :with_demandeur }
+  let!(:projet2) { create :projet, :with_demandeur }
+  let!(:projet3) { create :projet }
+
+  it { expect(Projet.with_demandeur).to include(projet1, projet2) }
+  it { expect(Projet.with_demandeur).not_to include(projet3) }
 end


### PR DESCRIPTION
> Lorsqu'un opérateur est engagé, les autres opérateurs invités ne voient plus le dossier