### PR TITLE
wording avis_fiscal et occupants

### DIFF
--- a/app/controllers/avis_impositions_controller.rb
+++ b/app/controllers/avis_impositions_controller.rb
@@ -9,7 +9,7 @@ class AvisImpositionsController < ApplicationController
   end
 
   def index
-    @page_heading = "Avis d’imposition"
+    @page_heading = "Mon avis d’imposition"
   end
 
   def update_project_rfr

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -136,7 +136,16 @@ module ApplicationHelper
     html << content_tag(:h4, "Informations supplémentaires")
     complements = []
     complements << "Je préfère être contacté " + demande.projet.disponibilite if demande.projet.disponibilite.present?
-    ptz = demande.ptz ? "Oui": "Non"
+
+    #ATTENTION une fois qu'une cas oui ou non a été cochée, on ne peut plus repasser en non renseigné. Est-ce ok ?
+    if demande.ptz.nil?
+      ptz = "Non renseigné"
+    elsif demande.ptz == true
+      ptz = "Oui"
+    else
+      ptz = "Non"
+    end
+
     ptz_strong = content_tag(:strong, ptz)
     complements << "#{t("demarrage_projet.demande.ptz")} : #{ptz_strong}"
     annee_construction = demande.annee_construction.present? ? demande.annee_construction : "Non renseigné"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,10 +137,9 @@ module ApplicationHelper
     complements = []
     complements << "Je préfère être contacté " + demande.projet.disponibilite if demande.projet.disponibilite.present?
 
-    #ATTENTION une fois qu'une cas oui ou non a été cochée, on ne peut plus repasser en non renseigné. Est-ce ok ?
     if demande.ptz.nil?
       ptz = "Non renseigné"
-    elsif demande.ptz == true
+    elsif demande.ptz
       ptz = "Oui"
     else
       ptz = "Non"

--- a/app/views/avis_impositions/index.html.slim
+++ b/app/views/avis_impositions/index.html.slim
@@ -26,7 +26,7 @@ table.table.table-striped.table-sm
               span Supprimer
               i.glyphicon.glyphicon-remove
 
-p.content__question= "Parmi les occupants du logement actuel y a-t-il d’autres avis d’imposition pour l’année #{@projet_courant.annee_fiscale_reference} ?"
+p.content__question= "S'il y a d'autres occupants dans le logement, ajoutez leurs avis d'imposition pour l'année #{@projet_courant.annee_fiscale_reference}."
 = btn name: "Ajouter un avis d’imposition", href: new_projet_or_dossier_avis_imposition_path(@projet_courant), icon: "plus", class: "btn-secondary"
 
 .imposition-form__footer

--- a/app/views/avis_impositions/new.html.slim
+++ b/app/views/avis_impositions/new.html.slim
@@ -1,5 +1,6 @@
+= btn name: "Retour", href: projet_or_dossier_avis_impositions_path(@projet_courant), class: "btn-secondary", icon: "arrow-left"
 = simple_form_for @avis_imposition, url: { controller: "avis_impositions", action: "create" }, html: { class: "form" } do |f|
-  = link_to "Revenir à la liste des avis d’imposition", projet_or_dossier_avis_impositions_path(@projet_courant)
+  = "Autres avis d'imposition sur les revenus #{@projet_courant.annee_fiscale_reference}"
   = render "shared/errors", resource: @avis_imposition
   = f.input :numero_fiscal,  wrapper_html: { class: "size-s" }, required: true, autofocus: true
   = f.input :reference_avis, wrapper_html: { class: "size-s" }, required: true

--- a/app/views/occupants/index.html.slim
+++ b/app/views/occupants/index.html.slim
@@ -14,14 +14,14 @@
         - else
           span.modified= number_to_currency(@projet_courant.modified_revenu_fiscal_reference, precision: 0)
           span= " (initialement #{number_to_currency(@projet_courant.revenu_fiscal_reference_total, precision: 0)})"
-  p.chapo= t("occupants.confirmer_nombre_personnes")
+  p.chapo= t("occupants.confirmer_nombre_personnes_supprimer")
 
   table.table.table-striped.table-sm.occ-table
     thead
       tr
         th= t("occupants.occupants")
         th= t("occupants.annee_naissance")
-        th= t("occupants.actions")
+        th=
     tbody
       - @occupants.each do |occupant|
         tr data-occupant-id= occupant.id
@@ -43,10 +43,8 @@
                 span= t("occupants.delete.action")
                 i.glyphicon.glyphicon-remove
 
