### PR TITLE
PF837 fixe l’objet de l’email de contact

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -22,6 +22,6 @@ class ContactMailer < ApplicationMailer
     subject += "[#{intervenant_type}]"
     subject += "[#{contact.plateform_id}]" if contact.plateform_id
     subject += " "
-    subject +  contact.subject
+    subject +  I18n.t("contacts.email_name.#{contact.subject}")
   end
 end

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -160,6 +160,11 @@ fr:
       general: "Une question générale sur les aides"
       project: "Un question concernant mon dossier"
       other: "Autre : Veuillez préciser dans le message"
+    email_name:
+      technical: "Question technique"
+      general: "Question générale"
+      project: "Question concernant mon dossier"
+      other: "Autre"
   # ----------------------- Page de visualisation du projet ---------------------
   projets:
     statut:

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -11,7 +11,7 @@ describe ContactMailer, type: :mailer do
       it do
         expect(email.from).to    eq([ENV["EMAIL_CONTACT"]])
         expect(email.to).to      eq([ENV["EMAIL_CONTACT"]])
-        expect(email.subject).to eq("[ANAH][TEST][12][Demandeur] #{contact.subject}")
+        expect(email.subject).to eq("[ANAH][TEST][12][Demandeur] #{I18n.t("contacts.email_name.#{contact.subject}")}")
         expect(email.body).to    include("#{contact.name} vous envoie ce message :")
       end
     end
@@ -24,7 +24,7 @@ describe ContactMailer, type: :mailer do
       it do
         expect(email.from).to    eq([ENV["EMAIL_CONTACT"]])
         expect(email.to).to      eq([ENV["EMAIL_CONTACT"]])
-        expect(email.subject).to eq("[ANAH][TEST][93][PRIS] #{contact.subject}")
+        expect(email.subject).to eq("[ANAH][TEST][93][PRIS] #{I18n.t("contacts.email_name.#{contact.subject}")}")
         expect(email.body).to    include("#{contact.name} vous envoie ce message :")
       end
     end
@@ -37,7 +37,7 @@ describe ContactMailer, type: :mailer do
       it do
         expect(email.from).to    eq([ENV["EMAIL_CONTACT"]])
         expect(email.to).to      eq([ENV["EMAIL_CONTACT"]])
-        expect(email.subject).to eq("[ANAH][TEST][93][Operateur][1234] #{contact.subject}")
+        expect(email.subject).to eq("[ANAH][TEST][93][Operateur][1234] #{I18n.t("contacts.email_name.#{contact.subject}")}")
         expect(email.body).to    include("#{contact.name} vous envoie ce message :")
       end
     end
@@ -50,7 +50,7 @@ describe ContactMailer, type: :mailer do
       it do
         expect(email.from).to    eq([ENV["EMAIL_CONTACT"]])
         expect(email.to).to      eq([ENV["EMAIL_CONTACT"]])
-        expect(email.subject).to eq("[ANAH][TEST][01][Instructeur] #{contact.subject}")
+        expect(email.subject).to eq("[ANAH][TEST][01][Instructeur] #{I18n.t("contacts.email_name.#{contact.subject}")}")
         expect(email.body).to    include("#{contact.name} vous envoie ce message :")
       end
     end


### PR DESCRIPTION
Tout est dans le titre… 😉

<img width="387" alt="capture d ecran 2017-10-16 a 18 36 24" src="https://user-images.githubusercontent.com/2368859/31623824-f8d569cc-b2a0-11e7-8a25-a230ad4e30bd.png">
