### PR TITLE
PF736 verrouillage PJs paiements

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -11,7 +11,10 @@ class Payment < ApplicationRecord
 
   state_machine :action, initial: :a_rediger do
     after_transition :a_rediger => :a_valider,   do: :update_statut_to_propose
-    after_transition :a_valider => :a_instruire, do: :update_statut_to_demande
+    after_transition :a_valider => :a_instruire do |payment, transition|
+      payment.update_statut_to_demande
+      payment.update!(corrected_at: Time.now) if payment.submitted_at.present?
+    end
     after_transition :a_instruire => :aucune,    do: :update_statut_to_en_cours_d_instruction
 
     event(:ask_for_validation)   { transition [:a_rediger, :a_modifier] => :a_valider}

--- a/db/migrate/20170915114816_add_corrected_at_to_payments.rb
+++ b/db/migrate/20170915114816_add_corrected_at_to_payments.rb
@@ -1,0 +1,5 @@
+class AddCorrectedAtToPayments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :payments, :corrected_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170914143339) do
+ActiveRecord::Schema.define(version: 20170915114816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -227,6 +227,7 @@ ActiveRecord::Schema.define(version: 20170914143339) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "action"
+    t.datetime "corrected_at"
     t.index ["payment_registry_id"], name: "index_payments_on_payment_registry_id"
   end
 

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -44,6 +44,7 @@ describe Agent do
 
         context "quand il est engagé avec le demandeur" do
           let(:agent) { create :agent, intervenant: projet.operateur }
+          let!(:document) { create :document, category: projet, created_at: DateTime.new(2017,02,03) }
 
           context "il peut gérer le projet jusqu'à ce qu'il soit 'transmis pour instruction'" do
             let(:projet) { create :projet, :en_cours}
@@ -55,12 +56,12 @@ describe Agent do
             it { is_expected.to be_able_to(:manage, Demande) }
             it { is_expected.to be_able_to(:manage, :demandeur) }
             it { is_expected.to be_able_to(:manage, Occupant) }
-            it { is_expected.to be_able_to(:destroy, Document) }
+            it { is_expected.to be_able_to(:destroy, document) }
             it { is_expected.to be_able_to(:manage, Projet) }
           end
 
           context "il peut uniquement lire le projet et gérer les documents une fois le projet 'transmis pour instruction'" do
-            let(:projet) { create :projet, :transmis_pour_instruction }
+            let(:projet) { create :projet, :transmis_pour_instruction, date_depot: DateTime.new(2017,02,04) }
 
             it { is_expected.not_to be_able_to(:manage, AvisImposition) }
             it { is_expected.not_to be_able_to(:manage, Demande) }
@@ -69,7 +70,7 @@ describe Agent do
             it { is_expected.not_to be_able_to(:manage, Occupant) }
             it { is_expected.not_to be_able_to(:manage, Projet) }
 
-            it { is_expected.to be_able_to(:destroy, Document) }
+            it { is_expected.not_to be_able_to(:destroy, document) }
             it { is_expected.to be_able_to(:read, Projet) }
           end
         end
@@ -197,10 +198,11 @@ describe Agent do
 
         context "en tant qu'operateur" do
           let(:agent)    { create :agent, intervenant: projet.operateur }
-          let(:document) { create :document, category: payment_a_rediger }
+          let!(:document) { create :document, category: payment_a_rediger }
 
           it { is_expected.to     be_able_to(:read,    document) }
           it { is_expected.to     be_able_to(:destroy, document) }
+          # tester les droits de suppression sur les documents des paiements
 
           it { is_expected.to     be_able_to(:create,               Payment) }
           it { is_expected.to     be_able_to(:read,                 Payment) }

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -118,6 +118,17 @@ describe Payment do
       it { should_have(:action).equal_to(:a_modifier).after_event(:ask_for_modification) }
       it { should_have(:action).equal_to(:a_instruire).after_event(:ask_for_instruction) }
       it { should_have(:action).equal_to(:aucune).after_event(:send_in_opal) }
+
+      context "quand la demande de paiement n'a pas encore été déposée" do
+        it { should_have(:corrected_at).equal_to(nil).after_event(:ask_for_instruction) }
+      end
+
+      context "quand la demande de paiement a déjà été déposée" do
+        let(:correction_time) { Time.now }
+        before { payment.update! submitted_at: Time.new(2017) }
+
+        it { should_have(:corrected_at).equal_to(correction_time).after_event(:ask_for_instruction) }
+      end
     end
   end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -124,8 +124,12 @@ describe Payment do
       end
 
       context "quand la demande de paiement a déjà été déposée" do
-        let(:correction_time) { Time.now }
-        before { payment.update! submitted_at: Time.new(2017) }
+        let(:correction_time) { Time.new(2017,2,1) }
+
+        before do
+          payment.update! action: :a_valider, submitted_at: Time.new(2017)
+          allow(Time).to receive(:now).and_return(correction_time)
+        end
 
         it { should_have(:corrected_at).equal_to(correction_time).after_event(:ask_for_instruction) }
       end


### PR DESCRIPTION
Maintenant les PJs des demandes de paiements ne sont plus supprimables si elles ont été uploadées avant dépôt ou "redépôt"