### PR TITLE
PF876 - BUG modifie la gestion des droits sur la page choix_operateur

### DIFF
--- a/app/controllers/choix_operateur_controller.rb
+++ b/app/controllers/choix_operateur_controller.rb
@@ -3,6 +3,7 @@ class ChoixOperateurController < ApplicationController
 
   before_action :assert_projet_courant
   before_action :init_view
+  authorize_resource :class => false
 
   def new
     @suggested_operateurs = @projet_courant.pris_suggested_operateurs.shuffle

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -27,6 +27,7 @@ private
       can :show,   Projet
       can :index,  Projet    if user == projet.mandataire_user
       can :read,   :intervenant
+      can [:new, :choose],   :choix_operateur unless projet.operateur.present?
       can :new,    Message
       can :read,   Document, category_type: "Projet",  category_id: projet.id
       can :read,   Document, category_type: "Payment", category_id: projet.payments.map(&:id)

--- a/spec/controllers/choix_operateur_controller_spec.rb
+++ b/spec/controllers/choix_operateur_controller_spec.rb
@@ -3,9 +3,10 @@ require "support/mpal_helper"
 require "support/rod_helper"
 
 describe ChoixOperateurController do
-  let(:projet) { create :projet, :prospect }
+  let(:projet) { create :projet, :prospect, :with_account, :with_intervenants_disponibles }
+  let(:user)   { projet.demandeur_user }
 
-  before(:each) { authenticate_as_project(projet.id) }
+  before(:each) { authenticate_as_user user }
 
   describe "#new" do
     it "affiche les opérateurs disponibles" do
@@ -15,32 +16,32 @@ describe ChoixOperateurController do
   end
 
   describe "#choose" do
-    let(:projet)    { create :projet, :prospect, :with_intervenants_disponibles }
-    let(:operateur) { Intervenant.pour_role(:operateur).first }
 
-    it "invite un opérateur sur le projet" do
-      patch :choose, params: {
-        projet_id: projet.id,
-        operateur_id: operateur.id,
-        projet: { disponibilite: 'Plutôt le midi' }
-      }
-      projet.reload
-      expect(projet.contacted_operateur).to eq operateur
-      expect(projet.disponibilite).to eq 'Plutôt le midi'
-      expect(response).to redirect_to projet_path(projet)
-    end
+    context "quand le demandeur n'est pas engagé avec un opérateur" do
+      let(:operateur) { Intervenant.pour_role(:operateur).first }
 
-    context "quand le demandeur est déjà engagé avec un opérateur" do
-      let(:projet)    { create :projet, :prospect, :with_committed_operateur }
-      let(:operateur) { create :operateur }
-
-      it "affiche une erreur" do
+      it "invite un opérateur sur le projet" do
         patch :choose, params: {
           projet_id: projet.id,
           operateur_id: operateur.id,
           projet: { disponibilite: 'Plutôt le midi' }
         }
-        expect(response).to redirect_to projet_choix_operateur_path(projet)
+        projet.reload
+        expect(projet.contacted_operateur).to eq operateur
+        expect(projet.disponibilite).to eq 'Plutôt le midi'
+        expect(response).to redirect_to projet_path(projet)
+      end
+    end
+
+    context "quand le demandeur est déjà engagé avec un opérateur" do
+      let(:projet_committed)      { create :projet, :en_cours, :with_committed_operateur }
+      let(:user_projet_committed) { projet_committed.demandeur_user }
+
+      before { authenticate_as_user user_projet_committed }
+
+      it "redirige sur la page projet" do
+        get :new, params: { projet_id: projet_committed.id }
+        expect(response).to redirect_to root_path
         expect(flash[:alert]).to be_present
       end
     end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -30,6 +30,7 @@ describe Agent do
             let(:projet) { create :projet, :prospect, :with_contacted_operateur }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
+            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, Document) }
@@ -53,6 +54,7 @@ describe Agent do
             it { is_expected.not_to be_able_to(:manage, :eligibility) }
 
             it { is_expected.to be_able_to(:manage, AvisImposition) }
+            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.to be_able_to(:read, :intervenant) }
             it { is_expected.to be_able_to(:manage, Demande) }
             it { is_expected.to be_able_to(:manage, :demandeur) }
