### PR TITLE
PF311 gère l'opérateur mandataire

### DIFF
--- a/app/models/intervenant.rb
+++ b/app/models/intervenant.rb
@@ -62,4 +62,8 @@ class Intervenant < ApplicationRecord
   def dreal?
     (roles || []).include?('dreal')
   end
+
+  def mandataire?
+    invitations.mandataire.present?
+  end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -13,8 +13,8 @@ class Invitation < ApplicationRecord
 
   validates :projet, :intervenant, presence: true
   validates_uniqueness_of :intervenant, scope: :projet_id
-  validate :mandataire_is_operateur, if: -> { kind.to_sym == :mandataire }
-  validate :single_mandataire,       if: -> { kind.to_sym == :mandataire && revoked_at.blank? }
+  validate :mandataire_is_operateur
+  validate :single_mandataire
 
   delegate :demandeur,           to: :projet
   delegate :description_adresse, to: :projet
@@ -22,19 +22,19 @@ class Invitation < ApplicationRecord
   scope :visible_for_operateur, -> (operateur) {
     where(intervenant_id: operateur.id).includes(:projet).select { |i| (i.projet.operateur == operateur) || i.projet.operateur.blank? }
   }
-  scope :mandataire,         -> { where "invitations.kind = 'mandataire' AND invitations.revoked_at IS NULL" }
-  scope :revoked_mandataire, -> { where "invitations.kind = 'mandataire' AND invitations.revoked_at IS NOT NULL" }
+  scope :mandataire,         -> { where(kind: :mandataire).where(revoked_at: nil) }
+  scope :revoked_mandataire, -> { where(kind: :mandataire).where.not(revoked_at: nil) }
 
   private
 
   def single_mandataire
-    if projet.invitations.mandataire.count >= 1 || projet.mandataire_user.present?
+    if (kind.to_sym == :mandataire) && revoked_at.blank? && (projet.invitations.mandataire.count >= 1 || projet.mandataire_user.present?)
       errors[:base] << I18n.t("invitations.single_mandataire")
     end
   end
 
   def mandataire_is_operateur
-    unless intervenant.operateur?
+    if (kind.to_sym == :mandataire) && !intervenant.operateur?
       errors[:base] << I18n.t("invitations.mandataire_is_operateur")
     end
   end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -13,6 +13,8 @@ class Invitation < ApplicationRecord
 
   validates :projet, :intervenant, presence: true
   validates_uniqueness_of :intervenant, scope: :projet_id
+  validate :mandataire_is_operateur, if: -> { kind.to_sym == :mandataire }
+  validate :single_mandataire,       if: -> { kind.to_sym == :mandataire && revoked_at.blank? }
 
   delegate :demandeur,           to: :projet
   delegate :description_adresse, to: :projet
@@ -20,5 +22,20 @@ class Invitation < ApplicationRecord
   scope :visible_for_operateur, -> (operateur) {
     where(intervenant_id: operateur.id).includes(:projet).select { |i| (i.projet.operateur == operateur) || i.projet.operateur.blank? }
   }
-end
+  scope :mandataire,         -> { where "invitations.kind = 'mandataire' AND invitations.revoked_at IS NULL" }
+  scope :revoked_mandataire, -> { where "invitations.kind = 'mandataire' AND invitations.revoked_at IS NOT NULL" }
 
+  private
+
+  def single_mandataire
+    if projet.invitations.mandataire.count >= 1 || projet.mandataire_user.present?
+      errors[:base] << I18n.t("invitations.single_mandataire")
+    end
+  end
+
+  def mandataire_is_operateur
+    unless intervenant.operateur?
+      errors[:base] << I18n.t("invitations.mandataire_is_operateur")
+    end
+  end
+end

--- a/app/models/projet.rb
+++ b/app/models/projet.rb
@@ -114,6 +114,14 @@ class Projet < ApplicationRecord
     User.where id: projets_users.revoked_mandataire.map(&:user_id)
   end
 
