### PR TITLE
PF737 retire le bouton paiements lorsqu'il n y a pas encore de registry

### DIFF
--- a/app/views/projets/_menu.html.slim
+++ b/app/views/projets/_menu.html.slim
@@ -22,9 +22,14 @@
       span.project-menu__icon.glyphicon.glyphicon-folder-open
       span.project-menu__text Dossier
     - if ENV["PAYMENTS_ENABLED"] == "true"
-      = link_to projet_or_dossier_payment_registry_path(project), class: "project-menu__item"
-        span.project-menu__icon.glyphicon.glyphicon-euro
-        span.project-menu__text Paiements
+      - if can? :create, PaymentRegistry
+        = link_to dossier_payment_registry_path(project), method: :post, class: "project-menu__item"
+          span.project-menu__icon.glyphicon.glyphicon-euro
+          span.project-menu__text Paiements
+      - elsif project.payment_registry.present?
+        = link_to projet_or_dossier_payment_registry_path(project), class: "project-menu__item"
+          span.project-menu__icon.glyphicon.glyphicon-euro
+          span.project-menu__text Paiements
     = link_to projet_or_dossier_documents_path(project), class: "project-menu__item"
       span.project-menu__icon.glyphicon.glyphicon-paperclip
       span.project-menu__text Pièces

--- a/app/views/projets/_menu.html.slim
+++ b/app/views/projets/_menu.html.slim
@@ -26,7 +26,7 @@
         = link_to dossier_payment_registry_path(project), method: :post, class: "project-menu__item"
           span.project-menu__icon.glyphicon.glyphicon-euro
           span.project-menu__text Paiements
-      - elsif project.payment_registry.present?
+      - elsif can? :show, project.payment_registry
         = link_to projet_or_dossier_payment_registry_path(project), class: "project-menu__item"
           span.project-menu__icon.glyphicon.glyphicon-euro
           span.project-menu__text Paiements


### PR DESCRIPTION
> S'il n'y a pas encore de payment registry, retire tous les boutons payment
> L'opérateur voit le bouton dès que le dossier passe à l'instructeur, et cliquer dessus crée le payment regisrty s'il n'existe pas encore, et l'ouvre sinon