### PR TITLE
PF448 envoie date naissance dans OPAL 

### DIFF
--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -78,6 +78,7 @@ private
           "civId":            serialize_civilite(projet.demandeur),
           "pphNom":           serialize_nom(projet.demandeur),
           "pphPrenom":        serialize_prenom(projet.demandeur),
+          "pphDateNaissance": projet.demandeur.date_de_naissance.strftime("%Y-%m-%d"),
           "adressePostale": {
             "payId": 1,
             "adpLigne1":     lignes_adresse_postale[0],

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -61,13 +61,17 @@ private
     projet.modified_revenu_fiscal_reference ? projet.modified_revenu_fiscal_reference : projet.revenu_fiscal_reference_total
   end
 
+  def serialize_date(date)
+    date.strftime("%Y-%m-%d")
+  end
+
   def serialize_dossier(projet, agent_instructeur)
     lignes_adresse_postale  = split_adresse_into_lines(projet.adresse_postale.ligne_1)
     lignes_adresse_geo      = split_adresse_into_lines(projet.adresse.ligne_1)
 
     {
       "dosNumeroPlateforme": projet.numero_plateforme,
-      "dosDateDepot": projet.date_depot.strftime("%Y-%m-%d"),
+      "dosDateDepot": serialize_date(projet.date_depot),
       "utiIdClavis": agent_instructeur.clavis_id,
       "demandeur": {
         "dmdNbOccupants": projet.nb_total_occupants,
@@ -78,7 +82,7 @@ private
           "civId":            serialize_civilite(projet.demandeur),
           "pphNom":           serialize_nom(projet.demandeur),
           "pphPrenom":        serialize_prenom(projet.demandeur),
-          "pphDateNaissance": projet.demandeur.date_de_naissance.strftime("%Y-%m-%d"),
+          "pphDateNaissance": serialize_date(projet.demandeur.date_de_naissance),
           "adressePostale": {
             "payId": 1,
             "adpLigne1":     lignes_adresse_postale[0],

--- a/app/views/documents/index.html.slim
+++ b/app/views/documents/index.html.slim
@@ -1,3 +1,3 @@
-= render "shared/ribbon_header"
+/= render "shared/ribbon_header"
 
 h1 Hello I am your Attachment Page !!!!

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -52,6 +52,7 @@ describe Opal do
         expect(personne_physique["civId"]).to eq 1
         expect(personne_physique["pphPrenom"]).to eq "Olaf"
         expect(personne_physique["pphNom"]).to eq "STRABE"
+        expect(personne_physique["pphDateNaissance"]).to eq "1977-06-20"
 
         adresse_postale = personne_physique["adressePostale"]
         expect(adresse_postale["adpLigne1"]).to eq "65 rue de Rome"


### PR DESCRIPTION
Ca marche a priori. Mais Questions : on est d'accord qu'il n'y a pas besoin d'after-party ? (on ne peut pas rajouter la date de naissance si dans Opal si le dossier a déjà été transféré dans Opal)...?