### PR TITLE
PF701 fixe le formulaire de contact pour les internautes

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -5,13 +5,13 @@ class Contact < ApplicationRecord
 
   strip_fields :name, :email, :phone, :subject, :description, :department, :plateform_id
 
-  validates_presence_of :name, :description, :email, :subject, :department
-  validates_presence_of :department, on: :agent
-  validates :email, email: true, allow_blank: false, length: { :maximum => 80 }
-  validates :phone, length: {minimum: 8, maximum: 20}, allow_blank: true
-  validates :name, length: { maximum: 128}
-  validates :subject, length: {maximum: 80}
-  validates :description, length: {maximum: 1500}
+  validates_presence_of :name, :description, :email, :subject
+  validates_presence_of :department, on: [:agent, :user]
+  validates :email, email: true, allow_blank: false, length: { maximum: 80 }
+  validates :phone, length: { minimum: 8, maximum: 20 }, allow_blank: true
+  validates :name, length: { maximum: 128 }
+  validates :subject, length: { maximum: 80 }
+  validates :description, length: { maximum: 1500 }
   attr_accessor :address
 
   def honeypot_filled?

--- a/app/views/layouts/informations.html.slim
+++ b/app/views/layouts/informations.html.slim
@@ -9,7 +9,6 @@
         = link_to t("menu.legal"),    informations_legal_path,  class: "col-menu__item"
         = link_to t("menu.contact"),  new_contact_path,         class: "col-menu__item"
     .col.col-main
-      section.public-information
-        = render "shared/flash"
-        = yield
+      = render "shared/flash"
+      = yield
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -8,6 +8,6 @@ describe Contact do
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_presence_of :description }
     it { is_expected.to validate_presence_of :subject }
-    it { is_expected.to validate_presence_of :department }
   end
 end
+


### PR DESCRIPTION
Reprise du travail de @qcattez. 👋

Le formulaire de contact ne fonctionnait pas pour les internautes non connectés : erreur "le département est obligatoire" sauf que le champ n’est pas affiché. J’ai rendu le numéro du département facultatif.