+  def mandataire_operateur
+    invitations.mandataire.first.try(:intervenant)
+  end
+
+  def revoked_mandataire_operateurs
+    Intervenant.where id: invitations.revoked_mandataire.map(&:intervenant_id)
+  end
+
   def self.find_by_locator(locator)
     is_numero_plateforme = locator.try(:include?, '_')
     if is_numero_plateforme

--- a/app/models/projets_user.rb
+++ b/app/models/projets_user.rb
@@ -18,7 +18,7 @@ class ProjetsUser < ApplicationRecord
   end
 
   def single_mandataire
-    if projet.projets_users.mandataire.count >= 1
+    if projet.projets_users.mandataire.count >= 1 || projet.mandataire_operateur.present?
       errors[:base] << I18n.t("projets_users.single_mandataire")
     end
   end

--- a/app/models/projets_user.rb
+++ b/app/models/projets_user.rb
@@ -3,22 +3,22 @@ class ProjetsUser < ApplicationRecord
   belongs_to :user
 
   scope :demandeur,          -> { where kind: :demandeur }
-  scope :mandataire,         -> { where "projets_users.kind = 'mandataire' AND projets_users.revoked_at IS NULL" }
-  scope :revoked_mandataire, -> { where "projets_users.kind = 'mandataire' AND projets_users.revoked_at IS NOT NULL" }
+  scope :mandataire,         -> { where(kind: :mandataire).where(revoked_at: nil) }
+  scope :revoked_mandataire, -> { where(kind: :mandataire).where.not(revoked_at: nil) }
 
-  validate :single_demandeur,  if: -> { kind.to_sym == :demandeur }
-  validate :single_mandataire, if: -> { kind.to_sym == :mandataire && revoked_at.blank? }
+  validate :single_demandeur
+  validate :single_mandataire
 
   private
 
   def single_demandeur
-    if projet.projets_users.demandeur.count >= 1
+    if (kind.to_sym == :demandeur) && projet.projets_users.demandeur.count >= 1
       errors[:base] << I18n.t("projets_users.single_demandeur")
     end
   end
 
   def single_mandataire
-    if projet.projets_users.mandataire.count >= 1 || projet.mandataire_operateur.present?
+    if (kind.to_sym == :mandataire) && revoked_at.blank? && (projet.projets_users.mandataire.count >= 1 || projet.mandataire_operateur.present?)
       errors[:base] << I18n.t("projets_users.single_mandataire")
     end
   end

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -411,6 +411,8 @@ fr:
         obligatoire: "L’adresse du logement à rénover est obligatoire"
       telephone:
         obligatoire: "Le numéro de téléphone est obligatoire"
+    single_mandataire: "Il ne peut y avoir qu’un seul mandataire actif par projet"
+    mandataire_is_operateur: "Aucun intervenant autre que l’opérateur du projet ne peux être mandataire"
 
   # ----------------------- Gestion des occupants ---------------------
   occupants:

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -412,7 +412,7 @@ fr:
       telephone:
         obligatoire: "Le numéro de téléphone est obligatoire"
     single_mandataire: "Il ne peut y avoir qu’un seul mandataire actif par projet"
-    mandataire_is_operateur: "Aucun intervenant autre que l’opérateur du projet ne peux être mandataire"
+    mandataire_is_operateur: "Aucun intervenant autre que l’opérateur du projet ne peut être mandataire"
 
   # ----------------------- Gestion des occupants ---------------------
   occupants:

