### PR TITLE
BUG passe tous les departements à 3 chiffres

### DIFF
--- a/app/services/api_ban.rb
+++ b/app/services/api_ban.rb
@@ -14,7 +14,7 @@ class ApiBan
     code_postal = properties['postcode']
     code_insee  = properties['citycode']
     ville       = properties['city']
-    departement = properties['context'][0,2]
+    departement = properties['context'].split(",").first
     region      = parse_context(properties['context'])
 
     Adresse.new({

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -92,11 +92,7 @@ private
 
   def serialize_numero_departement(projet)
     departement = projet.adresse.departement
-    if departement.length == 1
-      return "00#{departement}"
-    elsif departement.length == 2
-      return "0#{departement}"
-    end
+    departement.rjust(3, '0') 
   end
 
   def serialize_dossier(projet, agent_instructeur)

--- a/app/services/opal.rb
+++ b/app/services/opal.rb
@@ -90,6 +90,15 @@ private
     date.strftime("%Y-%m-%d")
   end
 
+  def serialize_numero_departement(projet)
+    departement = projet.adresse.departement
+    if departement.length == 1
+      return "00#{departement}"
+    elsif departement.length == 2
+      return "0#{departement}"
+    end
+  end
+
   def serialize_dossier(projet, agent_instructeur)
     lignes_adresse_postale  = split_adresse_into_lines(projet.adresse_postale.ligne_1)
     lignes_adresse_geo      = split_adresse_into_lines(projet.adresse.ligne_1)
@@ -134,7 +143,7 @@ private
           "adgLigne3": lignes_adresse_geo[2],
           "cdpCodePostal": projet.adresse.code_postal,
           "comCodeInsee": serialize_code_insee(projet.adresse.code_insee),
-          "dptNumero": projet.adresse.departement
+          "dptNumero": serialize_numero_departement(projet)
         }
       }
     }

--- a/spec/services/opal_spec.rb
+++ b/spec/services/opal_spec.rb
@@ -80,7 +80,7 @@ describe Opal do
         expect(adresse_geographique["adgLigne1"]).to eq "12 rue de la Mare"
         expect(adresse_geographique["cdpCodePostal"]).to eq "75010"
         expect(adresse_geographique["comCodeInsee"]).to eq "010"
-        expect(adresse_geographique["dptNumero"]).to eq "75"
+        expect(adresse_geographique["dptNumero"]).to eq "075"
       end
 
       it "met à jour le dossier avec la réponse d'Opal" do


### PR DESCRIPTION
La norme Opal avait mal été comprise : 
> Si le departement a 1 chiffre : il faut le passer à 3 chiffres
> Si le departement a 2 chiffres : ok
> So le departement a 3 chiffres : ok

J'ai tout passé à 3 chiffres.