### PR TITLE
BSR ajoute le lien opal dans le menu projet

### DIFF
--- a/app/views/projets/_menu.html.slim
+++ b/app/views/projets/_menu.html.slim
@@ -14,7 +14,11 @@
         p
           = project.numero_plateforme
           - if project.opal_numero.present?
-            = " / Opal : #{project.opal_numero}"
+            = " / Opal : "
+            - if current_agent.instructeur?
+              = link_to project.opal_numero, dossier_opal_url(project.opal_numero), target: "_blank"
+            - else
+              = project.opal_numero
 
   / TODO dynamiser l’élément actif avec la classe `project-menu__item--active`
   .project-menu__list.clearfix


### PR DESCRIPTION
Mêmes règles que l’affichage du lien dans le tableau de bord.

<img width="474" alt="capture d ecran 2017-10-17 a 15 21 40" src="https://user-images.githubusercontent.com/2368859/31667241-230b595a-b34f-11e7-9069-73d800153eeb.png">
