### PR TITLE
fix mise en page RFR et flash notice

### DIFF
--- a/app/assets/stylesheets/imposition.scss
+++ b/app/assets/stylesheets/imposition.scss
@@ -28,3 +28,8 @@
   text-align: center;
 }
 
+.imposition-form__align-left {
+  margin-top: 2em;
+  text-align: left;
+}
+

--- a/app/views/avis_impositions/index.html.slim
+++ b/app/views/avis_impositions/index.html.slim
@@ -31,9 +31,10 @@ p.content__question= "S'il y a d'autres occupants dans le logement, ajoutez leur
 
 .imposition-form__footer
   - if current_agent && current_agent.operateur?
-    = simple_form_for @projet_courant, url: dossier_update_project_rfr_path(@projet_courant), html: { method: :put, class: "form" } do |f|
-      = f.input :modified_revenu_fiscal_reference, as: :string, wrapper_html: { class: "size-s" }
-      = btn name: t("demarrage_projet.action"), class: "btn-centered", icon: "arrow-right"
+    .imposition-form__align-left
+      = simple_form_for @projet_courant, url: dossier_update_project_rfr_path(@projet_courant), html: { method: :put, class: "form" } do |f|
+        = f.input :modified_revenu_fiscal_reference, as: :string, wrapper_html: { class: "size-s" }
+        = btn name: t("demarrage_projet.action"), class: "btn-centered", icon: "arrow-right"
   - else
     - unless current_agent
       = btn name: t("demarrage_projet.go_back"), href: projet_demandeur_path(@projet_courant), class: "btn-secondary btn-large", icon: "arrow-left", icon_before: true

--- a/app/views/payments/index.html.slim
+++ b/app/views/payments/index.html.slim
@@ -1,4 +1,4 @@
-- unless @projet_courant.opal_numero
+- unless @projet_courant.opal_numero || current_user.try(:demandeur?)
   .registry__warning
     p= t("payment_registry.info_only_prepare")
 


### PR DESCRIPTION
J'ai retiré le bandeau orange de notif pour le demandeur.
Le texte "RFR Modifié" est aligné à gauche, pour être juste au dessus du champ à remplir.

<img width="1217" alt="capture d ecran 2017-11-03 a 09 27 34" src="https://user-images.githubusercontent.com/22198770/32365403-0a93f8ea-c07a-11e7-91fe-3d488429c6d8.png">
<img width="1226" alt="capture d ecran 2017-11-03 a 09 31 38" src="https://user-images.githubusercontent.com/22198770/32365401-0a6461c0-c07a-11e7-863e-68130a003511.png">