-  .occupant-inline-form
-    = f.fields_for @projet_courant do |ff|
-      = ff.input :future_birth
 
+  p.chapo= t("occupants.confirmer_nombre_personnes_ajouter")
   .occupant-inline-form
     h3.occupant-inline-form__title Ajouter un occupant
     .occupant-inline-form__fields
@@ -55,10 +53,16 @@
       = f.input :date_de_naissance, as: :string, wrapper_html: { class: "occupant-inline-form__field size-l" }, required: true
       = btn name: t("occupants.nouveau.action"), class: "btn-secondary occupant-inline-form__submit", icon: "plus"
 
+  .occupant-inline-form
+    h3.occupant-inline-form__title Autre situation
+    = f.fields_for @projet_courant do |ff|
+      = ff.input :future_birth
+
   .checkbox-validation
     label.form-control-label
       input type="checkbox" class="js-engagement"
       = t("agrements.attestation_communiquer_infos_occupants")
 
   = btn name: @action_label, class: "btn-large btn-centered js-engagement", icon: "arrow-right", html: { name: :submit_button }
+  = btn name: "Retour", href: projet_or_dossier_avis_impositions_path(@projet_courant), class: "btn-secondary", icon: "arrow-left"
 

--- a/app/views/projets/_foyer.html.slim
+++ b/app/views/projets/_foyer.html.slim
@@ -1,12 +1,12 @@
 article.block.occupants
-  h3 Ma Situation
+  h3 Ma situation
   - if can? :update, @projet_courant
     = edit_projet_button(@projet_courant, dossier_demandeur_path(@projet_courant))
   .occupants-recap
     ul
       li
         | Nombre d’occupants :
-        span= " #{@projet_courant.nb_total_occupants} " + (@projet_courant.future_birth ? "+ enfant(s) à naître" : "")
+        span= " #{@projet_courant.nb_total_occupants} " + (@projet_courant.future_birth ? "+ enfant à naître" : "")
       li
         = t('demarrage_projet.demandeur.revenu_fiscal_reference')
         span= " #{@projet_courant.annee_fiscale_reference} : "

--- a/app/views/projets/new.html.slim
+++ b/app/views/projets/new.html.slim
@@ -15,8 +15,8 @@
         = btn name: "Fermer", href: "#", class: "popin__close"
   #info-avis-fiscal.popin.popin--info_avis_fiscal
     .popin__container