@@ -65,6 +67,7 @@ describe Agent do
             let(:projet) { create :projet, :transmis_pour_instruction, date_depot: DateTime.new(2017,02,04) }
 
             it { is_expected.not_to be_able_to(:manage, AvisImposition) }
+            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.not_to be_able_to(:manage, Demande) }
             it { is_expected.not_to be_able_to(:manage, :demandeur) }
             it { is_expected.not_to be_able_to(:manage, :eligibility) }
@@ -85,6 +88,7 @@ describe Agent do
             let(:projet) { create :projet, :prospect, :with_invited_pris }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
+            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, :eligibility) }
@@ -100,6 +104,7 @@ describe Agent do
             let(:projet) { create :projet, :en_cours }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
+            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, Document) }
@@ -118,6 +123,7 @@ describe Agent do
             let(:agent)       { create :agent, intervenant: instructeur }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
+            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, Document) }
@@ -133,6 +139,7 @@ describe Agent do
             let(:agent)  { projet.agent_instructeur }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
+            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:destroy, Document) }

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -30,7 +30,7 @@ describe Agent do
             let(:projet) { create :projet, :prospect, :with_contacted_operateur }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
-            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
+            it { is_expected.not_to be_able_to([:new, :choose], :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, Document) }
@@ -52,9 +52,9 @@ describe Agent do
             let(:projet) { create :projet, :en_cours}
 
             it { is_expected.not_to be_able_to(:manage, :eligibility) }
+            it { is_expected.not_to be_able_to([:new, :choose], :choix_operateur) }
 
             it { is_expected.to be_able_to(:manage, AvisImposition) }
-            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
             it { is_expected.to be_able_to(:read, :intervenant) }
             it { is_expected.to be_able_to(:manage, Demande) }
             it { is_expected.to be_able_to(:manage, :demandeur) }
@@ -67,7 +67,7 @@ describe Agent do
             let(:projet) { create :projet, :transmis_pour_instruction, date_depot: DateTime.new(2017,02,04) }
 
             it { is_expected.not_to be_able_to(:manage, AvisImposition) }
-            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
+            it { is_expected.not_to be_able_to([:new, :choose], :choix_operateur) }
             it { is_expected.not_to be_able_to(:manage, Demande) }
             it { is_expected.not_to be_able_to(:manage, :demandeur) }
             it { is_expected.not_to be_able_to(:manage, :eligibility) }
@@ -88,7 +88,7 @@ describe Agent do
             let(:projet) { create :projet, :prospect, :with_invited_pris }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
-            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
+            it { is_expected.not_to be_able_to([:new, :choose], :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, :eligibility) }
@@ -104,7 +104,7 @@ describe Agent do
             let(:projet) { create :projet, :en_cours }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
-            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
+            it { is_expected.not_to be_able_to([:new, :choose], :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, Document) }
@@ -123,7 +123,7 @@ describe Agent do
             let(:agent)       { create :agent, intervenant: instructeur }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
-            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
+            it { is_expected.not_to be_able_to([:new, :choose], :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:read, Document) }
@@ -139,7 +139,7 @@ describe Agent do
             let(:agent)  { projet.agent_instructeur }
 
             it { is_expected.not_to be_able_to(:read, AvisImposition) }
-            it { is_expected.not_to be_able_to(:read, :choix_operateur) }
+            it { is_expected.not_to be_able_to([:new, :choose], :choix_operateur) }
             it { is_expected.not_to be_able_to(:read, Demande) }
             it { is_expected.not_to be_able_to(:read, :demandeur) }
             it { is_expected.not_to be_able_to(:destroy, Document) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,6 +10,7 @@ shared_context :projet_without_user_abilities do
     is_expected.not_to be_able_to :read,   :intervenant
     is_expected.not_to be_able_to :read,   Document
     is_expected.not_to be_able_to :manage, Message
+    is_expected.not_to be_able_to :read, :choix_operateur
 
     is_expected.to     be_able_to :manage, AvisImposition
     is_expected.to     be_able_to :manage, Demande


### PR DESCRIPTION
Des opérateurs tentaient d'accéder (probablement par erreur) à la page choix_operateur ce qui générait l'erreur.
ATTENTION : j'ai mis les tests sur la page intervenant_spec, mais je n'ai pas réussi à les mettre dans user_spec / je ne sais pas si c'est nécessaire