### PR TITLE
Pf447 date depot dans opal

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -14,7 +14,14 @@ class Ability
         can :manage, :all
         return
       end
-
+      if agent_or_user.siege?
+        can :read, AvisImposition
+        can :read, Demande
+        can :read, :eligibility
+        can :read, :demandeur
+        can :read, Occupant
+        can :read, Projet
+      end
       if agent_or_user.pris? && projet.statut.to_sym == :prospect && projet.invited_pris == agent_or_user.intervenant
         can [:read, :recommander_operateurs], Projet
       elsif agent_or_user.instructeur?

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -341,7 +341,7 @@ class Projet < ActiveRecord::Base
   def transmettre!(instructeur)
     invitation = invitations.find_by(intervenant: instructeur)
     if invitation.update(intermediaire: operateur)
-
+      self.date_depot = Time.now
       self.statut = :transmis_pour_instruction
       ProjetMailer.mise_en_relation_intervenant(invitation).deliver_later!
       ProjetMailer.accuse_reception(self).deliver_later!
@@ -369,12 +369,6 @@ class Projet < ActiveRecord::Base
 
   def prenom_occupants
     occupants.map { |occupant| occupant.prenom.capitalize }.join(' et ')
-  end
-
-  # TODO Attention : cette date est importante à conserver alors que les invitations
-  # sont faciles à supprimer. En attente de mise en place de l’historisation.
-  def date_depot
-    invitations.where.not(intermediaire: nil).first.try(:updated_at)
   end
 
   def status_for_intervenant

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -430,7 +430,7 @@ class Projet < ActiveRecord::Base
           projet.date_de_visite.present? ? format_date(projet.date_de_visite) : "",
           I18n.t(projet.status_for_intervenant, scope: "projets.statut"),
         ]
-        line.insert 9, projet.payment_registry.statuses        if agent.siege? || agent.instructeur? || agent.operateur?
+        line.insert 9, projet.payment_registry.try(:statuses)        if agent.siege? || agent.instructeur? || agent.operateur?
         line.insert 6, projet.agent_operateur.try(:fullname)   if agent.siege? || agent.instructeur? || agent.operateur?
         line.insert 4, projet.agent_instructeur.try(:fullname) if agent.siege? || agent.instructeur? || agent.operateur?
         line.insert 2, projet.adresse.try(:departement)        if agent.siege? || agent.operateur?

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -341,6 +341,7 @@ class Projet < ActiveRecord::Base
   def transmettre!(instructeur)
     invitation = invitations.find_by(intervenant: instructeur)
     if invitation.update(intermediaire: operateur)
+
       self.statut = :transmis_pour_instruction
       ProjetMailer.mise_en_relation_intervenant(invitation).deliver_later!
       ProjetMailer.accuse_reception(self).deliver_later!
@@ -373,12 +374,7 @@ class Projet < ActiveRecord::Base
   # TODO Attention : cette date est importante à conserver alors que les invitations
   # sont faciles à supprimer. En attente de mise en place de l’historisation.
   def date_depot
