### PR TITLE
ERASING Payment Registry step 1

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -18,6 +18,7 @@ class PaymentsController < ApplicationController
 
   def create
     @payment = Payment.new payment_params
+    @payment.projet_id = @projet_courant.id #TODO Delete with PaymentRegistry
     if @payment.save
       @projet_courant.payment_registry.payments << @payment
       redirect_to dossier_payment_registry_path @projet_courant
@@ -32,7 +33,9 @@ class PaymentsController < ApplicationController
   def update
     @payment = Payment.new payment_params
     payment_to_update = Payment.find params[:payment_id]
-    if @payment.valid? && payment_to_update.update(payment_params)
+    payment_to_update.assign_attributes payment_params
+    payment_to_update.projet_id = @projet_courant.id #TODO Delete with PaymentRegistry
+    if @payment.valid? && payment_to_update.save
       redirect_to dossier_payment_registry_path @projet_courant
     else
       render :edit

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -49,10 +49,6 @@ class Payment < ApplicationRecord
     [I18n.t("payment.description.statut.#{statut}"), I18n.t("payment.description.action.#{action}")].join(" ").strip.capitalize
   end
 
-  def projet_id
-    payment_registry.try(:projet_id)
-  end
-
   private
 
   def validate_type_paiement

--- a/db/migrate/20171004132955_change_payments_dependencies.rb
+++ b/db/migrate/20171004132955_change_payments_dependencies.rb
@@ -1,0 +1,5 @@
+class ChangePaymentsDependencies < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :payments, :projet, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170927134628) do
+ActiveRecord::Schema.define(version: 20171004132955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,7 +228,9 @@ ActiveRecord::Schema.define(version: 20170927134628) do
     t.datetime "updated_at", null: false
     t.string "action"
     t.datetime "corrected_at"
+    t.bigint "projet_id"
     t.index ["payment_registry_id"], name: "index_payments_on_payment_registry_id"
+    t.index ["projet_id"], name: "index_payments_on_projet_id"
   end
 
   create_table "personnes", id: :serial, force: :cascade do |t|

--- a/lib/tasks/deployment/20171004133538_migrate_payments_to_projet.rake
+++ b/lib/tasks/deployment/20171004133538_migrate_payments_to_projet.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_payments_to_projet'
+  task migrate_payments_to_projet: :environment do
+    puts "Running deploy task 'migrate_payments_to_projet'" unless Rake.application.options.quiet
+
+    Payment.find_each do |payment|
+      payment_registry = payment.payment_registry
+
+      if payment_registry && payment.projet_id.blank?
+        payment.update! projet_id: payment_registry.projet.id
+      end
+    end
+
+    AfterParty::TaskRecord.create version: '20171004133538'
+  end
+end

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -47,6 +47,7 @@ describe PaymentsController do
           expect(payment.type_paiement).to eq "avance"
           expect(payment.beneficiaire).to  eq "SOLIHA"
           expect(payment.procuration).to   eq true
+          expect(payment.projet_id).to     eq projet.id #TODO Delete with PaymentRegistry
           expect(response).to redirect_to dossier_payment_registry_path(projet)
         end
       end
@@ -67,6 +68,7 @@ describe PaymentsController do
           expect(payment.type_paiement).to eq "avance"
           expect(payment.beneficiaire).to  eq projet.demandeur.fullname
           expect(payment.procuration).to   eq false
+          expect(payment.projet_id).to     eq projet.id #TODO Delete with PaymentRegistry
           expect(response).to redirect_to dossier_payment_registry_path(projet)
         end
       end
@@ -115,6 +117,7 @@ describe PaymentsController do
           expect(payment.type_paiement).to eq "solde"
           expect(payment.beneficiaire).to  eq "SOLIHA"
           expect(payment.procuration).to   eq true
+          expect(payment.projet_id).to     eq projet.id #TODO Delete with PaymentRegistry
           expect(response).to redirect_to dossier_payment_registry_path(projet)
         end
       end
@@ -135,6 +138,7 @@ describe PaymentsController do
           expect(payment.type_paiement).to eq "solde"
           expect(payment.beneficiaire).to  eq projet.demandeur.fullname
           expect(payment.procuration).to   eq false
+          expect(payment.projet_id).to     eq projet.id #TODO Delete with PaymentRegistry
           expect(response).to redirect_to dossier_payment_registry_path(projet)
         end
       end

--- a/spec/lib/tasks/deployment/migrate_payments_to_projet_spec.rb
+++ b/spec/lib/tasks/deployment/migrate_payments_to_projet_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'support/after_party_helper'
+
+describe '20171004133538_migrate_payments_to_projet' do
+  include_context 'after_party'
+
+  let!(:projet)            { create :projet, :transmis_pour_instruction, :with_payment_registry }
+  let!(:other_projet)      { create :projet, :transmis_pour_instruction, :with_payment_registry }
+  let!(:payment_updated)   { create :payment, payment_registry: projet.payment_registry, projet_id: other_projet.id }
+  let!(:payment_to_update) { create :payment, payment_registry: projet.payment_registry }
+
+  before do
+    subject.invoke
+    payment_updated.reload
+    payment_to_update.reload
+  end
+
+  it "charge l'environment Rails" do
+    expect(subject.prerequisites).to include 'environment'
+  end
+
+  it "met à jour les payments" do
+    expect(payment_updated.projet_id).to   eq other_projet.id
+    expect(payment_to_update.projet_id).to eq projet.id
+  end
+end

--- a/spec/mailers/payment_mailer_spec.rb
+++ b/spec/mailers/payment_mailer_spec.rb
@@ -11,8 +11,8 @@ describe PaymentMailer, type: :mailer do
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t("mailers.paiement_mailer.destruction.sujet", operateur: projet.operateur.raison_sociale)) }
-    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
-    it { expect(email.body.encoded).to match(projet.operateur.raison_sociale) }
+    it { expect(email.body).to include(projet.demandeur.fullname) }
+    it { expect(email.body).to include(projet.operateur.raison_sociale) }
     it { expect(email.body).to include("a supprimé la demande de paiement") }
   end
 
