### PR TITLE
FIX affiche le diagramme de stats sur env de production

### DIFF
--- a/app/views/informations/stats.html.slim
+++ b/app/views/informations/stats.html.slim
@@ -1,7 +1,7 @@
 - content_for :head do
   = stylesheet_link_tag    "chartist.min", media: "all"
-  = javascript_include_tag "chartist.min", async: Rails.env.production?
-  = javascript_include_tag "moment",       async: Rails.env.production?
+  = javascript_include_tag "chartist.min"
+  = javascript_include_tag "moment"
 
 h2.stats__heading Depuis la création du service
 


### PR DESCRIPTION
Les librairies (Chartist et Moment) étaient chargées en asynchrone sur les environnements de production.

Conséquence : le diagramme ne s’affichait pas (en console `ReferenceError: Chartist is not defined`).