### PR TITLE
PF844 fix suppression demande lors MAJ proposition

### DIFF
--- a/app/controllers/demandes_controller.rb
+++ b/app/controllers/demandes_controller.rb
@@ -7,24 +7,30 @@ class DemandesController < ApplicationController
   before_action do
     set_current_registration_step CURRENT_REGISTRATION_STEP
   end
+  before_action :init_demande
 
   def show
-    @demande = projet_demande
-    @page_heading = "Ma demande"
-    @action_label = action_label
+    init_show
   end
 
   def update
-    @projet_courant.demande = projet_demande
-    if demande_params_valid?
-      @projet_courant.demande.update_attributes(demande_params)
-      redirect_to_next_step
-    else
-      redirect_to projet_or_dossier_demande_path(@projet_courant), alert: t('demarrage_projet.demande.erreurs.besoin_obligatoire')
+    @demande.update_attributes(demande_params)
+    unless @demande.save
+      init_show
+      return render :show
     end
+    redirect_to_next_step
   end
 
 private
+  def init_demande
+    @demande = @projet_courant.demande || @projet_courant.build_demande
+  end
+
+  def init_show
+    @page_heading = "Ma demande"
+    @action_label = action_label
+  end
 
   def action_label
     if needs_next_step?
@@ -32,10 +38,6 @@ private
     else
       t('projets.edition.action')
     end
-  end
-
-  def projet_demande
-    @projet_courant.demande || @projet_courant.build_demande
   end
 
   def demande_params
@@ -61,10 +63,6 @@ private
       :ptz,
       :date_achevement_15_ans
     )
-  end
-
-  def demande_params_valid?
-    demande_params.values.include?('1')
   end
 
   def needs_next_step?

--- a/app/controllers/dossiers_controller.rb
+++ b/app/controllers/dossiers_controller.rb
@@ -145,7 +145,7 @@ private
         :localized_amo_amount, :localized_assiette_subventionnable_amount, :localized_maitrise_oeuvre_amount, :localized_travaux_ht_amount, :localized_travaux_ttc_amount,
         :localized_loan_amount, :localized_personal_funding_amount,
         :documents_attributes,
-        :demande_attributes => [:annee_construction],
+        :demande_attributes => [:id, :annee_construction],
         :theme_ids => [],
         :suggested_operateur_ids => [],
         :prestation_choices_attributes => [:prestation_id, :desired, :recommended, :selected],

--- a/app/models/demande.rb
+++ b/app/models/demande.rb
@@ -1,6 +1,8 @@
 class Demande < ApplicationRecord
   belongs_to :projet
 
+  validate :validate_theme_existence
+
   REQUIRED_ATTRIBUTES = [
     :changement_chauffage,
     :froid,
@@ -26,14 +28,25 @@ class Demande < ApplicationRecord
   end
 
   def is_about_energy?
-    changement_chauffage || froid || travaux_fenetres || travaux_isolation || travaux_chauffage
+    !!(changement_chauffage || froid || travaux_fenetres || travaux_isolation || travaux_chauffage)
   end
 
   def is_about_self_sufficiency?
-    probleme_deplacement || accessibilite || hospitalisation || adaptation_salle_de_bain || travaux_adaptation_sdb || travaux_monte_escalier || travaux_amenagement_ext
+    !!(probleme_deplacement || accessibilite || hospitalisation || adaptation_salle_de_bain || travaux_adaptation_sdb || travaux_monte_escalier || travaux_amenagement_ext)
   end
 
   def is_about_unhealthiness?
-    arrete || saturnisme
+    !!(arrete || saturnisme)
+  end
+
+  def has_a_theme?
+    is_about_energy? || is_about_self_sufficiency? || is_about_unhealthiness?
+  end
+
+  def validate_theme_existence
+    unless has_a_theme?
+      errors[:base] << I18n.t("demarrage_projet.demande.erreurs.besoin_obligatoire")
+    end
   end
 end
+

--- a/app/views/shared/_errors.html.slim
+++ b/app/views/shared/_errors.html.slim
@@ -7,7 +7,7 @@
       ul.form-errors__list
         - resource.errors.each do |error, message|
           - id = i18n_simple_form_id(model, error)
-          - label = i18n_simple_form_label(model, error)
+          - label = :base == error ? nil : i18n_simple_form_label(model, error)
           li.form-errors__item
-            label for=id class="form-errors__label" = [label, message].join(" ")
+            label for=id class="form-errors__label" = [label, message].compact.join(" ")
 

--- a/spec/controllers/dossiers_controller_spec.rb
+++ b/spec/controllers/dossiers_controller_spec.rb
@@ -160,6 +160,7 @@ describe DossiersController do
       it "sauvegarder l'année de construction si elle est modifiée" do
         projet_params = {
           demande_attributes: {
+            id: projet.demande.id,
             annee_construction: "1980"
           }
         }

--- a/spec/factories/projets.rb
+++ b/spec/factories/projets.rb
@@ -168,7 +168,6 @@ FactoryGirl.define do
     trait :initial do
       statut :prospect
       email nil
-      annee_construction nil
       with_avis_imposition
 
       after(:create) do |projet, evaluator|


### PR DESCRIPTION
La demande était supprimée puis recréée lors de la mise à jour de la proposition de l’opérateur. La faute était due à la cascade Rails qui, si on ne `permit` pas l’id d’un modèle imbriqué, supprime et recrée ledit modèle. Comme on ne mettait que la date de construction à jour, c’était la seule donnée remplie.

Par ailleurs, le formulaire de "demande" faisait systématique un redirect après un update. En cas d’erreur, toutes les données du formulaire étaient perdues. Mon 2e commit corrige ce point.

![blah1](https://user-images.githubusercontent.com/2368859/31507651-ae67e4f0-af7b-11e7-9a49-342ec5fc43c9.gif)