@@ -25,8 +25,8 @@ describe PaymentMailer, type: :mailer do
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t("mailers.paiement_mailer.demande_validation.sujet")) }
-    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
-    it { expect(email.body.encoded).to match(projet.operateur.raison_sociale) }
+    it { expect(email.body).to include(projet.demandeur.fullname) }
+    it { expect(email.body).to include(projet.operateur.raison_sociale) }
     it { expect(email.body).to include("a complété votre demande de paiement") }
   end
 
@@ -38,7 +38,7 @@ describe PaymentMailer, type: :mailer do
     it { expect(email.from).to eq([ENV["EMAIL_CONTACT"]]) }
     it { expect(email.to).to eq([projet.operateur.email]) }
     it { expect(email.subject).to eq(I18n.t("mailers.paiement_mailer.depot.sujet", demandeur: projet.demandeur.fullname)) }
-    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
+    it { expect(email.body).to include(projet.demandeur.fullname) }
     it { expect(email.body).to include("a déposé la demande") }
   end
 
@@ -63,7 +63,7 @@ describe PaymentMailer, type: :mailer do
     it { expect(email.from).to eq([ENV["EMAIL_CONTACT"]]) }
     it { expect(email.to).to eq([projet.invited_instructeur.email]) }
     it { expect(email.subject).to eq(I18n.t("mailers.paiement_mailer.correction_depot.sujet", demandeur: projet.demandeur.fullname)) }
-    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
+    it { expect(email.body).to include(projet.demandeur.fullname) }
     it { expect(email.body).to include("a modifié la demande") }
   end
 

--- a/spec/mailers/projet_mailer_spec.rb
+++ b/spec/mailers/projet_mailer_spec.rb
@@ -9,8 +9,8 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.recommandation_operateurs.sujet')) }
-    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
-    it { expect(email.body.encoded).to match(projet_choix_operateur_url(projet)) }
+    it { expect(email.body).to include(projet.demandeur.fullname) }
+    it { expect(email.body).to include(projet_choix_operateur_url(projet)) }
   end
 
   describe "notifie l'opérateur de l'invitation du demandeur" do
