### PR TITLE
FIX rétablissement des backups manuels sur scalingo

### DIFF
--- a/scripts/backup_step1_open_tunnel.sh
+++ b/scripts/backup_step1_open_tunnel.sh
@@ -15,10 +15,6 @@ if [ -z "$env" ]; then
   exit 2
 fi
 
-secrets=$($command -a anah-$env env | grep "POSTGRESQL_URL=" | sed "s/^.*=//")
-
-DATE=$(date +%Y-%m-%d_%H-%M-%S)
-
 echo "Opening the tunnel…"
-$command -a anah-$env db-tunnel $secrets
+$command -a anah-$env db-tunnel SCALINGO_POSTGRESQL_URL
 

--- a/scripts/backup_step2_download.sh
+++ b/scripts/backup_step2_download.sh
@@ -15,7 +15,7 @@ if [ -z "$env" ]; then
   exit 2
 fi
 
-secrets=$($command -a anah-$env env | grep "POSTGRESQL_URL=" | sed "s/^.*=//")
+secrets=$($command -a anah-$env env | grep "POSTGRESQL_URL=" | sed "s/^[^=]*=//" | sed "s/\?.*$//")
 pgpassword=$(echo $secrets | sed "s/^.*:\([0-9a-zA-Z]*\)@.*$/\1/")
 pguser=$(echo $secrets | sed "s/^.*\/\/\([^:]*\):.*$/\1/")
 


### PR DESCRIPTION
L’URL de la variable d’environnement `SCALINGO_POSTGRESQL_URL` a changé, ils ont ajouté un paramètre à la fin.

`scalingo -a monenv db-tunnel SCALINGO_POSTGRESQL_URL` est le nouveau raccourci pour ouvrir un tunnel.