--- a/db/migrate/20170908135241_add_mandat_data_to_invitations.rb
+++ b/db/migrate/20170908135241_add_mandat_data_to_invitations.rb
@@ -1,0 +1,6 @@
+class AddMandatDataToInvitations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :invitations, :kind, :string, null: false, default: ""
+    add_column :invitations, :revoked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170904123932) do
+ActiveRecord::Schema.define(version: 20170908135241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,6 +165,8 @@ ActiveRecord::Schema.define(version: 20170904123932) do
     t.datetime "updated_at"
     t.boolean "suggested", default: false, null: false
     t.boolean "contacted", default: false, null: false
+    t.string "kind", default: "", null: false
+    t.datetime "revoked_at"
     t.index ["intermediaire_id"], name: "index_invitations_on_intermediaire_id"
     t.index ["intervenant_id"], name: "index_invitations_on_intervenant_id"
     t.index ["projet_id"], name: "index_invitations_on_projet_id"

--- a/spec/factories/invitations.rb
+++ b/spec/factories/invitations.rb
@@ -6,4 +6,13 @@ FactoryGirl.define do
   factory :mise_en_relation, parent: :invitation do
     association :intermediaire, factory: :intervenant
   end
+
+  trait :mandataire do
+    kind :mandataire
+  end
+
+  trait :revoked_mandataire do
+    kind :mandataire
+    revoked_at DateTime.new(1991, 02, 04)
+  end
 end

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -51,20 +51,39 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_mandataire do
+    trait :with_mandataire_user do
       after(:build) do |projet, evaluator|
         create :projets_user, :mandataire, projet: projet
       end
     end
 
-    trait :with_revoked_mandataire do
+    trait :with_mandataire_operateur do
+      after(:build) do |projet, evaluator|
+        Invitation.where(projet: projet, intervenant: projet.operateur).first.update! kind: :mandataire
+      end
+    end
+
+    trait :with_revoked_mandataire_user do
       transient do
-        revoked_mandataire_count 1
+        revoked_mandataire_user_count 1
       end
 
       after(:build) do |projet, evaluator|
-        evaluator.revoked_mandataire_count.times do
+        evaluator.revoked_mandataire_user_count.times do
           create :projets_user, :revoked_mandataire, projet: projet
+        end
+      end
+    end
+
+    trait :with_revoked_mandataire_operateur do
+      transient do
+        revoked_mandataire_operateur_count 1
+      end
+
+      after(:build) do |projet, evaluator|
+        evaluator.revoked_mandataire_operateur_count.times do
+          operateur = create :operateur
+          create :invitation, :revoked_mandataire, projet: projet, intervenant: operateur, contacted: true
         end
       end
     end

--- a/spec/models/intervenant_spec.rb
+++ b/spec/models/intervenant_spec.rb
@@ -57,4 +57,16 @@ describe Intervenant do
       it { is_expected.to eq nil }
     end
   end
+
+  describe "#mandataire?" do
+    let(:projet_without_mandataire_operateur) { create :projet, :with_committed_operateur }
+    let(:projet_with_mandataire_operateur)    { create :projet, :with_committed_operateur, :with_mandataire_operateur }
+    let(:operateur)                           { projet_without_mandataire_operateur.operateur }
+    let(:mandataire_operateur)                { projet_with_mandataire_operateur.operateur }
+
+    it "retourne vrai quand l'opérateur est mandataire sur un projet" do
+      expect(operateur.mandataire?).to            eq false
+      expect(mandataire_operateur.mandataire?).to eq true
+    end
+  end
 end

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -15,10 +15,10 @@ describe Invitation do
   it { is_expected.to delegate_method(:demandeur).to(:projet) }
   it { is_expected.to delegate_method(:description_adresse).to(:projet) }
 
-  context "if the mandataire is not an operateur" do
+  context "sans mandataire actif" do
     let(:intervenant) { create :intervenant }
 
-    it "prevents from creating the mandataire" do
+    it "je ne peux pas ajouter un opérateur mandataire qui n'est pas celui de mon projet" do
       expect{ create :invitation, projet: projet, intervenant: intervenant, kind: :mandataire }.to raise_error do |error|
         expect(error).to be_a ActiveRecord::RecordInvalid
         expect(error.message).to include I18n.t("invitations.mandataire_is_operateur")
@@ -26,12 +26,12 @@ describe Invitation do
     end
   end
 
-  context "with an active mandataire user" do
+  context "avec un utilisateur mandataire actif" do
     let(:projet)     { create :projet, :with_account, :with_mandataire_user }
     let(:operateur)  { create :operateur }
     let(:invitation) { create :invitation, projet: projet, intervenant: operateur }
 
-    it "prevents from creating two active mandataires" do
+    it "je ne peux pas ajouter d'autres mandataires actifs" do
       expect{ invitation.update! kind: :mandataire }.to raise_error do |error|
         expect(error).to be_a ActiveRecord::RecordInvalid
         expect(error.message).to include I18n.t("invitations.single_mandataire")
@@ -39,12 +39,12 @@ describe Invitation do
     end
   end
 
-  context "with an active mandataire operateur" do
+  context "avec un opérateur mandataire actif" do
     let(:projet)     { create :projet, :with_account, :with_committed_operateur, :with_mandataire_operateur }
     let(:operateur)  { create :operateur }
     let(:invitation) { create :invitation, projet: projet, intervenant: operateur }
 
-    it "prevents from creating two active mandataires" do
+    it "je ne peux pas ajouter d'autres mandataires actifs" do
       expect{ invitation.update! kind: :mandataire }.to raise_error do |error|
         expect(error).to be_a ActiveRecord::RecordInvalid
         expect(error.message).to include I18n.t("invitations.single_mandataire")
@@ -52,7 +52,7 @@ describe Invitation do
     end
   end
 
-  context "with revoked mandataires" do
+  context "avec des mandataires révoqués" do
     let(:projet)                { create :projet, :with_account, :with_committed_operateur, :with_revoked_mandataire_user }
     let(:revoked_operateur)     { create :operateur }
     let(:mandataire_operateur)  { create :operateur }
@@ -60,16 +60,16 @@ describe Invitation do
 
     before { create :invitation, projet: projet, intervenant: revoked_operateur, kind: :mandataire, revoked_at: DateTime.new(1991,02,04) }
 
-    it "can create an active mandataire" do
+    it "je peux ajouter un mandataire actif" do
       expect{ mandataire_invitation.update! kind: :mandataire }.not_to raise_error
     end
   end
 
   describe "scopes" do
-    let(:invitations_with_mandataire_operateur) { create :invitation, :mandataire }
-    let(:invitations_with_revoked_operateur)    { create :invitation, :revoked_mandataire }
+    let!(:invitations_with_mandataire_operateur) { create :invitation, :mandataire }
+    let!(:invitations_with_revoked_operateur)    { create :invitation, :revoked_mandataire }
 
-    it { expect(Invitation.mandataire).to         match_array [invitations_with_mandataire_operateur] }
+    it { expect(Invitation.mandataire).to match_array [invitations_with_mandataire_operateur] }
     it { expect(Invitation.revoked_mandataire).to match_array [invitations_with_revoked_operateur] }
   end
 

--- a/spec/models/projet_spec.rb
+++ b/spec/models/projet_spec.rb
@@ -749,7 +749,7 @@ describe Projet do
   end
 
   describe "#demandeur_user" do
-    let(:projet_without_demandeur) { create :projet, :with_mandataire }
+    let(:projet_without_demandeur) { create :projet, :with_mandataire_user }
     let(:projet_with_demandeur)    { create :projet }
     let(:demandeur)                { create :user }
     let(:mandataire)               { create :user }
@@ -764,37 +764,54 @@ describe Projet do
   end
 
   describe "#mandataire_user" do
-    let(:projet_without_mandataire) { create :projet, :with_account }
-    let(:projet_with_mandataire)    { create :projet }
-    let(:demandeur)                 { create :user }
-    let(:mandataire)                { create :user }
-    let(:revoked_mandataire)        { create :user }
+    let(:projet_without_mandataire)   { create :projet, :with_account }
+    let(:projet_with_mandataire_user) { create :projet }
+    let(:demandeur)                   { create :user }
+    let(:mandataire)                  { create :user }
+    let(:revoked_mandataire)          { create :user }
 
     before do
-      create :projets_user, :demandeur,          projet: projet_with_mandataire, user: demandeur
-      create :projets_user, :mandataire,         projet: projet_with_mandataire, user: mandataire
-      create :projets_user, :revoked_mandataire, projet: projet_with_mandataire, user: revoked_mandataire
+      create :projets_user, :demandeur,          projet: projet_with_mandataire_user, user: demandeur
+      create :projets_user, :mandataire,         projet: projet_with_mandataire_user, user: mandataire
+      create :projets_user, :revoked_mandataire, projet: projet_with_mandataire_user, user: revoked_mandataire
     end
 
     it { expect(projet_without_mandataire.mandataire_user).to be_blank }
-    it { expect(projet_with_mandataire.mandataire_user).to eq mandataire }
+    it { expect(projet_with_mandataire_user.mandataire_user).to eq mandataire }
   end
 
   describe "#revoked_mandataire_users" do
-    let(:projet_with_mandataire)         { create :projet, :with_mandataire }
-    let(:projet_with_revoked_mandataire) { create :projet }
-    let(:mandataire)                     { create :user }
-    let(:revoked_mandataire_1)           { create :user }
-    let(:revoked_mandataire_2)           { create :user }
+    let(:projet_with_mandataire_user)         { create :projet, :with_mandataire_user }
+    let(:projet_with_revoked_mandataire_user) { create :projet }
+    let(:mandataire)                          { create :user }
+    let(:revoked_mandataire_1)                { create :user }
+    let(:revoked_mandataire_2)                { create :user }
 
     before do
-      create :projets_user, :mandataire,         projet: projet_with_revoked_mandataire, user: mandataire
-      create :projets_user, :revoked_mandataire, projet: projet_with_revoked_mandataire, user: revoked_mandataire_1
-      create :projets_user, :revoked_mandataire, projet: projet_with_revoked_mandataire, user: revoked_mandataire_2
+      create :projets_user, :mandataire,         projet: projet_with_revoked_mandataire_user, user: mandataire
+      create :projets_user, :revoked_mandataire, projet: projet_with_revoked_mandataire_user, user: revoked_mandataire_1
+      create :projets_user, :revoked_mandataire, projet: projet_with_revoked_mandataire_user, user: revoked_mandataire_2
     end
 
-    it { expect(projet_with_mandataire.revoked_mandataire_users).to be_blank }
-    it { expect(projet_with_revoked_mandataire.revoked_mandataire_users.count).to eq 2 }
-    it { expect(projet_with_revoked_mandataire.revoked_mandataire_users).to match_array([revoked_mandataire_1, revoked_mandataire_2]) }
+    it { expect(projet_with_mandataire_user.revoked_mandataire_users).to be_blank }
+    it { expect(projet_with_revoked_mandataire_user.revoked_mandataire_users).to match_array([revoked_mandataire_1, revoked_mandataire_2]) }
+  end
+
+  describe "#mandataire_operateur" do
+    let(:projet_with_mandataire_operateur) { create :projet, :with_committed_operateur, :with_mandataire_operateur }
+    let(:projet_with_mandataire_user)      { create :projet, :with_committed_operateur, :with_mandataire_user }
+    let(:mandataire_operateur)             { projet_with_mandataire_operateur.operateur }
+
+    it { expect(projet_with_mandataire_operateur.mandataire_operateur).to eq mandataire_operateur }
+    it { expect(projet_with_mandataire_user.mandataire_operateur).to be_blank }
+  end
+
+  describe "#revoked_mandataire_operateurs" do
+    let(:projet_with_mandataire_operateur)          { create :projet, :with_committed_operateur, :with_mandataire_operateur }
+    let(:projet_with_revoked_mandataire_operateurs) { create :projet, :with_committed_operateur, :with_mandataire_operateur, :with_revoked_mandataire_operateur, revoked_mandataire_operateur_count: 2 }
+    let(:revoked_mandataire_operateurs)             { projet_with_revoked_mandataire_operateurs.intervenants - [projet_with_revoked_mandataire_operateurs.operateur] }
+
+    it { expect(projet_with_mandataire_operateur.revoked_mandataire_operateurs).to be_blank }
+    it { expect(projet_with_revoked_mandataire_operateurs.revoked_mandataire_operateurs).to match_array revoked_mandataire_operateurs }
   end
 end

--- a/spec/models/projets_user_spec.rb
+++ b/spec/models/projets_user_spec.rb
@@ -6,10 +6,10 @@ describe ProjetsUser do
     it { is_expected.to belong_to(:projet) }
     it { is_expected.to belong_to(:user) }
 
-    context "with a demandeur" do
+    context "avec un demandeur" do
       let(:projet) { create :projet, :with_account }
 
-      it "prevents from creating another demandeur" do
+      it "je ne peux ajouter un autre demandeur" do
         expect{ create :projets_user, :demandeur, projet: projet }.to raise_error do |error|
           expect(error).to be_a ActiveRecord::RecordInvalid
           expect(error.message).to include I18n.t("projets_users.single_demandeur")
@@ -17,10 +17,10 @@ describe ProjetsUser do
       end
     end
 
-    context "with an active mandataire user" do
+    context "avec un utilisateur mandataire actif" do
       let(:projet) { create :projet, :with_account, :with_mandataire_user }
 
-      it "prevents from creating two active mandataires" do
+      it "je ne peux créer d'autres mandataires actifs" do
         expect{ create :projets_user, :mandataire, projet: projet }.to raise_error do |error|
           expect(error).to be_a ActiveRecord::RecordInvalid
           expect(error.message).to include I18n.t("projets_users.single_mandataire")
@@ -28,10 +28,10 @@ describe ProjetsUser do
       end
     end
 
-    context "with an active mandataire operateur" do
+    context "avec un opérateur mandataire actif" do
       let(:projet) { create :projet, :with_account, :with_committed_operateur, :with_mandataire_operateur }
 
-      it "prevents from creating two active mandataires" do
+      it "je ne peux créer d'autres mandataires actifs" do
         expect{ create :projets_user, :mandataire, projet: projet }.to raise_error do |error|
           expect(error).to be_a ActiveRecord::RecordInvalid
           expect(error.message).to include I18n.t("projets_users.single_mandataire")
@@ -39,19 +39,19 @@ describe ProjetsUser do
       end
     end
 
-    context "with revoked mandataires" do
+    context "avec des mandataires révoqués" do
       let!(:projet) { create :projet, :with_account, :with_committed_operateur, :with_revoked_mandataire_operateur, :with_revoked_mandataire_user }
 
-      it "can create an active mandataire" do
+      it "je peux créer un mandataire actif" do
         expect{ create :projets_user, :mandataire, projet: projet }.not_to raise_error
       end
     end
   end
 
   describe "scopes" do
-    let(:projets_user_with_demandeur)       { create :projets_user, :demandeur }
-    let(:projets_user_with_mandataire_user) { create :projets_user, :mandataire }
-    let(:projets_user_with_revoked_user)    { create :projets_user, :revoked_mandataire }
+    let!(:projets_user_with_demandeur)       { create :projets_user, :demandeur }
+    let!(:projets_user_with_mandataire_user) { create :projets_user, :mandataire }
+    let!(:projets_user_with_revoked_user)    { create :projets_user, :revoked_mandataire }
 
     it { expect(ProjetsUser.demandeur).to          match_array [projets_user_with_demandeur] }
     it { expect(ProjetsUser.mandataire).to         match_array [projets_user_with_mandataire_user] }

--- a/spec/models/projets_user_spec.rb
+++ b/spec/models/projets_user_spec.rb
@@ -9,7 +9,7 @@ describe ProjetsUser do
     context "with a demandeur" do
       let(:projet) { create :projet, :with_account }
 
-      it "prevent from creating another demandeur" do
+      it "prevents from creating another demandeur" do
         expect{ create :projets_user, :demandeur, projet: projet }.to raise_error do |error|
           expect(error).to be_a ActiveRecord::RecordInvalid
           expect(error.message).to include I18n.t("projets_users.single_demandeur")
@@ -17,10 +17,10 @@ describe ProjetsUser do
       end
     end
 
-    context "with an active mandataire" do
-      let(:projet) { create :projet, :with_account, :with_mandataire }
+    context "with an active mandataire user" do
+      let(:projet) { create :projet, :with_account, :with_mandataire_user }
 
-      it "prevent from creating two active mandataires" do
+      it "prevents from creating two active mandataires" do
         expect{ create :projets_user, :mandataire, projet: projet }.to raise_error do |error|
           expect(error).to be_a ActiveRecord::RecordInvalid
           expect(error.message).to include I18n.t("projets_users.single_mandataire")
@@ -28,22 +28,33 @@ describe ProjetsUser do
       end
     end
 
-    context "with a revoked mandataire" do
-      let!(:projet) { create :projet, :with_account, :with_revoked_mandataire }
+    context "with an active mandataire operateur" do
+      let(:projet) { create :projet, :with_account, :with_committed_operateur, :with_mandataire_operateur }
 
-      it "do not prevent from creating an active mandataire" do
+      it "prevents from creating two active mandataires" do
+        expect{ create :projets_user, :mandataire, projet: projet }.to raise_error do |error|
+          expect(error).to be_a ActiveRecord::RecordInvalid
+          expect(error.message).to include I18n.t("projets_users.single_mandataire")
+        end
+      end
+    end
+
+    context "with revoked mandataires" do
+      let!(:projet) { create :projet, :with_account, :with_committed_operateur, :with_revoked_mandataire_operateur, :with_revoked_mandataire_user }
+
+      it "can create an active mandataire" do
         expect{ create :projets_user, :mandataire, projet: projet }.not_to raise_error
       end
     end
   end
 
   describe "scopes" do
-    let(:projets_user_with_demandeur)  { create :projets_user, :demandeur }
-    let(:projets_user_with_mandataire) { create :projets_user, :mandataire }
-    let(:projets_user_with_revoked)    { create :projets_user, :revoked_mandataire }
+    let(:projets_user_with_demandeur)       { create :projets_user, :demandeur }
+    let(:projets_user_with_mandataire_user) { create :projets_user, :mandataire }
+    let(:projets_user_with_revoked_user)    { create :projets_user, :revoked_mandataire }
 
     it { expect(ProjetsUser.demandeur).to          match_array [projets_user_with_demandeur] }
-    it { expect(ProjetsUser.mandataire).to         match_array [projets_user_with_mandataire] }
-    it { expect(ProjetsUser.revoked_mandataire).to match_array [projets_user_with_revoked] }
+    it { expect(ProjetsUser.mandataire).to         match_array [projets_user_with_mandataire_user] }
+    it { expect(ProjetsUser.revoked_mandataire).to match_array [projets_user_with_revoked_user] }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -116,7 +116,7 @@ describe User do
     end
 
     context "quand il y a un mandataire" do
-      let(:projet) { create :projet, :transmis_pour_instruction, :with_payment_registry, :with_mandataire }
+      let(:projet) { create :projet, :transmis_pour_instruction, :with_payment_registry, :with_mandataire_user }
 
       context "en tant que mandataire" do
         let(:user) { projet.mandataire_user }


### PR DESCRIPTION
Le mandataire peut maintenant être soit un opérateur soit un user.
J'ai rajouté la contrainte : un seul mandataire actif à la fois (opérateur ou user)
Le tout est testé