### PR TITLE
PF723 fix erreur sur les exports CSV

### DIFF
--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -204,7 +204,7 @@ private
       format.csv {
         response.headers["Content-Type"]        = "text/csv; charset=#{csv_ouput_encoding.name}"
         response.headers["Content-Disposition"] = "attachment; filename=#{export_filename}"
-        render text: Projet.to_csv(current_agent)
+        render plain: Projet.to_csv(current_agent)
         return false
       }
     end


### PR DESCRIPTION
C'etait une erreur liée au passage à rails 5 :
> render text: Projet.to_csv par => render plain: Projet.to_csv