### PR TITLE
BSR crée l’intervenant s’il n’existe pas en base

### DIFF
--- a/app/controllers/my_cas_controller.rb
+++ b/app/controllers/my_cas_controller.rb
@@ -18,3 +18,4 @@ private
     flash.delete(:error)
   end
 end
+

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -39,20 +39,16 @@ class Agent < ApplicationRecord
   end
 
   def cas_extra_attributes=(extra_attributes)
-    extra_attributes.each do |cas_cle, valeur|
-      case cas_cle.to_sym
-      when :Nom
-        self.nom = valeur
-      when :Prenom
-        self.prenom = valeur
-      when :Id
-        self.clavis_id = valeur
-      when :ServiceId
-        intervenant = Intervenant.find_by_clavis_service_id(valeur)
-        if intervenant.blank?
-          logger.warn "Agent #{id} : aucun intervenant trouvé pour le ServiceId '#{valeur}'"
-        end
-        self.intervenant = intervenant
+    extra_attributes.each do |key, value|
+      case key.to_sym
+        when :Nom
+          self.nom = value
+        when :Prenom
+          self.prenom = value
+        when :Id
+          self.clavis_id = value
+        when :ServiceId
+          self.intervenant = Intervenant.find_or_create_by_clavis_service_id(value)
       end
     end
   end
@@ -61,3 +57,4 @@ class Agent < ApplicationRecord
     "#{prenom} #{nom}"
   end
 end
+

--- a/app/models/intervenant.rb
+++ b/app/models/intervenant.rb
@@ -38,6 +38,17 @@ class Intervenant < ApplicationRecord
   alias_attribute :name, :raison_sociale
   alias_attribute :description_adresse, :adresse_postale
 
+  def self.find_or_create_by_clavis_service_id(clavis_service_id)
+    intervenant = Intervenant.find_by_clavis_service_id(clavis_service_id)
+    if intervenant.blank?
+      intervenant = Rod.new(RodClient).create_intervenant(clavis_service_id)
+      if intervenant.blank?
+        Rails.logger.error "Agent #{id} : aucun intervenant trouvé pour le intervenantId '#{clavis_service_id}'"
+      end
+    end
+    intervenant
+  end
+
   def instructeur?
     (roles || []).include?('instructeur')
   end

--- a/app/services/rod.rb
+++ b/app/services/rod.rb
@@ -6,6 +6,38 @@ class Rod
     @client = client
   end
 
+  ROLE_MAPPING = {
+    "DREAL" =>      "dreal",
+    "DEAT" =>       "deat",
+    "DL" =>         "instructeur",
+    "DLC2" =>       "instructeur",
+    "DLC3" =>       "instructeur",
+    "DL_AUT_GES" => "instructeur",
+  }
+
+  def create_intervenant(clavis_service_id)
+    Rails.logger.info %(Started Api-ROD request "#{@client.base_uri}/service/#{clavis_service_id}")
+    start = Time.now
+    response = @client.get("/service/#{clavis_service_id}")
+    Rails.logger.info "Completed Api-ROD request (#{response.code}) in #{Time.now - start}s"
+    intervenant = Intervenant.new
+    intervenant.raison_sociale = response["raison_sociale"]
+    intervenant.adresse_postale = [response["adresse"], response["code_postal"], response["commune"]].reject(&:blank?).join(" ")
+    # DEV NOTE: themes à ajouter ?
+    intervenant.departements = response["perimetre_geo"]
+    intervenant.email = response["email"]
+    intervenant.roles = [ROLE_MAPPING[response["type_service"]]].compact
+    intervenant.clavis_service_id = response["id_service"]
+    intervenant.phone = response["tel"]
+    intervenant
+  end
+
+  def create_intervenant!(clavis_service_id)
+    intervenant = create_intervenant clavis_service_id
+    intervenant.save!
+    intervenant
+  end
+
   def query_for(projet)
     Rails.logger.info "Started Api-ROD request \"#{@client.base_uri}/intervenants\""
     start = Time.now

--- a/app/services/rod_client.rb
+++ b/app/services/rod_client.rb
@@ -5,3 +5,4 @@ class RodClient
   format :json
   headers "Authorization" => "Bearer #{ENV["ROD_API_KEY"]}"
 end
+

--- a/app/services/rod_response.rb
+++ b/app/services/rod_response.rb
@@ -65,3 +65,4 @@ private
     end
   end
 end
+

--- a/spec/factories/intervenants.rb
+++ b/spec/factories/intervenants.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:raison_sociale) {|n| "Intervenant#{n}" }
     email 'contact@urbanos.com'
     departements ['75']
+    clavis_service_id "4321"
 
     factory :operateur do
       sequence(:raison_sociale) {|n| "Operateur#{n}" }

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 require "cancan/matchers"
 require "support/mpal_features_helper"