-      p.popin__p Vous souhaitez vous renseigner ou demander une aide à l’Anah. Identifiez-vous en renseignant votre numéro fiscal et la référence de l’avis d’imposition présents sur votre dernier avis d’imposition (#{Time.current.year-1} sur les revenus de #{Time.current.year-2}).
-      p.popin__p Ces renseignements permettront d’aller rechercher directement auprès de la direction générale des finances publiques les coordonnées vous concernant ainsi que votre revenu fiscal de référence (RFR) correspondant à votre niveau de ressources.
+      p.popin__p Pour bénéficier des aides de l’Anah, les ressources de toutes les personnes habitant le logement sont prises en compte.
+      p.popin__p Pour faire votre démarche en ligne, nous vous invitons à vous munir du ou des avis d’imposition des personnes vivant chez vous.
       p.popin__p.popin__p--centered
         = btn name: "Fermer", href: "#", class: "popin__close"
 

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -18,7 +18,7 @@ fr:
         complement: "Je précise mon projet"
         date_achevement_15_ans: "Mon logement (maison ou immeuble) a été construit il y a plus de 15 ans"
         annee_construction: "Si je la connais, j’indique l’année de construction de mon logement"
-        ptz: "J’ai obtenu un prêt à taux zéro (PTZ) pour acheter le logement à rénover (dans les 5 dernières années)"
+        ptz: "J’ai obtenu un prêt à taux zéro (PTZ) pour acheter le logement à rénover dans les 5 dernières années"
       proposition:
         consommation_avant_travaux: "Consommation énergétique avant travaux"
         consommation_apres_travaux: "Consommation énergétique après travaux"
@@ -85,7 +85,7 @@ fr:
 
   # ----------------------- Initialisation d’un projet ---------------------
   demarrage_projet:
-    action: "Suivant"
+    action: "Continuer"
     # ----------------------- Demandeur ---------------------
     demandeur:
       erreurs:
@@ -262,7 +262,7 @@ fr:
       remplir_le_projet: "Je remplis le projet"
       modifier_liste_occupant: "Modifier le nombre d’occupant à charge"
       lien_ajout_occupant: "J’ajoute un occupant"
-      future_birth: "Enfant(s) à naître dans le foyer"
+      future_birth: "Enfant à naître"
       titre_infos_demandeur: "Mes infos"
       titre_identification_demandeur: "Identification du demandeur"
       titre_liste_occupants: "Liste des occupants"
@@ -447,10 +447,11 @@ fr:
 
   # ----------------------- Gestion des occupants ---------------------
   occupants:
-    title: "Occupants"
+    title: "Les occupants de mon logement"
     occupants: "Occupants"
     nombre_occupant: "Nombre d’occupants :"
-    confirmer_nombre_personnes: "Veuillez confirmer le nombre de personnes occupant le logement ainsi que leurs années de naissance."
+    confirmer_nombre_personnes_supprimer: "Voici le récapitulatif des personnes occupant votre logement d'après les avis d'imposition. Si une ou plusieurs de ces personnes n'habitent pas dans votre logement, veuillez les supprimer."
+    confirmer_nombre_personnes_ajouter: "Si d'autres personnes (sans avis d'imposition) habitent dans votre logement, merci de compléter les informations ci-dessous:"
     annee_naissance: "Année de naissance"
     actions: "Actions"
     nouveau:
@@ -463,7 +464,7 @@ fr:
       composition_logement: "Composition du logement"
     delete:
       confirm: "Êtes-vous sûr de vouloir retirer %{fullname} de la liste des occupants de votre logement ?"
-      action: "Retirer"
+      action: "Supprimer"
       success: "%{fullname} a été retiré de la liste des occupants."
       error: "Une erreur s’est produite lors de la suppression de l’occupant."
       cant_delete_demandeur: "Les occupants mentionnés dans l’avis d’imposition ne peuvent pas être retirés de la liste."

--- a/config/locales/simple_form/fr.yml
+++ b/config/locales/simple_form/fr.yml
@@ -72,7 +72,7 @@ fr:
         etage: "Étage"
         etiquette_apres_travaux: "Étiquette énergétique après travaux"
         etiquette_avant_travaux: "Étiquette énergétique avant travaux"
-        future_birth: "Enfant(s) à naître dans le foyer"
+        future_birth: "Enfant à naître"
         gain_energetique: "Gain énergétique"
         handicap: "MDPH / CDAPH"
         loan_amount: "Prêt"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,7 +190,6 @@ ActiveRecord::Schema.define(version: 20170914143339) do
     t.string "prenom"
     t.integer "lien_demandeur"
     t.date "date_de_naissance"
-    t.integer "civilite"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "demandeur"

--- a/spec/features/1_demarrage/etape3_occupants_spec.rb
+++ b/spec/features/1_demarrage/etape3_occupants_spec.rb
@@ -59,7 +59,7 @@ feature "Occupants :" do
       visit projet_path(projet)
 
       expect(page).to have_content I18n.t("projets.visualisation.future_birth")
-      expect(page).to have_content "+ enfant(s) à naître"
+      expect(page).to have_content "+ enfant à naître"
 
       visit projet_occupants_path(projet)
       uncheck I18n.t("simple_form.labels.projet.future_birth")
@@ -67,7 +67,7 @@ feature "Occupants :" do
       visit projet_path(projet)
 
       expect(page).to have_no_content I18n.t("projets.visualisation.future_birth")
-      expect(page).to have_no_content "+ enfant(s) à naître"
+      expect(page).to have_no_content "+ enfant à naître"
     end
 
     scenario "je peux passer à l'étape suivante" do


### PR DESCRIPTION
Pour le wording : je pense que ce qu'il reste à implémenter est plus que du simple wording, ça va prendre du temps à faire je propose de merger ça déjà et de voir pour d'eventuelles US pour le reste


Wording en cours : 
A implémenter je n'ai pas pu / pas eu le temps

Avis revenu fiscal pour année invalide --> quel est le compte de test j'ai l'impression qu'il ne marche plus? Il semblerait que le message d'erreur pour les mauvaises années ne s'affiche pas (on a le générique)

Occupants : enjoliver la nouvelle page & modifier le bouton "ajouter" --> sont genées par le retour en haut de page, mettre le bouton ajouter au même niveau que les boutons retirer dans les occupants? --> aucun message de succes

Page projet : A la premiere connexion y a ecrit que PRIS DDT n'a rien proposé. Ca c'est à partir de la connexion suivante. A la premiere connexion on dit juste le message a été envoyé au PRIS

Récap projet : espace entre mon chauffage me coute trop cher et informations supplémentaires --> GROS refacto à faire sur cette page pour pouovir l'ajouter xD