### PR TITLE
[WAIT] PF626 reformule l'année de l'avis fiscal page accueil - QUESTION

### DIFF
--- a/app/assets/stylesheets/new-project.scss
+++ b/app/assets/stylesheets/new-project.scss
@@ -13,7 +13,7 @@
 
 .new-project__label {
   display: inline-block;
-  margin-top: 1em;
+  margin-top: 2em;
   font-weight: bold;
   line-height: 32px;
 }
@@ -22,6 +22,9 @@
 }
 .new-project__label--first {
   margin-top: 0;
+}
+.new-project__label--second {
+  margin-bottom: 5px;
 }
 .new-project__proprietaire-input {
   margin-right: 10px;

--- a/app/views/projets/new.html.slim
+++ b/app/views/projets/new.html.slim
@@ -31,10 +31,7 @@ section.new-project
     label.new-project__proprietaire-label for="lab-proprietaire-no"
       = radio_button_tag "proprietaire", "0", !proprietaire, class: "new-project__proprietaire-input", id: "lab-proprietaire-no"
       | Non
-    br/
-    br/
-    br/
-    p.new-project__label.new-project__label--p.new-project__label--first= "Avis Fiscal #{Time.current.year-1} sur les revenus de #{Time.current.year-2}"
+    p.new-project__label.new-project__label--p.new-project__label--second= "Avis Fiscal #{Time.current.year-1} sur les revenus de #{Time.current.year-2} :"
 
     .labeled-info-point
       = f.label :numero_fiscal

--- a/app/views/projets/new.html.slim
+++ b/app/views/projets/new.html.slim
@@ -33,11 +33,12 @@ section.new-project
       | Non
     br/
     br/
+    br/
+    p.new-project__label.new-project__label--p.new-project__label--first= "Avis Fiscal #{Time.current.year-1} sur les revenus de #{Time.current.year-2}"
 
     .labeled-info-point
       = f.label :numero_fiscal
       a.info-point.info-point--light.js-popin data-target="#numero-fiscal" title="Où trouver le numéro fiscal ?" ?
-      p.new-project__commentaire= "Avis Fiscal #{Time.current.year-1} sur les revenus de #{Time.current.year-2}"
     = f.input :numero_fiscal, wrapper_html: { class: "size-m" }, required: true, label: false
 
     .labeled-info-point

--- a/app/views/projets/new.html.slim
+++ b/app/views/projets/new.html.slim
@@ -32,10 +32,12 @@ section.new-project
       = radio_button_tag "proprietaire", "0", !proprietaire, class: "new-project__proprietaire-input", id: "lab-proprietaire-no"
       | Non
     br/
-    
+    br/
+
     .labeled-info-point
       = f.label :numero_fiscal
       a.info-point.info-point--light.js-popin data-target="#numero-fiscal" title="Où trouver le numéro fiscal ?" ?
+      p.new-project__commentaire= "Avis Fiscal #{Time.current.year-1} sur les revenus de #{Time.current.year-2}"
     = f.input :numero_fiscal, wrapper_html: { class: "size-m" }, required: true, label: false
 
     .labeled-info-point


### PR DESCRIPTION
Question : sur la page avis d'impositions (où on rajoute tous les autres avis du logement), on demande les autres avis de la même année que l'avis du demandeur ? Ou ce sont les mêmes règles (n-1 sur n-2) ? 
En réalité, cela ne pose un problème que si le demandeur se connecte avant le 31 décembre (donc sans créer de compte), et ajoute les avis d'imposition des autres occupants après le 31 
![image](https://user-images.githubusercontent.com/22198770/29027174-c8644d92-7b7f-11e7-8431-9e12ec0f8612.png)

