### PR TITLE
Suppression code mort et gestion erreur 500 sur engagement opérateur

### DIFF
--- a/app/controllers/engagement_operateur_controller.rb
+++ b/app/controllers/engagement_operateur_controller.rb
@@ -11,6 +11,9 @@ class EngagementOperateurController < ApplicationController
 
   def create
     operateur = Intervenant.find(params[:operateur_id])
+    if operateur && (@projet_courant.statut != "prospect" || @projet_courant.operateur.present?)
+      return redirect_to projet_path(@projet_courant), flash: { notice: t('projets.intervenants.messages.already_committed', operateur: @projet_courant.operateur) }
+    end
     if @projet_courant.commit_with_operateur!(operateur)
       ProjetMailer.notification_engagement_operateur(@projet_courant).deliver_later!
       EvenementEnregistreurJob.perform_later(label: 'choix_intervenant', projet: @projet_courant, producteur: @projet_courant.operateur)

--- a/app/models/intervenant.rb
+++ b/app/models/intervenant.rb
@@ -5,7 +5,6 @@ class Intervenant < ApplicationRecord
   has_many :projets, through: :invitations
 
   has_and_belongs_to_many :operations, order: :id
-  has_and_belongs_to_many :suggested_on_projets, class_name: 'Projet', join_table: 'suggested_operateurs'
 
   validates :raison_sociale, presence: true
   validates :email, presence: true, email: true

--- a/config/locales/defaults/fr.yml
+++ b/config/locales/defaults/fr.yml
@@ -247,6 +247,7 @@ fr:
 
     intervenants:
       messages:
+        already_committed: "Vous avez déjà confirmé votre opérateur-conseil : %{operateur}"
         succes_choix_intervenant: "Vous avez confirmé votre opérateur-conseil : %{operateur}"
         erreur_choix_intervenant: "Une erreur est survenue"
     messages:

--- a/db/migrate/20171026165651_remove_projet_id_from_occupants.rb
+++ b/db/migrate/20171026165651_remove_projet_id_from_occupants.rb
@@ -1,0 +1,10 @@
+class RemoveProjetIdFromOccupants < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :occupants, :projet_id
+  end
+
+  def down
+    add_column    :occupants, :projet_id, :integer
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171017144615) do
+ActiveRecord::Schema.define(version: 20171026165651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,7 +192,6 @@ ActiveRecord::Schema.define(version: 20171017144615) do
   end
 
   create_table "occupants", id: :serial, force: :cascade do |t|
-    t.integer "projet_id"
     t.string "nom"
     t.string "prenom"
     t.integer "lien_demandeur"
@@ -203,7 +202,6 @@ ActiveRecord::Schema.define(version: 20171017144615) do
     t.integer "avis_imposition_id"
     t.boolean "declarant", default: false, null: false
     t.string "civility"
-    t.index ["projet_id"], name: "index_occupants_on_projet_id"
   end
 
   create_table "operations", id: :serial, force: :cascade do |t|
@@ -386,7 +384,6 @@ ActiveRecord::Schema.define(version: 20171017144615) do
   add_foreign_key "invitations", "intervenants"
   add_foreign_key "invitations", "projets"
   add_foreign_key "messages", "projets"
-  add_foreign_key "occupants", "projets"
   add_foreign_key "prestation_choices", "prestations"
   add_foreign_key "prestation_choices", "projets"
   add_foreign_key "projet_aides", "aides"

--- a/spec/controllers/engagement_operateur_controller_spec.rb
+++ b/spec/controllers/engagement_operateur_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require "support/mpal_helper"
+require "support/rod_helper"
+
+describe EngagementOperateurController do
+  describe "#create" do
+    context "si déjà engagé avec un opérateur" do
+      let(:projet)     { create :projet, :en_cours }
+      let(:user)       { projet.demandeur_user }
+      let(:operateur)  { projet.operateur }
+      let(:operateur2) { create :operateur }
+
+      before { authenticate_as_user user }
+
+      it "affiche une information au demandeur" do
+        post :create, params: { projet_id: projet.id, operateur_id: operateur2.id }
+        expect(response).to redirect_to projet_path(projet)
+        expect(flash[:notice]).to be_present
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
- suppression d’une ligne de code mort qui empêche notamment de faire un `@intervenant.destroy`
- suppression de `Occupants.projet_id`, n’est plus utilisé depuis le début d’année
- suppression de l’erreur 500 quand un demandeur tente de s’engager avec un opérateur alors qu’il l’est déjà

Concernant le dernier point, j’ai une petite crainte qu’on ait un trou dans la raquette. Ça me paraît trop dur de suivre la navigation d’un utilisateur pour s’en rendre compte.