+require "support/rod_helper"
 
 describe Agent do
   describe "validations" do
@@ -259,14 +260,20 @@ describe Agent do
   describe "#cas_extra_attributes=" do
     let(:prenom) { "Jean" }
     let(:nom) { "Durand" }
-    let(:service_id) { "someserviceid" }
     let(:agent) { build :agent }
-    let!(:intervenant) { create :intervenant, clavis_service_id: service_id }
-    before { agent.cas_extra_attributes = { Prenom: prenom, Nom: nom, ServiceId: service_id } }
-    it "should translate successfully" do
-      expect(agent.prenom).to eq(prenom)
-      expect(agent.nom).to eq(nom)
-      expect(agent.intervenant).to eq(intervenant)
+    before { Fakeweb::Rod.register_intervenant }
+    before { agent.cas_extra_attributes = { Prenom: prenom, Nom: nom, ServiceId: clavis_service_id } }
+
+    context "si l’agent n’existe pas" do
+      let(:clavis_service_id) { "4321" }
+      it { expect(agent.prenom).to eq(prenom) }
+      it { expect(agent.nom).to eq(nom) }
+      it { expect(agent.intervenant.clavis_service_id).to eq(clavis_service_id) }
+    end
+
+    context "si l’intervenant n’existe pas" do
+      let(:clavis_service_id) { "1234" }
+      it { expect(agent.intervenant.clavis_service_id).to eq(clavis_service_id) }
     end
   end
 
@@ -283,3 +290,4 @@ describe Agent do
     end
   end
 end
+

--- a/spec/services/rod_spec.rb
+++ b/spec/services/rod_spec.rb
@@ -2,6 +2,22 @@ require 'rails_helper'
 require 'support/rod_helper'
 
 describe Rod do
+  describe "#create_intervenant!" do
+    let(:clavis_service_id) { "1234" }
+    subject(:intervenant) { Rod.new(RodClient).create_intervenant!(clavis_service_id) }
+    before { Fakeweb::Rod.register_intervenant }
+
+    it {
+      expect(intervenant.clavis_service_id).to eq clavis_service_id
+      expect(intervenant.raison_sociale).to    eq "DREAL Provence-Alpes-Côte d'Azur"
+      expect(intervenant.adresse_postale).to   eq "16 Rue Zattara CS 70248 13331 MARSEILLE CEDEX"
+      expect(intervenant.departements).to      eq ["04", "05", "06", "13", "83", "84"]
+      expect(intervenant.email).to             eq "contact@example.com"
+      expect(intervenant.roles).to             eq ["dreal"]
+      expect(intervenant.phone).to             eq "0102030405"
+    }
+  end
+
   describe "#query_for" do
     let(:projet)           { create :projet, :with_demandeur, :with_demande }
     subject(:rod_response) { Rod.new(RodClient).query_for(projet) }

--- a/spec/support/rod_helper.rb
+++ b/spec/support/rod_helper.rb
@@ -2,6 +2,33 @@ require 'dotenv'
 
 module Fakeweb
   class Rod
+    def self.register_intervenant
+      FakeWeb.register_uri(
+        :get, %r|#{ENV['ROD_API_BASE_URI']}service|,
+        body: JSON.generate({
+          "id_service": "1234",
+          "raison_sociale": "DREAL Provence-Alpes-Côte d'Azur",
+          "tel": "0102030405",
+          "email": "contact@example.com",
+          "adresse": "16 Rue Zattara CS 70248",
+          "code_postal": "13331",
+          "commune": "MARSEILLE CEDEX",
+          "type_service": "DREAL",
+          "aut_gestion": false,
+          "type_perimetre_geo": "region",
+          "perimetre_geo": [
+            "04",
+            "05",
+            "06",
+            "13",
+            "83",
+            "84"
+          ]
+        }),
+        status: [200, "OK"]
+      )
+    end
+
     def self.register_query_for_success_without_operation_programmee
       FakeWeb.register_uri(
         :get, %r|#{ENV['ROD_API_BASE_URI']}intervenants|,


### PR DESCRIPTION
Crée automatiquement l’intervenant s’il n’existe pas en base de données, lors de la création d’un agent (sa première connexion).

Il reste quelques points à gérer :
- gérer une 404
- ajouter une task `after_party` pour supprimer les agents sans intervenant (je ne vois pas d’autre moyen de refaire l’association, nous ne stockons le `clavis_service_id`) 🤔
- ajouter `created_at` et `updated_at` sur `Intervenant` (et peut-être d’autres modèles au passage)
- forcer la mise à jour d’un intervenant s’il n’a pas été modifié depuis X jours
- …