@@ -20,10 +20,10 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([invitation.intervenant.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.invitation_intervenant.sujet', demandeur: invitation.demandeur.fullname)) }
-    it { expect(email.body.encoded).to match(invitation.demandeur.fullname) }
-    it { expect(email.body.encoded).to match(invitation.description_adresse) }
-    it { expect(email.body.encoded).to include("Difficultés rencontrées dans le logement") }
-    it { expect(email.body.encoded).to include(dossier_url(invitation.projet)) }
+    it { expect(email.body).to include(invitation.demandeur.fullname) }
+    it { expect(email.body).to include(invitation.description_adresse) }
+    it { expect(email.body).to include("Difficultés rencontrées dans le logement") }
+    it { expect(email.body).to include(dossier_url(invitation.projet)) }
   end
 
   describe "notifie le demandeur qu'il a bien invité un opérateur " do
@@ -35,8 +35,8 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_invitation_intervenant.sujet', intervenant: invitation.intervenant.raison_sociale)) }
-    it { expect(email.body.encoded).to match(invitation.intervenant.raison_sociale) }
-    it { expect(email.body.encoded).to include("Un email vient d’être envoyé à ") }
+    it { expect(email.body).to include(invitation.intervenant.raison_sociale) }
+    it { expect(email.body).to include("Un email vient d’être envoyé à ") }
   end
 
   describe "notifie l'opérateur que le demandeur a choisi un autre opérateur" do
@@ -46,7 +46,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([invitation.intervenant.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.resiliation_operateur.sujet', demandeur: invitation.demandeur.fullname)) }
-    it { expect(email.body.encoded).to match(invitation.demandeur.fullname) }
+    it { expect(email.body).to include(invitation.demandeur.fullname) }
   end
 
   describe "notifie l'intervenant qu'il a été choisi par le demandeur" do
@@ -58,8 +58,8 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([projet.operateur.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_engagement_operateur.sujet', intervenant: operateur.raison_sociale, demandeur: projet.demandeur.fullname)) }
-    it { expect(email.body.encoded).to match(invitation.demandeur.fullname) }
-    it { expect(email.body.encoded).to include(dossier_url(projet)) }
+    it { expect(email.body).to include(invitation.demandeur.fullname) }
+    it { expect(email.body).to include(dossier_url(projet)) }
   end
 
   describe "notifie le demandeur qu'il doit valider la proposition faite par l'opérateur" do
@@ -71,8 +71,8 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.to).to eq([projet.email]) }
     it { expect(email.cc).to eq([projet.personne.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.notification_validation_dossier.sujet')) }
-    it { expect(email.body.encoded).to match(projet.demandeur.fullname) }
-    it { expect(email.body.encoded).to match(projet.operateur.raison_sociale) }
+    it { expect(email.body).to include(projet.demandeur.fullname) }
+    it { expect(email.body).to include(projet.operateur.raison_sociale) }
     it { expect(email.body).to include("a complété votre dossier") }
   end
 
@@ -85,7 +85,7 @@ describe ProjetMailer, type: :mailer do
     it { expect(email.from).to eq([ENV['EMAIL_CONTACT']]) }
     it { expect(email.to).to eq([mise_en_relation.intervenant.email]) }
     it { expect(email.subject).to eq(I18n.t('mailers.projet_mailer.mise_en_relation_intervenant.sujet', intermediaire: mise_en_relation.intermediaire.raison_sociale)) }
-    it { expect(email.body.encoded).to match(mise_en_relation.description_adresse) }
+    it { expect(email.body).to include(mise_en_relation.description_adresse) }
     it { expect(email.body).to include(prestation.libelle) }
   end
 


### PR DESCRIPTION
Cette PR : 
- rajoute une colonne projet_id sur les payments et la remplit avec le projet concerné
- update cette colonne lors de la création d'un nouveau payment => tous les payments seront ok pour la suite