-    invitation_intervenant = invitations.where(intervenant: invited_instructeur).first
-    if invitation_intervenant
-      invitation_intervenant.created_at
-    else
-      nil
-    end
+    invitations.where.not(intermediaire: nil).first.try(:updated_at)
   end
 
   def status_for_intervenant

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -67,7 +67,8 @@ private
 
     {
       "dosNumeroPlateforme": "#{projet.numero_plateforme}",
-      "dosDateDepot": Time.now.strftime("%Y-%m-%d"),
+      "dosDateDepot": projet.date_depot.strftime("%y-%m-%d"),
+      "dmdNbOccupants": projet.nb_total_occupants,
       "utiIdClavis": agent_instructeur.clavis_id,
       "demandeur": {
         "dmdNbOccupants": projet.nb_total_occupants,

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -67,7 +67,7 @@ private
 
     {
       "dosNumeroPlateforme": "#{projet.numero_plateforme}",
-      "dosDateDepot": projet.date_depot.strftime("%y-%m-%d"),
+      "dosDateDepot": projet.date_depot,
       "dmdNbOccupants": projet.nb_total_occupants,
       "utiIdClavis": agent_instructeur.clavis_id,
       "demandeur": {

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -66,9 +66,8 @@ private
     lignes_adresse_geo      = split_adresse_into_lines(projet.adresse.ligne_1)
 
     {
-      "dosNumeroPlateforme": "#{projet.numero_plateforme}",
+      "dosNumeroPlateforme": projet.numero_plateforme,
       "dosDateDepot": projet.date_depot,
-      "dmdNbOccupants": projet.nb_total_occupants,
       "utiIdClavis": agent_instructeur.clavis_id,
       "demandeur": {
         "dmdNbOccupants": projet.nb_total_occupants,

--- a/app/views/projet_mailer/accuse_reception.html.slim
+++ b/app/views/projet_mailer/accuse_reception.html.slim
@@ -1,6 +1,6 @@
 p Bonjour #{@demandeur.fullname},
 
-p Le #{l(@date_depot, format:'%d %B %Y à %H h %M')}, vous avez déposé auprès de l’Agence nationale de l’habitat – Anah – une demande de subvention.
+p Le #{@projet.date_depot.to_date}, vous avez déposé auprès de l’Agence nationale de l’habitat – Anah – une demande de subvention.
 
 p Votre demande a été enregistrée sous le numéro « #{@projet.plateforme_id} ». Elle sera instruite par le service suivant :
 

--- a/app/views/projet_mailer/accuse_reception.html.slim
+++ b/app/views/projet_mailer/accuse_reception.html.slim
@@ -1,6 +1,6 @@
 p Bonjour #{@demandeur.fullname},
 
-p Le #{@projet.date_depot.to_date}, vous avez déposé auprès de l’Agence nationale de l’habitat – Anah – une demande de subvention.
+p Le l(@projet.date_depot.to_date), vous avez déposé auprès de l’Agence nationale de l’habitat – Anah – une demande de subvention.
 
 p Votre demande a été enregistrée sous le numéro « #{@projet.plateforme_id} ». Elle sera instruite par le service suivant :
 

--- a/app/views/projets/_projet_details.html.slim
+++ b/app/views/projets/_projet_details.html.slim
@@ -193,7 +193,8 @@ ul.ctr-ope
       = with_semicolon(t('helpers.label.proposition.precisions_financement'))
       span= @projet_courant.precisions_financement
 
-date= l(Time.now.to_date)
+- if @projet_courant.date_depot.present?
+  date= l(@projet_courant.date_depot.to_date)
 
 - if @projet_courant.documents.present?
   h4 Pièces jointes

--- a/db/migrate/20170727083643_add_date_depot_to_projets.rb
+++ b/db/migrate/20170727083643_add_date_depot_to_projets.rb
@@ -1,0 +1,5 @@
+class AddDateDepotToProjets < ActiveRecord::Migration
+  def change
+    add_column :projets, :date_depot, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170719120538) do
+ActiveRecord::Schema.define(version: 20170727083643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -214,6 +214,8 @@ ActiveRecord::Schema.define(version: 20170719120538) do
 
   create_table "payments", force: :cascade do |t|
     t.integer  "payment_registry_id"
+    t.string   "statut"
+    t.string   "type_paiement"
     t.string   "beneficiaire",                                 default: "",    null: false
     t.boolean  "personne_morale",                              default: false, null: false
     t.decimal  "montant",             precision: 10, scale: 2
@@ -221,9 +223,7 @@ ActiveRecord::Schema.define(version: 20170719120538) do
     t.datetime "payed_at"
     t.datetime "created_at",                                                   null: false
     t.datetime "updated_at",                                                   null: false
-    t.string   "statut"
     t.string   "action"
-    t.string   "type_paiement"
   end
 
   add_index "payments", ["payment_registry_id"], name: "index_payments_on_payment_registry_id", using: :btree
@@ -318,6 +318,7 @@ ActiveRecord::Schema.define(version: 20170719120538) do
     t.integer  "user_id"
     t.integer  "modified_revenu_fiscal_reference"
     t.datetime "locked_at"
+    t.datetime "date_depot"
   end
 
   add_index "projets", ["adresse_a_renover_id"], name: "index_projets_on_adresse_a_renover_id", using: :btree

--- a/lib/tasks/deployment/20170727121006_migrate_date_depot.rake
+++ b/lib/tasks/deployment/20170727121006_migrate_date_depot.rake
@@ -8,8 +8,14 @@ namespace :after_party do
     end
 
     Projet.find_each do |projet|
-      if projet.date_depot.blank? && !projet.status_not_yet(:transmis_pour_instruction)
-        projet.update_attribute(:date_depot, date_depot_a_jour(projet))
+      projet_transmited = !projet.status_not_yet(:transmis_pour_instruction)
+      if projet.date_depot.blank? && projet_transmited
+        invitation_depot = projet.invitations.find_by(intermediaire: projet.operateur)
+        if invitation_depot.present?
+          projet.update_attribute(:date_depot, invitation_depot.updated_at)
+        else
+          puts "Aucune invitation relative au dépôt trouvé pour le projet #{projet.id}"
+        end
       end
     end
 

--- a/lib/tasks/deployment/20170727121006_migrate_date_depot.rake
+++ b/lib/tasks/deployment/20170727121006_migrate_date_depot.rake
@@ -1,0 +1,20 @@
+namespace :after_party do
+  desc 'Deployment task: store date when project is sent to instructor'
+  task migrate_date_depot: :environment do
+    puts "Running deploy task 'migrate_date_depot'" unless Rake.application.options.quiet
+
+    def date_depot_a_jour(projet)
+      projet.invitations.where.not(intermediaire: nil).first.updated_at
+    end
+
+    Projet.find_each do |projet|
+      if projet.date_depot.blank? && !projet.status_not_yet(:transmis_pour_instruction)
+        projet.update_attribute(:date_depot, date_depot_a_jour(projet))
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20170727121006'
+  end
+end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -84,6 +84,7 @@ FactoryGirl.define do
       end
     end
 
+
     trait :with_invited_instructeur do
       after(:build) do |projet|
         instructeur = create(:instructeur, departements: [projet.departement])
@@ -172,6 +173,7 @@ FactoryGirl.define do
       with_assigned_operateur
       with_selected_prestation
       with_invited_instructeur
+      date_depot DateTime.new(2066, 06, 06)
 
       after(:build) do |projet|
         projet.statut = :transmis_pour_instruction

--- a/spec/lib/tasks/deployment/migrate_date_depot_spec.rb
+++ b/spec/lib/tasks/deployment/migrate_date_depot_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'support/after_party_helper'
+require 'support/api_particulier_helper'
+
+describe '20170727121006_migrate_date_depot' do
+  include_context 'after_party'
+
+  context "Mettre à jour la date de dépot" do
+    let(:present_date)        { DateTime.new(1980, 04, 19) }
+    let(:add_date)            { DateTime.new(2010, 10, 01) }
+    let!(:instructeur)        { create :instructeur }
+    let!(:projet_prospect)     { create :projet, :en_cours, email: "prenom.nom1@site.com" }
+    let!(:projet_date_present) { create :projet, :transmis_pour_instruction, date_depot: present_date, email: "prenom.nom2@site.com" }
+    let!(:projet_date_absent)  { create :projet, :transmis_pour_instruction, date_depot: nil, email: "prenom.nom3@site.com" }
+
+
+    before do
+      projet_date_present.invitations.where(intervenant: projet_date_present.invited_instructeur).first.update_attribute(:intermediaire, projet_date_present.operateur)
+      projet_date_present.invitations.where(intervenant: projet_date_present.invited_instructeur).first.update_attribute(:updated_at, add_date)
+      projet_date_absent.invitations.where(intervenant: projet_date_absent.invited_instructeur).first.update_attribute(:intermediaire, projet_date_absent.operateur)
+      projet_date_absent.invitations.where(intervenant: projet_date_absent.invited_instructeur).first.update_attribute(:updated_at, add_date)
+      subject.invoke
+    end
+
+    it "ne change rien si date_depot n'est pas nulle ou dossier pas encore transmis pour instruction" do
+      projet_date_present.reload
+      projet_prospect.reload
+      expect(projet_date_present.date_depot).to eq present_date
+      expect(projet_prospect.date_depot).to be_nil
+    end
+
+    it "met à jour date_depot si elle est nulle" do
+      projet_date_absent.reload
+      expect(projet_date_absent.date_depot).to eq add_date
+    end
+  end
+end

--- a/spec/lib/tasks/deployment/migrate_date_depot_spec.rb
+++ b/spec/lib/tasks/deployment/migrate_date_depot_spec.rb
@@ -6,32 +6,38 @@ describe '20170727121006_migrate_date_depot' do
   include_context 'after_party'
 
   context "Mettre à jour la date de dépot" do
-    let(:present_date)        { DateTime.new(1980, 04, 19) }
-    let(:add_date)            { DateTime.new(2010, 10, 01) }
-    let!(:instructeur)        { create :instructeur }
-    let!(:projet_prospect)     { create :projet, :en_cours, email: "prenom.nom1@site.com" }
-    let!(:projet_date_present) { create :projet, :transmis_pour_instruction, date_depot: present_date, email: "prenom.nom2@site.com" }
-    let!(:projet_date_absent)  { create :projet, :transmis_pour_instruction, date_depot: nil, email: "prenom.nom3@site.com" }
+    let(:transmission_date)      { DateTime.new(1980, 04, 19) }
+    let(:update_invitation_date) { DateTime.new(2010, 10, 01) }
+    let!(:instructeur)           { create :instructeur }
+    let!(:projet_prospect)       { create :projet, :en_cours, email: "prenom.nom1@site.com" }
+    let!(:projet_date_present)   { create :projet, :transmis_pour_instruction, date_depot: transmission_date, email: "prenom.nom2@site.com" }
+    let!(:projet_date_absent)    { create :projet, :transmis_pour_instruction, date_depot: nil, email: "prenom.nom3@site.com" }
 
 
     before do
-      projet_date_present.invitations.where(intervenant: projet_date_present.invited_instructeur).first.update_attribute(:intermediaire, projet_date_present.operateur)
-      projet_date_present.invitations.where(intervenant: projet_date_present.invited_instructeur).first.update_attribute(:updated_at, add_date)
-      projet_date_absent.invitations.where(intervenant: projet_date_absent.invited_instructeur).first.update_attribute(:intermediaire, projet_date_absent.operateur)
-      projet_date_absent.invitations.where(intervenant: projet_date_absent.invited_instructeur).first.update_attribute(:updated_at, add_date)
+      invitation_instructeur_avec_depot = projet_date_present.invitations.where(intervenant: projet_date_present.invited_instructeur).first
+      invitation_instructeur_sans_depot = projet_date_absent.invitations.where(intervenant: projet_date_absent.invited_instructeur).first
+
+      invitation_instructeur_avec_depot.update_attribute(:intermediaire, projet_date_present.operateur)
+      invitation_instructeur_avec_depot.update_attribute(:updated_at, update_invitation_date)
+      invitation_instructeur_sans_depot.update_attribute(:intermediaire, projet_date_absent.operateur)
+      invitation_instructeur_sans_depot.update_attribute(:updated_at, update_invitation_date)
+
       subject.invoke
     end
 
     it "ne change rien si date_depot n'est pas nulle ou dossier pas encore transmis pour instruction" do
       projet_date_present.reload
       projet_prospect.reload
-      expect(projet_date_present.date_depot).to eq present_date
+      expect(projet_date_present.date_depot).to eq transmission_date
       expect(projet_prospect.date_depot).to be_nil
     end
 
     it "met à jour date_depot si elle est nulle" do
       projet_date_absent.reload
-      expect(projet_date_absent.date_depot).to eq add_date
+      expect(projet_date_absent.date_depot).to eq update_invitation_date
     end
   end
 end
+
+

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -583,6 +583,7 @@ describe Projet do
 
     context "avec un instructeur valide" do
       let(:instructeur) { projet.invited_instructeur }
+
       it "rajoute l'instructeur au projet" do
         result = projet.transmettre!(instructeur)
         expect(result).to be true
@@ -590,24 +591,17 @@ describe Projet do
         expect(projet.invitations.count).to eq(2)
       end
 
+      it "met à jour la date_depot" do
+        expect(projet.date_depot).to be_nil
+        projet.transmettre!(instructeur)
+        expect(projet.date_depot).to_not be_nil
+      end
+
       it "notifie l'instructeur et le demandeur" do
         expect(ProjetMailer).to receive(:mise_en_relation_intervenant).and_call_original
         expect(ProjetMailer).to receive(:accuse_reception).and_call_original
         projet.transmettre!(instructeur)
       end
-    end
-  end
-
-  describe "#date_depot" do
-    subject { projet.date_depot }
-    context "avant la transmission du dossier" do
-      let(:projet) { create :projet, :proposition_proposee }
-      it { is_expected.to be_nil }
-    end
-
-    context "après la transmission du dossier" do
-      let(:projet) { create :projet, :transmis_pour_instruction }
-      it { is_expected.to eq projet.invitations.last.created_at }
     end
   end
 
@@ -687,3 +681,4 @@ describe Projet do
     end
   end
 end
+ 

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -170,4 +170,17 @@ describe Opal do
       end
     end
   end
+
+  # describe "#date_de_transmission_pour_instruction" do
+  #   let(:projet_propose)  { create :projet, :proposition_proposee, :with_invited_instructeur }
+  #   let(:projet_transmis) { create :projet, :transmis_pour_instruction }
+  #   let(:invitation_updated_at) { Time.new(1789, 7, 14, 16, 0, 0)
+  #
+  #   it { expect(projet_propose).invitations.where.not(intermediaire: nil).count.to eq 0 }
+  #   it { expect(projet_transmis).invitations.where.not(intermediaire: nil).count.to eq 1 }
+  #
+  #   it { expect(projet_transmis).invitations.where.not(intermediaire: nil).first.updated_at.to eq invitation_updated_at }
+  #
+  #
+  # end
 end

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -170,17 +170,4 @@ describe Opal do
       end
     end
   end
-
-  # describe "#date_de_transmission_pour_instruction" do
-  #   let(:projet_propose)  { create :projet, :proposition_proposee, :with_invited_instructeur }
-  #   let(:projet_transmis) { create :projet, :transmis_pour_instruction }
-  #   let(:invitation_updated_at) { Time.new(1789, 7, 14, 16, 0, 0)
-  #
-  #   it { expect(projet_propose).invitations.where.not(intermediaire: nil).count.to eq 0 }
-  #   it { expect(projet_transmis).invitations.where.not(intermediaire: nil).count.to eq 1 }
-  #
-  #   it { expect(projet_transmis).invitations.where.not(intermediaire: nil).first.updated_at.to eq invitation_updated_at }
-  #
-  #
-  # end
 end


### PR DESCRIPTION
ATTENTION TESTS A CORRIGER
- Gère la date de depot opal
- Affiche la date de dépot dans le résumé du projet
- Rajoute les droits ANAH SIEGE initialement oubliés